### PR TITLE
fix(analytics): flush account_identified immediately (Gate B server-side ingest)

### DIFF
--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -219,6 +219,13 @@ class AnalyticsBuffer {
   private captureAccountIdentified(): void {
     try {
       posthog.capture('account_identified', { source: 'auth_provider' });
+      // Flush IMMEDIATELY so the materialization event is sent now, not held in the batch queue.
+      // A login is often followed quickly by navigation; if the batched request never flushes before
+      // the page unloads, PostHog never ingests the event and no server-side person is created (the
+      // Gate B failure: 0 web events under the user.id despite local distinct_id being correct).
+      // flush() exists in the deployed posthog-js (1.298.1); guarded + cast so it is a safe no-op if
+      // a future version drops it, and the surrounding try/catch keeps it non-fatal.
+      (posthog as unknown as { flush?: () => void }).flush?.();
     } catch (err) {
       logger.warn({ err }, '[AnalyticsBuffer] Failed to send account_identified event');
     }

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -10,7 +10,8 @@ vi.mock('posthog-js', () => ({
     identify: vi.fn(),
     reset: vi.fn(),
     reloadFeatureFlags: vi.fn(),
-    _isIdentified: vi.fn()
+    _isIdentified: vi.fn(),
+    flush: vi.fn()
   }
 }));
 
@@ -193,6 +194,16 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
     const reloadOrder = vi.mocked(posthog.reloadFeatureFlags).mock.invocationCallOrder[0];
     expect(captureOrder).toBeLessThan(reloadOrder);
+  });
+
+  it('flushes IMMEDIATELY after the materialization capture so the event is sent, not batch-queued', () => {
+    const phFlush = (posthog as unknown as { flush: ReturnType<typeof vi.fn> }).flush;
+    analyticsBuffer.identify('user-123');
+    expect(phFlush).toHaveBeenCalled();
+    // flush must come after the capture (send the queued account_identified event now).
+    const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
+    const flushOrder = vi.mocked(phFlush).mock.invocationCallOrder[0];
+    expect(flushOrder).toBeGreaterThan(captureOrder);
   });
 
   it('keeps the materialization capture NON-FATAL: a capture throw must not block flag reload / Sentry', () => {


### PR DESCRIPTION
## Summary

Third fix for `POSTHOG-STT-A/B — FAIL_AUTH_POSTHOG_IDENTIFY`. After #750 deployed the `account_identified` capture, Test's server-side proof **still** found `0` web events under the Supabase user.id. This PR flushes the capture immediately so it actually ingests. 2 files.

## Investigation of the deployed build (`speaksharp-public.vercel.app`)
- **Deployed PostHog key = `phc_Mp4Ap4…` = project 207400's key** → production *does* target the Gate B project. **Wrong-project hypothesis ruled out.**
- Deployed bundle **contains** the `account_identified` capture (the #750 code is live; `captureAccountIdentified(){try{...capture("account_identified",{source:"auth_provider"})...}}`).
- posthog-js `1.298.1` exposes **`flush()`** and `request_batching`; ingestion endpoint is `/e/`.
- Yet project 207400 has **`0` `lib='web'` events in 6h**.

## Root cause (remaining app-side mode) + fix
With wrong-project ruled out and the code confirmed live, the remaining app-side failure mode is **batching**: the capture is enqueued in posthog's batch and not flushed before a (often short) login session navigates/unloads, so it never reaches `/e/` and no person is materialized.

Fix — flush immediately after the capture:
```ts
posthog.capture('account_identified', { source: 'auth_provider' });
(posthog as unknown as { flush?: () => void }).flush?.();   // send now, don't batch-queue
```
Guarded + cast (safe no-op if a future posthog-js drops `flush`), inside the existing `try/catch` (non-fatal). **`flush()` is confirmed present in the deployed posthog-js — not a guess.**

## Privacy contract — unchanged
`distinct_id = user.id` only; payload is the constant `{ source: 'auth_provider' }`; no email/PII; no client-settable `isInternalTester`.

## Verification
- `tsc` clean · `eslint` clean · AnalyticsBuffer **15/15** (new test asserts `flush()` is called after the capture).

## ⚠️ Important for Test (proof-harness)
`0` web events in 6h *also* means **no real flushing login session has reached the deployed app** in that window. This flush removes the last app-side cause, but for the proof to observe anything Test must:
- drive a **real interactive Supabase login** as the Pro user against the deployed app (not injected local state), and
- watch the **`https://us.i.posthog.com/e/`** ingestion request after login (the capture fires on `AuthProvider` identify).

Acceptance unchanged: `queryablePerson=true`, `eventsUnderUserId>0` (a `lib='web'` `account_identified` under `22899590-…`), `hasEmailProperty=false`, `mutations=[]` before identity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
