### PR TITLE
I have implemented the password reset functionality and improved the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ SpeakSharp uses a "progressive reveal" model. All pages are accessible to everyo
 -   **Unlimited Session Length**: The 2-minute limit is removed.
 -   **Custom Filler Words**: Add and track your own list of custom filler words.
 
+## User Tiers & Authentication
+
+The application is built with a "public-first" approach. Core pages like the main session recorder and analytics dashboard are viewable by anyone. However, to persist data and unlock features, users must create an account.
+
+-   **Authentication Provider**: We use **Supabase Auth** for handling user sign-up, sign-in, and password recovery.
+-   **Sign-Up**: When a new user signs up, Supabase sends a confirmation email with a verification link. The user must click this link to activate their account.
+-   **Password Reset**: Users can request a password reset link from the Sign-In page. This also uses Supabase's secure email-based recovery flow.
+-   **Session Management**: User sessions are managed via the `AuthContext`, which provides user and profile data throughout the application.
+
+This model allows for a low-friction initial experience while providing a clear path to engagement and feature unlock for registered users.
+
 ## Project Status & Roadmap
 
 This project is currently being developed into a full-stack SaaS application with a **"Speed Over Perfection"** philosophy. The immediate goal is to launch a monetizable MVP within 3 weeks to gather user feedback and iterate quickly.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
+      serve-handler:
+        specifier: ^6.1.6
+        version: 6.1.6
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.11)
@@ -1678,6 +1681,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.0.0:
+    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1727,6 +1734,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-disposition@0.5.2:
+    resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
+    engines: {node: '>= 0.6'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2246,6 +2257,14 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  mime-db@1.33.0:
+    resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.18:
+    resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2326,9 +2345,15 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-inside@1.0.2:
+    resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@3.3.0:
+    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2375,6 +2400,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  range-parser@1.2.0:
+    resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
+    engines: {node: '>= 0.6'}
 
   react-day-picker@8.10.1:
     resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
@@ -2514,6 +2543,9 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  serve-handler@6.1.6:
+    resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -4260,6 +4292,8 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.2)
 
+  bytes@3.0.0: {}
+
   cac@6.7.14: {}
 
   callsites@3.1.0: {}
@@ -4308,6 +4342,8 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  content-disposition@0.5.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4793,6 +4829,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  mime-db@1.33.0: {}
+
+  mime-types@2.1.18:
+    dependencies:
+      mime-db: 1.33.0
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -4859,7 +4901,11 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-inside@1.0.2: {}
+
   path-key@3.1.1: {}
+
+  path-to-regexp@3.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -4900,6 +4946,8 @@ snapshots:
       react-is: 16.13.1
 
   punycode@2.3.1: {}
+
+  range-parser@1.2.0: {}
 
   react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
     dependencies:
@@ -5054,6 +5102,16 @@ snapshots:
       loose-envify: 1.4.0
 
   semver@6.3.1: {}
+
+  serve-handler@6.1.6:
+    dependencies:
+      bytes: 3.0.0
+      content-disposition: 0.5.2
+      mime-types: 2.1.18
+      minimatch: 3.1.2
+      path-is-inside: 1.0.2
+      path-to-regexp: 3.3.0
+      range-parser: 1.2.0
 
   set-cookie-parser@2.7.1: {}
 

--- a/src/__tests__/AuthPage.test.jsx
+++ b/src/__tests__/AuthPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import AuthPage from '../pages/AuthPage';
 import { useAuth } from '../contexts/AuthContext';
@@ -16,6 +16,7 @@ vi.mock('../lib/supabaseClient', () => ({
     auth: {
       signUp: vi.fn(),
       signInWithPassword: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
     },
   },
 }));
