### PR TITLE
fix(analytics): materialize server-side PostHog person on identify (Gate B FAIL_AUTH_POSTHOG_IDENTIFY)

### DIFF
--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -192,16 +192,11 @@ class AnalyticsBuffer {
 
     try {
       posthog.identify(userId, properties);
-      // Materialize a SERVER-SIDE PostHog person for the identified user (Gate B / feature-flag
-      // targeting). posthog-js (1.298.1 deployed) defaults person_profiles to 'identified_only', so
-      // a queryable person is created only once an INGESTED event is tied to the identified
-      // distinct_id. On the deployed build the lone $identify did not reliably ingest (short sessions
-      // never flushed a single batched event) — server-side showed 0 web $identify / 0 events under
-      // the Supabase user.id — so no person appeared and flag targeting could not match. Emit ONE
-      // minimal, NON-PII event under the now-identified distinct_id to guarantee materialization.
-      // STRICT no-PII: a constant source tag only — never email, name, transcript, audio, secrets,
-      // or the raw auth/session object.
-      posthog.capture('account_identified', { source: 'auth_provider' });
+      // Materialize a SERVER-SIDE PostHog person (Gate B / flag targeting) — see
+      // captureAccountIdentified(). It is ISOLATED in its own try/catch so a capture failure can
+      // NEVER block the reloadFeatureFlags()/Sentry.setUser() below: flag reload after identify is
+      // the load-bearing step and must always run.
+      this.captureAccountIdentified();
       // Explicitly re-evaluate feature flags AFTER identify + capture so the app never keeps the
       // prior anonymous flag state (the Gate B stale-flag gotcha — flags must reflect the account).
       posthog.reloadFeatureFlags();
@@ -209,6 +204,23 @@ class AnalyticsBuffer {
       logger.debug({ userId }, '[AnalyticsBuffer] User identified');
     } catch (err) {
       logger.warn({ err }, '[AnalyticsBuffer] Failed to identify user');
+    }
+  }
+
+  /**
+   * Emit ONE minimal, NON-PII event under the now-identified distinct_id to materialize a queryable
+   * server-side PostHog person (Gate B / feature-flag targeting). posthog-js (1.298.1 deployed)
+   * defaults person_profiles to 'identified_only', so a person is created only once an INGESTED event
+   * is tied to the identified distinct_id; the lone $identify did not reliably ingest in short
+   * sessions. STRICT no-PII: a constant source tag only — never email, name, transcript, audio,
+   * secrets, or the raw auth/session object. Self-contained try/catch so a capture failure is
+   * non-fatal and never prevents the caller's flag reload / Sentry update.
+   */
+  private captureAccountIdentified(): void {
+    try {
+      posthog.capture('account_identified', { source: 'auth_provider' });
+    } catch (err) {
+      logger.warn({ err }, '[AnalyticsBuffer] Failed to send account_identified event');
     }
   }
 

--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -192,7 +192,17 @@ class AnalyticsBuffer {
 
     try {
       posthog.identify(userId, properties);
-      // Explicitly re-evaluate feature flags for the now-identified user so the app never keeps the
+      // Materialize a SERVER-SIDE PostHog person for the identified user (Gate B / feature-flag
+      // targeting). posthog-js (1.298.1 deployed) defaults person_profiles to 'identified_only', so
+      // a queryable person is created only once an INGESTED event is tied to the identified
+      // distinct_id. On the deployed build the lone $identify did not reliably ingest (short sessions
+      // never flushed a single batched event) — server-side showed 0 web $identify / 0 events under
+      // the Supabase user.id — so no person appeared and flag targeting could not match. Emit ONE
+      // minimal, NON-PII event under the now-identified distinct_id to guarantee materialization.
+      // STRICT no-PII: a constant source tag only — never email, name, transcript, audio, secrets,
+      // or the raw auth/session object.
+      posthog.capture('account_identified', { source: 'auth_provider' });
+      // Explicitly re-evaluate feature flags AFTER identify + capture so the app never keeps the
       // prior anonymous flag state (the Gate B stale-flag gotcha — flags must reflect the account).
       posthog.reloadFeatureFlags();
       Sentry.setUser({ id: userId, ...properties });

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { analyticsBuffer } from '../AnalyticsBuffer';
 import posthog from 'posthog-js';
+import * as Sentry from '@sentry/react';
 
 // Mock PostHog
 vi.mock('posthog-js', () => ({
@@ -12,6 +13,9 @@ vi.mock('posthog-js', () => ({
     _isIdentified: vi.fn()
   }
 }));
+
+// Mock Sentry so identity-path assertions (setUser) are observable.
+vi.mock('@sentry/react', () => ({ setUser: vi.fn() }));
 
 describe('AnalyticsBuffer (Hardened Background Asset)', () => {
   beforeEach(() => {
@@ -189,6 +193,19 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
     const reloadOrder = vi.mocked(posthog.reloadFeatureFlags).mock.invocationCallOrder[0];
     expect(captureOrder).toBeLessThan(reloadOrder);
+  });
+
+  it('keeps the materialization capture NON-FATAL: a capture throw must not block flag reload / Sentry', () => {
+    // The account_identified capture is best-effort; flag reload after identify is the load-bearing
+    // step and must always run, plus identify() must never throw out of its catch.
+    vi.mocked(posthog.capture).mockImplementationOnce(() => { throw new Error('capture boom'); });
+
+    expect(() => analyticsBuffer.identify('user-123')).not.toThrow();
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-123', undefined);
+    expect(posthog.capture).toHaveBeenCalledWith('account_identified', { source: 'auth_provider' });
+    expect(posthog.reloadFeatureFlags).toHaveBeenCalled(); // still runs despite capture failure
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-123' }); // still runs despite capture failure
   });
 
   it('resetIdentity() resets PostHog to a fresh anonymous id and reloads flags', () => {

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -174,6 +174,23 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     expect(posthog.reloadFeatureFlags).toHaveBeenCalled(); // flags re-evaluated for the identified user
   });
 
+  it('identify() emits ONE minimal non-PII materialization event under the identified id (Gate B person creation)', () => {
+    analyticsBuffer.identify('user-123');
+    // Guarantees a server-ingested web event so PostHog materializes a queryable person at user.id
+    // (identified_only mode); without this, a lone $identify can fail to ingest in short sessions.
+    expect(posthog.capture).toHaveBeenCalledWith('account_identified', { source: 'auth_provider' });
+    // STRICT no-PII: the materialization event must never carry email/name/transcript/audio/etc.
+    const payload = JSON.stringify(vi.mocked(posthog.capture).mock.calls);
+    expect(payload).not.toMatch(/email|@|transcript|audio|password|token|name/i);
+  });
+
+  it('identify() materializes (capture) BEFORE reloading flags so eval reflects the new person', () => {
+    analyticsBuffer.identify('user-123');
+    const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
+    const reloadOrder = vi.mocked(posthog.reloadFeatureFlags).mock.invocationCallOrder[0];
+    expect(captureOrder).toBeLessThan(reloadOrder);
+  });
+
   it('resetIdentity() resets PostHog to a fresh anonymous id and reloads flags', () => {
     analyticsBuffer.resetIdentity();
     expect(posthog.reset).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Second fix for `POSTHOG-STT-A/B — FAIL_AUTH_POSTHOG_IDENTIFY`. The sync-init fix (#749) deployed (build `79b224f`) and **browser-local** identity passed, but Test's **server-side** proof still failed: `0` `lib='web'` `$identify`, `0` events under the Supabase `user.id`, `queryablePerson=false`. 2 files.

## Root cause (confirmed server-side)
- Deployed build `79b224f` **is** the #749 merge — sync init is live, so the init race is not the remaining cause.
- posthog-js **`1.298.1`** (queried from ingested `web` events) defaults `person_profiles` to **`identified_only`**: a queryable person is materialized only once an **ingested** event is tied to the identified `distinct_id`.
- The lone `$identify` from `identify()` did **not** reliably ingest — server-side shows `last web event = 2026-06-11T16:39` (pre-deploy) and `0` web `$identify` all-time. A single batched `$identify` in a short Phase-1 session never flushed, so no person was created and flag `709644` could not match.

## Fix
Emit **one minimal, NON-PII** event immediately after `posthog.identify(user.id)` and before `reloadFeatureFlags()`:

```ts
posthog.capture('account_identified', { source: 'auth_provider' });
```

This guarantees a server-ingested `web` event tied to the user.id → PostHog materializes a queryable person. Release-owner-endorsed follow-up to Option A (sync init **retained**).

## Privacy contract — unchanged and enforced
- `distinct_id = Supabase user.id` only
- **no** email / name / transcript / audio / secrets / raw auth or session object — the materialization payload is a constant `source` tag
- no client-settable `isInternalTester`
- `reloadFeatureFlags()` after identify + capture

A test asserts the materialization payload carries no PII and that `capture` precedes the flag reload.

## Verification
- `tsc` clean · `eslint` clean · AnalyticsBuffer suite **13/13** (2 new: non-PII materialization event; capture-before-reload ordering).

## Post-merge validation (Test — two-layer Phase-1, unchanged)
**Browser-local:** `distinct_id === 22899590-…`, not anonymous, no email.
**PostHog server-side (project 207400):** a `lib='web'` `$identify` **or** `account_identified` event under that distinct_id; a **queryable person** at it; `eventsUnderUserId > 0`; no email property; `private_stt_v4_enabled` evaluable after operator targeting.

Only then → Product targets the user.id (operator cohort, not `isInternalTester`) → Gate B proof + negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
