### PR TITLE
fix(live-transcript): withhold severe v4 streaming repetition loops (LIVE-TRANSCRIPT-REPEATED-DISPLAY)

### DIFF
--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Lock, Cloud } from 'lucide-react';
 import { TEST_IDS } from '@/constants/testIds';
 import { SESSION_INSET_SURFACE_CLASS, SESSION_SURFACE_CLASS } from './sessionSurface';
-import { splitSettledActiveTranscript } from './liveTranscriptUtils';
+import { splitSettledActiveTranscript, hasSevereRepetitionLoop } from './liveTranscriptUtils';
 
 import { parseTranscriptForHighlighting } from '@/utils/highlightUtils';
 
@@ -104,6 +104,15 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             : (hasTranscript ? 'final' : 'idle');
     const normalizedSttMode = (sttMode ?? '').toLowerCase();
     const isPrivateMode = normalizedSttMode === 'private';
+    // LIVE-TRANSCRIPT-REPEATED-DISPLAY (A+): release containment for the v4 Whisper streaming
+    // repetition-loop failure mode. When the live (committed or interim) text is severely looped,
+    // WITHHOLD it from the surface and show the existing "Processing…" state until the clean
+    // whole-utterance final replaces it. Display-only: no transcript data is mutated/de-duplicated;
+    // gated to private mode so Native/Cloud are untouched, and the detector only fires on v4-grade
+    // loops so healthy private-v2 text is unaffected. (Proper fix tracked separately: keep v4
+    // streaming hypotheses out of the committed transcript store.)
+    const withholdLoopedLive = isPrivateMode
+        && (hasSevereRepetitionLoop(transcript) || hasSevereRepetitionLoop(interimTranscript));
     const isDrafting = uiState === 'drafting';
     const showDraftTrustBanner = isListening && !isFinalizing;
     const showPrivateFeedback = isPrivateMode && isListening;
@@ -306,6 +315,17 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                     ) : (
                         <p className="text-sm font-semibold text-foreground/75 animate-pulse">{listeningEmptyText}</p>
                     )
+                ) : withholdLoopedLive ? (
+                    // A+ release containment: a severe v4 streaming repetition loop is withheld from
+                    // the surface; show Processing until the clean whole-utterance final lands.
+                    <div
+                        className="flex min-h-[120px] flex-col items-center justify-center gap-2 text-center text-foreground/80"
+                        data-testid="live-transcript-loop-withheld"
+                        data-transcript-loop-withheld="true"
+                    >
+                        <p className="text-sm font-semibold text-primary">{finalizingBannerText}</p>
+                        <p className="max-w-sm text-xs text-foreground/60">{finalizingEmptyDescription}</p>
+                    </div>
                 ) : hasTranscript || hasInterimTranscript ? (
                     <div
                         className={`text-foreground text-lg leading-relaxed ${isDrafting ? 'rounded-md border border-dashed border-primary/30 bg-primary/5 p-3 text-foreground/80' : ''}`}

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '../../../../tests/support/test-utils';
 import { act } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { LiveTranscriptPanel } from '@/components/session/LiveTranscriptPanel';
-import { splitSettledActiveTranscript } from '@/components/session/liveTranscriptUtils';
+import { splitSettledActiveTranscript, hasSevereRepetitionLoop } from '@/components/session/liveTranscriptUtils';
 import { TEST_IDS } from '@/constants/testIds';
 
 describe('LiveTranscriptPanel', () => {
@@ -546,6 +546,78 @@ describe('LiveTranscriptPanel', () => {
             // Regression: previously textContent read "Draft transcriptText may change…".
             expect(banner).toHaveTextContent('Draft transcript Text may change before the final transcript is saved.');
             expect(banner.textContent).not.toContain('transcriptText');
+        });
+    });
+
+    describe('v4 repetition-loop withholding (LIVE-TRANSCRIPT-REPEATED-DISPLAY)', () => {
+        // Real failure mode from Test artifact speaksharp-official-stt-ab-targeted-trust-1781263998:
+        // the v4 rolling/streaming hypothesis loops ("It's a question" x28) in the COMMITTED store
+        // transcript during drafting/finalizing, while the final whole-utterance decode is clean.
+        // The display must WITHHOLD the looped live text (show Processing) until the clean final
+        // arrives — without mutating any transcript data.
+        const REAL_LOOP = 'Love from a return. ' + "It's a question. ".repeat(28);
+
+        it('withholds a severe v4 loop from the visible surface and shows Processing (private)', () => {
+            render(
+                <LiveTranscriptPanel
+                    transcript={REAL_LOOP}
+                    interimTranscript=""
+                    isListening={false}
+                    isFinalizing
+                    sttMode="private"
+                />
+            );
+            const container = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+            const visibleReps = (container.textContent?.match(/it'?s a question/gi) || []).length;
+            // The looped phrase must NOT be on the user-visible surface.
+            expect(visibleReps).toBeLessThan(3);
+            // Processing state shown instead of the loop.
+            expect(screen.getByTestId('live-transcript-loop-withheld')).toBeInTheDocument();
+            expect(container).toHaveTextContent(/processing speech locally/i);
+            // NON-destructive: the committed transcript data itself is preserved (hidden committed hook).
+            expect(screen.getByTestId('transcript-text-only'))
+                .toHaveAttribute('data-transcript-text-only', REAL_LOOP.trim());
+        });
+
+        it('renders a clean final transcript normally (no withhold)', () => {
+            const clean = 'This is a clean final transcript with varied content and no repetition loops.';
+            render(
+                <LiveTranscriptPanel transcript={clean} interimTranscript="" isListening={false} sttMode="private" />
+            );
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+            expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveTextContent('This is a clean final transcript');
+        });
+
+        it('renders normal non-looped live text (no withhold)', () => {
+            render(
+                <LiveTranscriptPanel transcript="hello world this is going fine" interimTranscript="and a few more words" isListening sttMode="private" />
+            );
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+            expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveTextContent('hello world this is going fine');
+        });
+
+        it('does NOT withhold in native (non-private) mode even with a looped transcript', () => {
+            render(
+                <LiveTranscriptPanel transcript={REAL_LOOP} interimTranscript="" isListening sttMode="native" />
+            );
+            // Native/Cloud paths are unaffected by the v4 containment guard.
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+            expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER).textContent).toMatch(/it'?s a question/i);
+        });
+
+        describe('hasSevereRepetitionLoop detector', () => {
+            it('flags a severe repetition loop', () => {
+                expect(hasSevereRepetitionLoop('Love from a return. ' + "It's a question. ".repeat(28))).toBe(true);
+            });
+            it('does NOT flag clean varied text', () => {
+                expect(hasSevereRepetitionLoop('This is a perfectly normal sentence with varied content and absolutely no loops here.')).toBe(false);
+            });
+            it('does NOT flag short text', () => {
+                expect(hasSevereRepetitionLoop('too short to judge')).toBe(false);
+            });
+            it('does NOT flag mild/legitimate repetition', () => {
+                expect(hasSevereRepetitionLoop('no no no I really do mean it, the honest answer here is simply no.')).toBe(false);
+            });
         });
     });
 });