@@ -23,6 +24,9 @@ vi.mock('../lib/supabaseClient', () => ({
 describe('AuthPage', () => {
   beforeEach(() => {
     useAuth.mockReturnValue({ session: null });
+    supabase.auth.signUp.mockResolvedValue({ error: null });
+    supabase.auth.signInWithPassword.mockResolvedValue({ error: null });
+    supabase.auth.resetPasswordForEmail.mockResolvedValue({ error: null });
     vi.clearAllMocks();
   });
 
@@ -30,45 +34,84 @@ describe('AuthPage', () => {
     cleanup();
   });
 
+  const getTitle = (name) => screen.getByText(name, { selector: 'div[data-slot="card-title"]' });
+
   it('should render Sign In form by default', () => {
     render(<AuthPage />, { wrapper: BrowserRouter });
-    expect(screen.getByText(/sign in/i, { selector: 'div[data-slot="card-title"]' })).toBeInTheDocument();
+    expect(getTitle(/sign in/i)).toBeInTheDocument();
   });
 
   it('should switch to Sign Up form when "Sign Up" is clicked', () => {
     render(<AuthPage />, { wrapper: BrowserRouter });
     fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
-    expect(screen.getByText(/create an account/i, { selector: 'div[data-slot="card-title"]' })).toBeInTheDocument();
+    expect(getTitle(/create an account/i)).toBeInTheDocument();
   });
 
   it('should call signInWithPassword on sign in form submission', async () => {
-    supabase.auth.signInWithPassword.mockResolvedValue({ error: null });
     render(<AuthPage />, { wrapper: BrowserRouter });
 
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
     fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
-    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
-      email: 'test@example.com',
-      password: 'password',
+    await waitFor(() => {
+      expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password',
+      });
     });
   });
 
   it('should call signUp on sign up form submission', async () => {
-    supabase.auth.signUp.mockResolvedValue({ error: null });
     render(<AuthPage />, { wrapper: BrowserRouter });
 
-    // Switch to Sign Up form
     fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }));
 
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
     fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }));
 
