### PR TITLE
fix(analytics): sync PostHog init before render (Gate B FAIL_AUTH_POSTHOG_IDENTIFY)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -160,24 +160,31 @@ const renderApp = async (initialSession: Session | null = null) => {
 
       // 🛑 Skip ALL analytics in test mode (Sentry already initialized above)
       if (!isTestMode) {
-        // Defer PostHog initialization
+        // Initialize PostHog SYNCHRONOUSLY, before root.render() mounts <AuthProvider>.
+        // Gate B / FAIL_AUTH_POSTHOG_IDENTIFY root cause: AuthProvider's identity effect calls
+        // posthog.identify(user.id) on its first commit. When init() was deferred (previously
+        // wrapped in setTimeout(…, 0)), identify() could run BEFORE init on a restored-session
+        // boot — that sets the local distinct_id (so a browser localStorage check passes) but
+        // NEVER sends the server-side $identify event, so no PostHog person is materialized at the
+        // Supabase user.id and feature-flag targeting can never match. Server-side evidence pre-fix:
+        // 0 web $identify events and 0 events under the user.id. Running init() synchronously here
+        // guarantees the SDK is ready before any identify() call. The empirical gate remains runtime
+        // Phase-1 server-ingestion sanity (a web $identify + queryable person at the user.id).
         if (import.meta.env.VITE_POSTHOG_KEY && import.meta.env.VITE_POSTHOG_HOST) {
-          setTimeout(() => {
-            try {
-              posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-                api_host: import.meta.env.VITE_POSTHOG_HOST,
-                autocapture: false,
-                capture_pageview: false,
-                capture_exceptions: enableSentryConsoleCapture,
-                capture_performance: false,
-                disable_session_recording: true,
-                debug: import.meta.env.MODE === 'development',
-              });
-              logger.debug('[PostHog] Initialized successfully');
-            } catch (error) {
-              logger.warn({ error }, "PostHog failed to initialize:");
-            }
-          }, 0);
+          try {
+            posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
+              api_host: import.meta.env.VITE_POSTHOG_HOST,
+              autocapture: false,
+              capture_pageview: false,
+              capture_exceptions: enableSentryConsoleCapture,
+              capture_performance: false,
+              disable_session_recording: true,
+              debug: import.meta.env.MODE === 'development',
+            });
+            logger.debug('[PostHog] Initialized successfully');
+          } catch (error) {
+            logger.warn({ error }, "PostHog failed to initialize:");
+          }
         }
       } else {
         logger.warn('[E2E MODE] Analytics disabled entirely.');


### PR DESCRIPTION
## Summary

Initializes PostHog **synchronously before `root.render()`** by removing the `setTimeout(…, 0)` wrapper around `posthog.init()` in `main.tsx`. One file, narrow change.

This is the **Option A** fix for `POSTHOG-STT-A/B — FAIL_AUTH_POSTHOG_IDENTIFY`, the Gate B blocker found after PR #748 deployed.

## Root cause

`AuthProvider`'s identity effect calls `posthog.identify(user.id)` on its first commit. With init deferred via `setTimeout(0)`, on a **restored-session boot** `identify()` could run **before** `init()`. A pre-init `identify()`:
- sets the **local** `distinct_id` (so PR #748's Phase-1 `localStorage` check passed ✅), but
- never sends the **server-side `$identify`** event → no PostHog person is materialized at the Supabase `user.id` → feature-flag targeting can never match → `private_stt_v4_enabled` stays `false`.

### Server-side evidence (PostHog project 207400, pre-fix)
- `persons-list` for `22899590…` → **empty**; `0` events under that distinct_id.
- **`0`** browser (`lib='web'`) `$identify` events all-time (incl. the post-#748-deploy window).
- `0` web events with a non-anonymous distinct_id — every browser session is anonymous server-side.
- The only `$identify` in the project is the Test closeout harness's (`lib=None`), malformed (`distinct_id` = anon id, `$anon_distinct_id` = same anon id), which stamped `isInternalTester` onto an anonymous person, not the user.id.

## Fix

Run `posthog.init(...)` synchronously at the same point in bootstrap (still inside the `!isTestMode` guard, still gated on the PostHog env vars), just without the `setTimeout`. By the time `<AuthProvider>`'s effect runs (after the initial commit/paint), the SDK is guaranteed initialized, so `identify()` emits a real `$identify`.

**Identity contract unchanged** (no behavioral change to PR #748's contract):
- `distinct_id = Supabase user.id` only — no email/PII
- no client-settable `isInternalTester`
- `reloadFeatureFlags()` after identify/reset
- `resetIdentity()` on anonymous/sign-out

No new custom identity event added (per release-owner direction — keep telemetry surface minimal; add a non-PII `user_identified` capture only as a second fix if `$identify` still fails after sync init).

## Verification
- `tsc --noEmit` clean
- `eslint src/main.tsx` clean
- `pnpm build` succeeds (entry-module change)

Unit-testing the entry-module init **ordering** isn't practical (top-level side effects, singleton SDK), so the rationale is documented inline in `main.tsx`. The **empirical gate is runtime Phase-1 server-ingestion sanity** (below).

## Post-merge validation (Test — two layers, not just localStorage)
**Browser-local:** `distinct_id === 22899590-4af1-4a0c-88d6-b00996cb5ae0`, not anonymous, no email in payloads/person props.
**PostHog server-side:** a `lib='web'` `$identify` exists for that distinct_id; a **queryable person** exists for it; no email property; `private_stt_v4_enabled` can be evaluated against it after targeting.

Only after that does Product target the `user.id` (operator cohort preferred over client-settable `isInternalTester`), then Test runs the official Gate B proof + negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
