### PR TITLE
fix(analytics): send account_identified with send_instantly (Gate B /e/ fires)

### DIFF
--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -218,14 +218,13 @@ class AnalyticsBuffer {
    */
   private captureAccountIdentified(): void {
     try {
-      posthog.capture('account_identified', { source: 'auth_provider' });
-      // Flush IMMEDIATELY so the materialization event is sent now, not held in the batch queue.
-      // A login is often followed quickly by navigation; if the batched request never flushes before
-      // the page unloads, PostHog never ingests the event and no server-side person is created (the
-      // Gate B failure: 0 web events under the user.id despite local distinct_id being correct).
-      // flush() exists in the deployed posthog-js (1.298.1); guarded + cast so it is a safe no-op if
-      // a future version drops it, and the surrounding try/catch keeps it non-fatal.
-      (posthog as unknown as { flush?: () => void }).flush?.();
+      // send_instantly:true SKIPS the batched request queue and POSTs the event to /e/ immediately.
+      // Required for Gate B: a login is often followed quickly by navigation/page-close, and the
+      // default batch flush is ~3s, so the materialization event otherwise never leaves the browser
+      // (deployed proof saw /flags requests but ZERO /e/ requests; 0 server-side events under the
+      // user.id). NOTE: posthog-js 1.298.1 has NO public flush() — the prior flush() attempt was a
+      // silent no-op — so the per-event send_instantly option is the correct, documented mechanism.
+      posthog.capture('account_identified', { source: 'auth_provider' }, { send_instantly: true });
     } catch (err) {
       logger.warn({ err }, '[AnalyticsBuffer] Failed to send account_identified event');
     }

--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -60,6 +60,17 @@ class AnalyticsBuffer {
   public readonly MAX_QUEUE_SIZE = 1000;
   private readonly BATCH_SIZE = 10;
 
+  // Non-PII identity observability probe (mirrored to window.__SS_ANALYTICS_IDENTITY__) so a deployed
+  // proof can confirm EXACTLY which step of the identify path ran — without guessing from network
+  // traces. Strictly mechanism counters/booleans: NO user.id, email, transcript, or any PII.
+  private readonly identityProbe = {
+    identifyCalls: 0,
+    accountIdentifiedAttempts: 0,
+    accountIdentifiedSendInstantly: false,
+    lastAccountIdentifiedError: null as string | null,
+    lastUpdated: 0,
+  };
+
   private constructor() {
     if (typeof window !== 'undefined') {
       window.addEventListener('pagehide', () => this.drainSynchronously());
@@ -190,6 +201,7 @@ class AnalyticsBuffer {
    */
   public identify(userId: string, properties?: Record<string, unknown>): void {
 
+    this.identityProbe.identifyCalls += 1;
     try {
       posthog.identify(userId, properties);
       // Materialize a SERVER-SIDE PostHog person (Gate B / flag targeting) — see
@@ -204,6 +216,21 @@ class AnalyticsBuffer {
       logger.debug({ userId }, '[AnalyticsBuffer] User identified');
     } catch (err) {
       logger.warn({ err }, '[AnalyticsBuffer] Failed to identify user');
+    } finally {
+      this.publishIdentityProbe();
+    }
+  }
+
+  /** Mirror the non-PII identity probe to window so a deployed proof can read it. Never throws. */
+  private publishIdentityProbe(): void {
+    if (typeof window === 'undefined') return;
+    try {
+      this.identityProbe.lastUpdated = Date.now();
+      (window as unknown as { __SS_ANALYTICS_IDENTITY__?: unknown }).__SS_ANALYTICS_IDENTITY__ = {
+        ...this.identityProbe,
+      };
+    } catch {
+      /* observability must never affect app behavior */
     }
   }
 
@@ -217,6 +244,8 @@ class AnalyticsBuffer {
    * non-fatal and never prevents the caller's flag reload / Sentry update.
    */
   private captureAccountIdentified(): void {
+    this.identityProbe.accountIdentifiedAttempts += 1;
+    this.identityProbe.accountIdentifiedSendInstantly = true;
     try {
       // send_instantly:true SKIPS the batched request queue and POSTs the event to /e/ immediately.
       // Required for Gate B: a login is often followed quickly by navigation/page-close, and the
@@ -225,7 +254,10 @@ class AnalyticsBuffer {
       // user.id). NOTE: posthog-js 1.298.1 has NO public flush() — the prior flush() attempt was a
       // silent no-op — so the per-event send_instantly option is the correct, documented mechanism.
       posthog.capture('account_identified', { source: 'auth_provider' }, { send_instantly: true });
+      this.identityProbe.lastAccountIdentifiedError = null;
     } catch (err) {
+      // Record only the error NAME (never the message) to keep the probe strictly PII-free.
+      this.identityProbe.lastAccountIdentifiedError = err instanceof Error ? err.name : 'unknown';
       logger.warn({ err }, '[AnalyticsBuffer] Failed to send account_identified event');
     }
   }

--- a/frontend/src/services/__tests__/AnalyticsBuffer.identity.integration.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.identity.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+// REAL posthog-js (intentionally NOT mocked). This proves, end-to-end through the real SDK, that
+// AnalyticsBuffer.identify() drives posthog to actually PROCESS the non-PII `account_identified`
+// materialization event (it is not dropped by any config/guard) and that the processed event carries
+// no PII. We assert via posthog's `before_send` hook — the last point an event passes through before
+// transport.
+//
+// SCOPE / KNOWN LIMITATION (verified empirically, not assumed): jsdom cannot exercise posthog's
+// network transport. A fully-processed `send_instantly` event reaches `before_send` and capture()
+// returns a valid event object, yet ZERO fetch/XHR/sendBeacon requests fire in jsdom. So the actual
+// "/e/ request fires immediately" proof is NOT achievable here — it is delegated to Test's real-
+// browser deployed proof (now made conclusive by window.__SS_ANALYTICS_IDENTITY__). That
+// send_instantly routes to the immediate-send branch (not the batch queue) is verified at the
+// posthog-js source level; this test verifies the wiring + privacy that ARE provable in jsdom.
+import posthog from 'posthog-js';
+import { analyticsBuffer } from '../AnalyticsBuffer';
+
+interface ProcessedEvent { event?: string; properties?: Record<string, unknown> }
+
+const processed: ProcessedEvent[] = [];
+
+describe('AnalyticsBuffer identity → REAL posthog-js processing (Gate B materialization)', () => {
+  beforeAll(() => {
+    posthog.init('phc_integration_test', {
+      api_host: 'https://ph.integration.test',
+      advanced_disable_flags: true,
+      disable_external_dependency_loading: true,
+      disable_session_recording: true,
+      autocapture: false,
+      capture_pageview: false,
+      before_send: (ev) => {
+        if (ev) processed.push(ev as ProcessedEvent);
+        return ev;
+      },
+    });
+  });
+
+  it('drives real posthog to process a non-PII account_identified event on identify()', () => {
+    processed.length = 0;
+    analyticsBuffer.identify('itest-user-7a3f');
+
+    const accountIdentified = processed.find((e) => e.event === 'account_identified');
+    // Real posthog ACCEPTED and processed the event (not silently dropped by config/guards).
+    expect(accountIdentified).toBeDefined();
+    expect(accountIdentified?.properties?.source).toBe('auth_provider');
+
+    // STRICT no-PII on the fully-enriched event: no email/transcript/audio/etc.
+    const blob = JSON.stringify(accountIdentified);
+    expect(blob).not.toMatch(/email|transcript|audio|password|secret|@/i);
+  });
+
+  it('records the non-PII identity probe (window.__SS_ANALYTICS_IDENTITY__) for deployed proofs', () => {
+    analyticsBuffer.identify('itest-user-9c21');
+    const probe = (window as unknown as { __SS_ANALYTICS_IDENTITY__?: Record<string, unknown> })
+      .__SS_ANALYTICS_IDENTITY__;
+    expect(probe).toBeDefined();
+    expect(probe?.accountIdentifiedSendInstantly).toBe(true);
+    expect((probe?.identifyCalls as number) ?? 0).toBeGreaterThan(0);
+    expect((probe?.accountIdentifiedAttempts as number) ?? 0).toBeGreaterThan(0);
+    // The probe itself must be PII-free (no user id / email leaked into the diagnostic surface).
+    const probeBlob = JSON.stringify(probe);
+    expect(probeBlob).not.toMatch(/itest-user|email|@/i);
+  });
+});

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -10,8 +10,7 @@ vi.mock('posthog-js', () => ({
     identify: vi.fn(),
     reset: vi.fn(),
     reloadFeatureFlags: vi.fn(),
-    _isIdentified: vi.fn(),
-    flush: vi.fn()
+    _isIdentified: vi.fn()
   }
 }));
 
@@ -179,11 +178,15 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     expect(posthog.reloadFeatureFlags).toHaveBeenCalled(); // flags re-evaluated for the identified user
   });
 
-  it('identify() emits ONE minimal non-PII materialization event under the identified id (Gate B person creation)', () => {
+  it('identify() emits ONE minimal non-PII materialization event sent INSTANTLY (Gate B person creation)', () => {
     analyticsBuffer.identify('user-123');
-    // Guarantees a server-ingested web event so PostHog materializes a queryable person at user.id
-    // (identified_only mode); without this, a lone $identify can fail to ingest in short sessions.
-    expect(posthog.capture).toHaveBeenCalledWith('account_identified', { source: 'auth_provider' });
+    // send_instantly skips the batch queue so the /e/ request fires immediately and PostHog
+    // materializes a queryable person at user.id (identified_only mode) even on a short session.
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'account_identified',
+      { source: 'auth_provider' },
+      { send_instantly: true },
+    );
     // STRICT no-PII: the materialization event must never carry email/name/transcript/audio/etc.
     const payload = JSON.stringify(vi.mocked(posthog.capture).mock.calls);
     expect(payload).not.toMatch(/email|@|transcript|audio|password|token|name/i);
@@ -194,16 +197,6 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
     const reloadOrder = vi.mocked(posthog.reloadFeatureFlags).mock.invocationCallOrder[0];
     expect(captureOrder).toBeLessThan(reloadOrder);
-  });
-
-  it('flushes IMMEDIATELY after the materialization capture so the event is sent, not batch-queued', () => {
-    const phFlush = (posthog as unknown as { flush: ReturnType<typeof vi.fn> }).flush;
-    analyticsBuffer.identify('user-123');
-    expect(phFlush).toHaveBeenCalled();
-    // flush must come after the capture (send the queued account_identified event now).
-    const captureOrder = vi.mocked(posthog.capture).mock.invocationCallOrder[0];
-    const flushOrder = vi.mocked(phFlush).mock.invocationCallOrder[0];
-    expect(flushOrder).toBeGreaterThan(captureOrder);
   });
 
   it('keeps the materialization capture NON-FATAL: a capture throw must not block flag reload / Sentry', () => {

--- a/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
+++ b/frontend/src/services/__tests__/AnalyticsBuffer.test.ts
@@ -207,7 +207,11 @@ describe('AnalyticsBuffer identity (account-linked PostHog identity)', () => {
     expect(() => analyticsBuffer.identify('user-123')).not.toThrow();
 
     expect(posthog.identify).toHaveBeenCalledWith('user-123', undefined);
-    expect(posthog.capture).toHaveBeenCalledWith('account_identified', { source: 'auth_provider' });
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'account_identified',
+      { source: 'auth_provider' },
+      { send_instantly: true },
+    );
     expect(posthog.reloadFeatureFlags).toHaveBeenCalled(); // still runs despite capture failure
     expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-123' }); // still runs despite capture failure
   });


### PR DESCRIPTION
## Summary

Fourth and **root** fix for `POSTHOG-STT-A/B — FAIL_AUTH_POSTHOG_IDENTIFY`. #751 (`flush()`) merged + deployed (`ddfe620d`) but the browser **still emitted zero `/e/` requests** (only `/flags`), and the server-side proof still failed. 2 files.

## Why #751 didn't work (verified, not guessed)
Checked posthog-js `1.298.1` **published type defs**:
- There is **no public `flush()`** — only `private _flush` / `_flushToCapture`. So #751's guarded `(posthog as ...).flush?.()` resolved to `undefined` and was a **silent no-op**.
- `capture()` events sit in the **batched request queue** (default flush ~3s, per `RequestQueueConfig.flush_interval_ms`), so the `account_identified` event never left the short proof session → 0 ingested events → no server-side person.

## Fix
Use the documented `CaptureOptions.send_instantly` (3rd arg of `capture`, *"If set, skips the batched queue"*):
```ts
posthog.capture('account_identified', { source: 'auth_provider' }, { send_instantly: true });
```
This POSTs to `/e/` immediately, independent of the batch timer / page lifetime. Removed the no-op `flush()` call.

`capture(event_name, properties?, options?: CaptureOptions)` and `send_instantly?: boolean` are both in the `1.298.1` type defs — verified, stable API.

## Privacy contract — unchanged
`distinct_id = user.id` only; payload is the constant `{ source: 'auth_provider' }`; no email/PII; no client-settable `isInternalTester`. Still non-fatal (own try/catch); capture still precedes `reloadFeatureFlags()`.

## Verification
- `tsc` clean · `eslint` clean · AnalyticsBuffer suite green (test asserts capture is called with `{ send_instantly: true }` and carries no PII).

## Post-merge validation (Test)
After deploy (build SHA must include this merge), rerun the server-identity proof and watch for a **`POST https://us.i.posthog.com/e/`** carrying `account_identified` immediately after login — `eRequestCount`/`accountIdentifiedRequestCount` should now be ≥ 1. Acceptance unchanged: `queryablePerson=true`, `eventsUnderUserId>0`, `hasEmailProperty=false`, `mutations=[]` before identity pass. Then operator targeting → official Gate B + negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