-    expect(supabase.auth.signUp).toHaveBeenCalledWith({
-      email: 'test@example.com',
-      password: 'password',
+    await waitFor(() => {
+      expect(supabase.auth.signUp).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password',
+      });
+    });
+  });
+
+  it('should switch to Forgot Password view when link is clicked', () => {
+    render(<AuthPage />, { wrapper: BrowserRouter });
+    fireEvent.click(screen.getByRole('button', { name: /forgot password/i }));
+    expect(getTitle(/reset password/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+  });
+
+  it('should call resetPasswordForEmail on forgot password form submission', async () => {
+    render(<AuthPage />, { wrapper: BrowserRouter });
+    fireEvent.click(screen.getByRole('button', { name: /forgot password/i }));
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+        expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+            'test@example.com',
+            expect.any(Object)
+        );
+    });
+  });
+
+  it('should display a user-friendly error message on failure', async () => {
+    const errorMessage = 'Invalid login credentials';
+    supabase.auth.signInWithPassword.mockResolvedValue({ error: { message: errorMessage } });
+    render(<AuthPage />, { wrapper: BrowserRouter });
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => {
+        expect(screen.getByText('The email or password you entered is incorrect. Please try again.')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -5,11 +5,22 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { supabase } from '@/lib/supabaseClient';
 import { useAuth } from '@/contexts/AuthContext';
-import { Navigate, Link } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
+
+// A map of Supabase error messages to more user-friendly ones.
+const friendlyErrors = {
+  'Invalid login credentials': 'The email or password you entered is incorrect. Please try again.',
+  'User already registered': 'An account with this email already exists. Please sign in or reset your password.',
+  'Password should be at least 6 characters': 'Your password must be at least 6 characters long.',
+};
+
+const mapError = (message) => {
+    return friendlyErrors[message] || 'An unexpected error occurred. Please try again.';
+};
 
 export default function AuthPage() {
   const { session } = useAuth();
-  const [isSignUp, setIsSignUp] = useState(false);
+  const [view, setView] = useState('sign_in'); // 'sign_in', 'sign_up', or 'forgot_password'
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -21,17 +32,23 @@ export default function AuthPage() {
     setLoading(true);
     setError(null);
     setMessage('');
+
     try {
-      if (isSignUp) {
-        const { error } = await supabase.auth.signUp({ email, password });
-        if (error) throw error;
-        setMessage('Check your email for the confirmation link!');
-      } else {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
+      let error;
+      if (view === 'sign_in') {
+        ({ error } = await supabase.auth.signInWithPassword({ email, password }));
+      } else if (view === 'sign_up') {
+        ({ error } = await supabase.auth.signUp({ email, password }));
+        if (!error) setMessage('Success! Please check your email for a confirmation link to complete your registration.');
+      } else if (view === 'forgot_password') {
+        ({ error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: window.location.origin + '/', // Redirect user back to the app after password reset
+        }));
+        if (!error) setMessage('If an account with this email exists, a password reset link has been sent.');
       }
+      if (error) throw error;
     } catch (error) {
-      setError(error.message);
+      setError(mapError(error.message));
     } finally {
       setLoading(false);
     }
@@ -41,6 +58,13 @@ export default function AuthPage() {
     return <Navigate to="/" />;
   }
 
+  const handleViewChange = (newView) => {
+    setView(newView);
+    setError(null);
+    setMessage('');
+    setPassword('');
+  }
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-background p-4">
       <div className="text-center mb-6">
@@ -48,9 +72,15 @@ export default function AuthPage() {
       </div>
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">{isSignUp ? 'Create an Account' : 'Sign In'}</CardTitle>
+          <CardTitle className="text-2xl">
+            {view === 'sign_in' && 'Sign In'}
+            {view === 'sign_up' && 'Create an Account'}
+            {view === 'forgot_password' && 'Reset Password'}
+          </CardTitle>
           <CardDescription>
-            {isSignUp ? 'Enter your details to get started.' : 'Enter your credentials to access your account.'}
+            {view === 'sign_in' && 'Enter your credentials to access your account.'}
+            {view === 'sign_up' && 'Enter your details to get started.'}
+            {view === 'forgot_password' && "Enter your email to receive a password reset link. You will be redirected after resetting."}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -68,39 +98,42 @@ export default function AuthPage() {
                   className="bg-input"
                 />
               </div>
-              <div className="grid gap-2">
-                <div className="flex items-center">
-                  <Label htmlFor="password">Password</Label>
-                  {!isSignUp && (
-                     <Link to="#" className="ml-auto inline-block text-sm underline text-muted-foreground hover:text-primary">
-                        Forgot Password?
-                     </Link>
-                  )}
+              {view !== 'forgot_password' && (
+                <div className="grid gap-2">
+                  <div className="flex items-center">
+                    <Label htmlFor="password">Password</Label>
+                    {view === 'sign_in' && (
+                       <Button variant="link" type="button" onClick={() => handleViewChange('forgot_password')} className="ml-auto inline-block text-sm underline text-muted-foreground hover:text-primary h-auto p-0">
+                          Forgot Password?
+                       </Button>
+                    )}
+                  </div>
+                  <Input
+                    id="password"
+                    type="password"
+                    required
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="bg-input"
+                  />
                 </div>
-                <Input
-                  id="password"
-                  type="password"
-                  required
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="bg-input"
-                />
-              </div>
-              {error && <p className="text-sm text-destructive">{error}</p>}
-              {message && <p className="text-sm text-green-500">{message}</p>}
+              )}
+              {error && <p className="text-sm text-destructive font-semibold">{error}</p>}
+              {message && <p className="text-sm text-green-600 font-semibold bg-green-100 border border-green-200 rounded-md p-3 text-center">{message}</p>}
               <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Processing...' : (isSignUp ? 'Sign Up' : 'Sign In')}
+                {loading ? 'Processing...' :
+                  view === 'sign_in' ? 'Sign In' :
+                  view === 'sign_up' ? 'Sign Up' : 'Send Reset Link'
+                }
               </Button>
             </div>
           </form>
           <div className="mt-4 text-center text-sm">
-            {isSignUp ? 'Already have an account?' : "Don't have an account?"}
-            <Button variant="link" type="button" onClick={() => {
-              setIsSignUp(!isSignUp);
-              setError(null);
-              setMessage('');
-            }} className="text-primary">
-              {isSignUp ? 'Sign In' : 'Sign Up'}
+            {view === 'sign_in' && "Don't have an account?"}
+            {view === 'sign_up' && 'Already have an account?'}
+            {view === 'forgot_password' && 'Remembered your password?'}
+            <Button variant="link" type="button" onClick={() => handleViewChange(view === 'sign_in' || view === 'forgot_password' ? 'sign_up' : 'sign_in')} className="text-primary">
+                {view === 'sign_in' || view === 'forgot_password' ? 'Sign Up' : 'Sign In'}
             </Button>
           </div>
         </CardContent>

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -35,6 +35,25 @@ global.navigator.mediaDevices = {
   })
 }
 
+// Mock scrollIntoView, which is not implemented in JSDOM
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+// Mock ResizeObserver, which is not implemented in JSDOM
+global.ResizeObserver = class ResizeObserver {
+    constructor(callback) {
+        this.callback = callback;
+    }
+    observe(target) {
+        // Do nothing
+    }
+    unobserve(target) {
+        // Do nothing
+    }
+    disconnect() {
+        // Do nothing
+    }
+};
+
 afterEach(() => {
   vi.clearAllMocks()
   vi.restoreAllMocks()


### PR DESCRIPTION
…authentication page.

To achieve this, I refactored the `AuthPage` component to handle three distinct views: sign-in, sign-up, and forgot password, which is now managed by a new `view` state.

Key improvements include:
- A complete password reset flow using Supabase's `resetPasswordForEmail` method.
- User-friendly error messages that map cryptic backend errors to clear, actionable text.
- Enhanced UI feedback for success states, such as after a user signs up or requests a password reset link.

I also updated and expanded the unit tests for the `AuthPage` to ensure the new functionality is robust and to prevent regressions.

Finally, as you requested, I updated the `README.md` with a new "User Tiers & Authentication" section to document the authentication flow.