### PR TITLE
fix(auth): identify authenticated users to PostHog by user.id (Gate B unblock)

### DIFF
--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -89,10 +89,16 @@ export function AuthProvider({ children, initialSession = null }: AuthProviderPr
   useEffect(() => {
     const userId = sessionState?.user?.id ?? null;
     if (!userId) {
-      if (identifiedAnalyticsUserRef.current) {
+      // No active session. Clear a persisted PostHog identity if EITHER this mount identified someone
+      // OR PostHog still carries a prior user's account-linked identity from an EARLIER visit. The
+      // ref starts null on every fresh mount, but PostHog persists distinct_id across page loads — so
+      // an anonymous/no-session boot on a shared device or after an expired session would otherwise
+      // keep events/flags attached to the previous user. We gate on isIdentified() so a genuinely
+      // fresh anonymous visitor is left untouched (no needless anonymous-id churn).
+      if (identifiedAnalyticsUserRef.current || analyticsBuffer.isIdentified()) {
         analyticsBuffer.resetIdentity();
-        identifiedAnalyticsUserRef.current = null;
       }
+      identifiedAnalyticsUserRef.current = null;
       return;
     }
     if (identifiedAnalyticsUserRef.current === userId) return;

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { ENV } from '../config/TestFlags';
 import logger from '../lib/logger';
 import { useSessionStore } from '@/stores/useSessionStore';
 import { useReadinessStore } from '@/stores/useReadinessStore';
+import { analyticsBuffer } from '@/services/AnalyticsBuffer';
 
 /**
  * AUTHENTICATION PROVIDER
@@ -43,6 +44,7 @@ export function AuthProvider({ children, initialSession = null }: AuthProviderPr
   const supabase = getSupabaseClient();
   const queryClient = useQueryClient();
   const initialCheckRef = useRef(false);
+  const identifiedAnalyticsUserRef = useRef<string | null>(null);
 
   const getInjectedSession = useCallback(() => {
     if (initialSession) return initialSession;
@@ -78,6 +80,25 @@ export function AuthProvider({ children, initialSession = null }: AuthProviderPr
   useEffect(() => {
     sessionStateRef.current = sessionState;
   }, [sessionState]);
+
+  // Account-linked analytics identity. Identify the authenticated user to PostHog/Sentry by the
+  // stable Supabase user.id ONLY — NO email or other PII (privacy-first posture; matches the v4
+  // telemetry sanitizer that drops email). This gives PostHog an account-linked person so feature
+  // flags can be targeted via an operator cohort on user.id; on sign-out we reset to a fresh
+  // anonymous id so a shared device never inherits the prior account's identity/flags.
+  useEffect(() => {
+    const userId = sessionState?.user?.id ?? null;
+    if (!userId) {
+      if (identifiedAnalyticsUserRef.current) {
+        analyticsBuffer.resetIdentity();
+        identifiedAnalyticsUserRef.current = null;
+      }
+      return;
+    }
+    if (identifiedAnalyticsUserRef.current === userId) return;
+    analyticsBuffer.identify(userId); // user.id only — no email/PII to PostHog
+    identifiedAnalyticsUserRef.current = userId;
+  }, [sessionState?.user?.id]);
 
   useEffect(() => {
     const injectedSession = getInjectedSession();

--- a/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
@@ -15,7 +15,12 @@ vi.mock('../../utils/fetchWithRetry', () => ({
 }));
 
 // Account-linked analytics identity (PostHog/Sentry) — assert the AuthProvider identifies by user.id.
-const analyticsMock = vi.hoisted(() => ({ identify: vi.fn(), resetIdentity: vi.fn() }));
+// isIdentified() reports whether PostHog still holds a persisted (cross-boot) account-linked identity.
+const analyticsMock = vi.hoisted(() => ({
+    identify: vi.fn(),
+    resetIdentity: vi.fn(),
+    isIdentified: vi.fn(() => false),
+}));
 vi.mock('@/services/AnalyticsBuffer', () => ({ analyticsBuffer: analyticsMock }));
 
 // Test consumer component
@@ -46,6 +51,9 @@ describe('AuthProvider', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        // clearAllMocks clears call history but not implementations — restore the default so a prior
+        // test's mockReturnValue(true) cannot leak a persisted-identity signal into the next test.
+        analyticsMock.isIdentified.mockReturnValue(false);
 
         // Mock Supabase Client structure
         mockSupabase = {
@@ -145,6 +153,45 @@ describe('AuthProvider', () => {
         await waitFor(() => expect(analyticsMock.identify).toHaveBeenCalledWith('user-123'));
         screen.getByText('Sign Out').click();
         await waitFor(() => expect(analyticsMock.resetIdentity).toHaveBeenCalled());
+    });
+
+    it('clears a PERSISTED PostHog identity on an anonymous boot (shared device / expired session)', async () => {
+        // No session this boot, but PostHog still carries a prior user's account-linked identity
+        // persisted across page loads. The mount ref starts null, so the fix must rely on
+        // isIdentified() to clear the stale identity — otherwise events/flags leak to the prior user.
+        analyticsMock.isIdentified.mockReturnValue(true);
+        mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <AuthProvider>
+                    <TestConsumer />
+                </AuthProvider>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(screen.getByText('Unauthenticated')).toBeInTheDocument());
+        await waitFor(() => expect(analyticsMock.resetIdentity).toHaveBeenCalled());
+        expect(analyticsMock.identify).not.toHaveBeenCalled();
+    });
+
+    it('does NOT reset on a fresh anonymous boot with no persisted identity (no anonymous-id churn)', async () => {
+        // No session and PostHog is already anonymous — resetting here would needlessly mint a new
+        // anonymous distinct_id and fragment returning-anonymous-visitor analytics.
+        analyticsMock.isIdentified.mockReturnValue(false);
+        mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <AuthProvider>
+                    <TestConsumer />
+                </AuthProvider>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(screen.getByText('Unauthenticated')).toBeInTheDocument());
+        expect(analyticsMock.resetIdentity).not.toHaveBeenCalled();
+        expect(analyticsMock.identify).not.toHaveBeenCalled();
     });
 
     it('handles getSession error gracefully', async () => {

--- a/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
@@ -14,6 +14,10 @@ vi.mock('../../utils/fetchWithRetry', () => ({
     fetchWithRetry: vi.fn((fn) => fn()),
 }));
 
+// Account-linked analytics identity (PostHog/Sentry) — assert the AuthProvider identifies by user.id.
+const analyticsMock = vi.hoisted(() => ({ identify: vi.fn(), resetIdentity: vi.fn() }));
+vi.mock('@/services/AnalyticsBuffer', () => ({ analyticsBuffer: analyticsMock }));
+
 // Test consumer component
 const TestConsumer = () => {
     const context = useContext(AuthContext);
@@ -107,6 +111,40 @@ describe('AuthProvider', () => {
         screen.getByText('Sign Out').click();
 
         await waitFor(() => expect(mockSupabase.auth.signOut).toHaveBeenCalled());
+    });
+
+    it('identifies the authenticated user to analytics by user.id ONLY (no email/PII)', async () => {
+        const mockSession = { user: { id: 'user-123', email: 'tester@example.com' } };
+        mockSupabase.auth.getSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <AuthProvider>
+                    <TestConsumer />
+                </AuthProvider>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(analyticsMock.identify).toHaveBeenCalledWith('user-123'));
+        // The session has an email, but it must NOT be forwarded to analytics.
+        expect(analyticsMock.identify).not.toHaveBeenCalledWith('user-123', expect.objectContaining({ email: expect.anything() }));
+    });
+
+    it('resets analytics identity on sign out', async () => {
+        const mockSession = { user: { id: 'user-123' } };
+        mockSupabase.auth.getSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <AuthProvider>
+                    <TestConsumer />
+                </AuthProvider>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(analyticsMock.identify).toHaveBeenCalledWith('user-123'));
+        screen.getByText('Sign Out').click();
+        await waitFor(() => expect(analyticsMock.resetIdentity).toHaveBeenCalled());
     });
 
     it('handles getSession error gracefully', async () => {

--- a/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthProvider.component.test.tsx
@@ -194,6 +194,38 @@ describe('AuthProvider', () => {
         expect(analyticsMock.identify).not.toHaveBeenCalled();
     });
 
+    it('does not re-identify the same user on token refresh / re-render (no duplicate identify)', async () => {
+        const mockSession = { user: { id: 'user-123' } };
+        mockSupabase.auth.getSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+
+        let authStateCallback: (event: string, session: unknown) => void;
+        mockSupabase.auth.onAuthStateChange.mockImplementation((callback: (event: string, session: unknown) => void) => {
+            authStateCallback = callback;
+            return { data: { subscription: { unsubscribe: vi.fn() } } };
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <AuthProvider>
+                    <TestConsumer />
+                </AuthProvider>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(analyticsMock.identify).toHaveBeenCalledWith('user-123'));
+        expect(analyticsMock.identify).toHaveBeenCalledTimes(1);
+
+        // A token refresh for the SAME user id (new session object, identical user.id) must NOT
+        // trigger a second identify — the ref-equality guard short-circuits the effect.
+        act(() => {
+            authStateCallback('TOKEN_REFRESHED', { user: { id: 'user-123' } });
+        });
+
+        await waitFor(() => expect(screen.getByTestId('user-id')).toHaveTextContent('user-123'));
+        expect(analyticsMock.identify).toHaveBeenCalledTimes(1);
+        expect(analyticsMock.resetIdentity).not.toHaveBeenCalled();
+    });
+
     it('handles getSession error gracefully', async () => {
         mockSupabase.auth.getSession.mockResolvedValue({
             data: { session: null },

--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -203,6 +203,23 @@ class AnalyticsBuffer {
   }
 
   /**
+   * Whether PostHog currently holds an IDENTIFIED (account-linked) distinct id — true after
+   * identify() and until reset(). PostHog persists this across page loads (localStorage/cookie), so
+   * on an anonymous/no-session boot it can still report a PRIOR user's identity. Callers use this to
+   * decide whether a stale persisted identity must be cleared (shared device / expired session)
+   * WITHOUT churning the anonymous id of a genuinely fresh anonymous visitor. Never throws; returns
+   * false if the underlying posthog-js signal is unavailable so callers fall back to ref-only logic.
+   */
+  public isIdentified(): boolean {
+    try {
+      const ph = posthog as unknown as { _isIdentified?: () => boolean };
+      return typeof ph._isIdentified === 'function' ? ph._isIdentified() : false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Clear the identified user on sign-out: reset PostHog to a fresh anonymous distinct id and clear
    * the Sentry user. Pairs with identify() so a shared device does not retain a prior account's
    * identity (and so PostHog feature-flag evaluation reverts to the anonymous/default cohort).

--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -192,10 +192,31 @@ class AnalyticsBuffer {
 
     try {
       posthog.identify(userId, properties);
+      // Explicitly re-evaluate feature flags for the now-identified user so the app never keeps the
+      // prior anonymous flag state (the Gate B stale-flag gotcha — flags must reflect the account).
+      posthog.reloadFeatureFlags();
       Sentry.setUser({ id: userId, ...properties });
       logger.debug({ userId }, '[AnalyticsBuffer] User identified');
     } catch (err) {
       logger.warn({ err }, '[AnalyticsBuffer] Failed to identify user');
+    }
+  }
+
+  /**
+   * Clear the identified user on sign-out: reset PostHog to a fresh anonymous distinct id and clear
+   * the Sentry user. Pairs with identify() so a shared device does not retain a prior account's
+   * identity (and so PostHog feature-flag evaluation reverts to the anonymous/default cohort).
+   */
+  public resetIdentity(): void {
+    try {
+      posthog.reset();
+      // Re-evaluate flags for the fresh anonymous id so a signed-out shared device does not retain
+      // the prior account's flag evaluation.
+      posthog.reloadFeatureFlags();
+      Sentry.setUser(null);
+      logger.debug('[AnalyticsBuffer] User identity reset');
+    } catch (err) {
+      logger.warn({ err }, '[AnalyticsBuffer] Failed to reset identity');
     }
   }
 }

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -8,7 +8,8 @@ vi.mock('posthog-js', () => ({
     capture: vi.fn(),
     identify: vi.fn(),
     reset: vi.fn(),
-    reloadFeatureFlags: vi.fn()
+    reloadFeatureFlags: vi.fn(),
+    _isIdentified: vi.fn()
   }
 }));
 
@@ -177,5 +178,23 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     analyticsBuffer.resetIdentity();
     expect(posthog.reset).toHaveBeenCalledTimes(1);
     expect(posthog.reloadFeatureFlags).toHaveBeenCalled();
+  });
+
+  it('isIdentified() reflects PostHog persisted identity state (used to clear stale cross-boot identity)', () => {
+    const isIdentifiedMock = (posthog as unknown as { _isIdentified: ReturnType<typeof vi.fn> })._isIdentified;
+    isIdentifiedMock.mockReturnValue(true);
+    expect(analyticsBuffer.isIdentified()).toBe(true);
+
+    isIdentifiedMock.mockReturnValue(false);
+    expect(analyticsBuffer.isIdentified()).toBe(false);
+  });
+
+  it('isIdentified() never throws and is false when the posthog signal is unavailable', () => {
+    const isIdentifiedMock = (posthog as unknown as { _isIdentified: ReturnType<typeof vi.fn> })._isIdentified;
+    isIdentifiedMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(() => analyticsBuffer.isIdentified()).not.toThrow();
+    expect(analyticsBuffer.isIdentified()).toBe(false);
   });
 });

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -6,7 +6,9 @@ import posthog from 'posthog-js';
 vi.mock('posthog-js', () => ({
   default: {
     capture: vi.fn(),
-    identify: vi.fn()
+    identify: vi.fn(),
+    reset: vi.fn(),
+    reloadFeatureFlags: vi.fn()
   }
 }));
 