--- a/frontend/src/components/session/liveTranscriptUtils.ts
+++ b/frontend/src/components/session/liveTranscriptUtils.ts
@@ -21,3 +21,46 @@ export function splitSettledActiveTranscript(text: string): { settled: string; a
         active: trimmed.slice(lastEnd).trim(),
     };
 }
+
+// Conservative thresholds, grounded on the real failure artifact
+// (speaksharp-official-stt-ab-targeted-trust-1781263998): a v4 rolling-hypothesis loop has a top
+// repeated 3-gram count of 28-29 and 3-gram redundancy 0.38-0.65, while clean v4-final AND v2
+// transcripts top out at a 3-gram count of 2 and redundancy <= 0.009. The cuts below sit far from
+// any healthy transcript, so the detector fires ONLY on a severe loop.
+const SEVERE_LOOP_MIN_TOKENS = 12;
+const SEVERE_LOOP_MAX_NGRAM_COUNT = 4; // healthy max is 2; looped is 28+
+const SEVERE_LOOP_REDUNDANCY = 0.25;   // healthy is <= 0.009; looped is 0.38-0.65
+
+/**
+ * Conservative, deterministic detector for a SEVERE repetition loop in live STT text — the v4
+ * Whisper streaming/rolling-hypothesis failure mode (drift + repetition). DISPLAY-ONLY: callers use
+ * this purely to decide whether to WITHHOLD unstable live text from the surface until the clean
+ * whole-utterance final arrives. It NEVER mutates, rewrites, or de-duplicates transcript content
+ * (collapse/fuzzy-dedup is intentionally NOT used — it can delete legitimate repeated speech and is
+ * empirically insufficient anyway). Signal = frequency of the most-repeated normalized 3-gram and
+ * overall 3-gram redundancy; both far separate looped from healthy text.
+ */
+export function hasSevereRepetitionLoop(text: string): boolean {
+    const words = (text || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9'\s]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean);
+    if (words.length < SEVERE_LOOP_MIN_TOKENS) return false;
+
+    const counts = new Map<string, number>();
+    let totalGrams = 0;
+    let maxCount = 0;
+    let repeatedGrams = 0;
+    for (let i = 0; i + 3 <= words.length; i += 1) {
+        const gram = `${words[i]} ${words[i + 1]} ${words[i + 2]}`;
+        const next = (counts.get(gram) ?? 0) + 1;
+        counts.set(gram, next);
+        totalGrams += 1;
+        if (next > maxCount) maxCount = next;
+        if (next > 1) repeatedGrams += 1; // each occurrence past the first is a repeat
+    }
+    if (totalGrams === 0) return false;
+    const redundancy = repeatedGrams / totalGrams;
+    return maxCount >= SEVERE_LOOP_MAX_NGRAM_COUNT || redundancy >= SEVERE_LOOP_REDUNDANCY;
+}


### PR DESCRIPTION
A+ release containment for the v4 Whisper streaming repetition-loop failure mode.

**Reproduce-first:** the new component test renders the REAL artifact loop string and FAILS on unfixed main (28 reps render), then PASSES after the fix.

**Fix (display-layer, 3 files):**
- `hasSevereRepetitionLoop()` — conservative deterministic detector (top repeated 3-gram count / redundancy). Thresholds grounded on the real artifact: looped text = 28-29 / 0.38-0.65 vs clean v4-final AND v2 = 2 / <=0.009.
- `LiveTranscriptPanel` withholds looped live text (private mode only) and shows the existing "Processing speech locally…" state until the clean whole-utterance final lands.

**Acceptance (all covered by tests):** real-artifact reproduction fails pre-fix; loop withheld; clean final still renders; no transcript-data mutation (committed hook preserved); normal live text preserved; native/non-private unaffected; "Processing…" shown.

**By design NOT done:** no fuzzy collapse (empirically insufficient — 28->2, leaves run-ons — and risks deleting legit repeated speech); no data mutation; no engine/store commit-semantics change. Follow-up B filed: keep v4 streaming hypotheses out of the committed transcript store.

41/41 panel tests pass; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)