@@ -159,5 +161,21 @@ describe('AnalyticsBuffer (Hardened Background Asset)', () => {
     expect(payload).not.toContain('very-sensitive');
     expect(payload).not.toContain('another sensitive');
     expect(payload).not.toContain('nested array transcript');
+  });
+});
+
+describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('identify() passes through the user id (no email) and reloads feature flags', () => {
+    analyticsBuffer.identify('user-123');
+    expect(posthog.identify).toHaveBeenCalledWith('user-123', undefined);
+    expect(posthog.reloadFeatureFlags).toHaveBeenCalled(); // flags re-evaluated for the identified user
+  });
+
+  it('resetIdentity() resets PostHog to a fresh anonymous id and reloads flags', () => {
+    analyticsBuffer.resetIdentity();
+    expect(posthog.reset).toHaveBeenCalledTimes(1);
+    expect(posthog.reloadFeatureFlags).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What
Identify authenticated users to PostHog/Sentry by Supabase `user.id` — the **focused** unblock for the v4 PostHog A/B Gate B. Today the deployed app never calls `posthog.identify()` for logged-in users, so PostHog only ever has an anonymous device id and there is no account-linked person to operator-target.

## Contract (least-PII, owner-approved)
- `distinct_id = Supabase user.id` (stable; not email)
- **No email / PII** to PostHog (matches the v4 telemetry sanitizer; tests assert email is NOT forwarded even when the session has one)
- `posthog.reloadFeatureFlags()` after identify and reset (flags reflect the account immediately)
- `resetIdentity()` = `posthog.reset()` + `Sentry.setUser(null)` on sign-out
- No client-settable `isInternalTester` — Gate B targets an operator-managed cohort on `user.id`

## Scope (focused, NOT the whole v4 branch)
4-file change cherry-picked from `dev/v4-integration@ecfc0e0d`; does not bring the rest of the 72-commit v4 branch:
- `frontend/src/services/AnalyticsBuffer.ts` (+ test)
- `frontend/src/contexts/AuthProvider.tsx` (+ test)

## Verification
`tsc --noEmit` clean · eslint clean · **21/21** (AnalyticsBuffer identify/reset/reloadFeatureFlags; AuthProvider identifies by user.id only, asserts no email forwarded, resets on sign-out, no duplicate identify for same id).

## Known caveat — Test Phase-1 is the empirical gate
`posthog.init()` is deferred in `main.tsx` (`setTimeout(…, 0)`) while the React tree renders synchronously, so the identify effect could theoretically race init for the already-logged-in case. Likely benign (the `setTimeout(0)` is queued before the passive effect), but **post-deploy Phase-1 identity sanity is the gate** — if a confirmed-deployed build still shows anonymous `distinct_id`, the deferred-init race is the prime suspect and we harden (move init earlier / wait for `posthog.__loaded`).

## After merge
Vercel deploys from `main` → Test Phase-1 (confirm `distinct_id === user.id`, no email) → Product targets `user.id` on flag `709644` via cohort → official Gate B proof + negative control → close `POSTHOG-STT-A/B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)