### PR TITLE
fix(live-transcript): withhold severe v4 repetition loops — A+ port to v4 deploy candidate

### DIFF
--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -4,6 +4,7 @@ import { TEST_IDS } from '@/constants/testIds';
 import { SESSION_INSET_SURFACE_CLASS, SESSION_SURFACE_CLASS } from './sessionSurface';
 import {
     collapseAdjacentRepeatedPhrases,
+    hasSevereRepetitionLoop,
     splitSettledActiveTranscript,
     trimOverlappingDraftTranscript
 } from './liveTranscriptUtils';
@@ -111,6 +112,15 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             : (hasTranscript ? 'final' : 'idle');
     const normalizedSttMode = (sttMode ?? '').toLowerCase();
     const isPrivateMode = normalizedSttMode === 'private';
+    // LIVE-TRANSCRIPT-REPEATED-DISPLAY (A+): release containment for the v4 Whisper streaming
+    // repetition-loop failure mode. When the live (committed or interim) text is severely looped,
+    // WITHHOLD it from the surface and show the existing "Processing…" state until the clean
+    // whole-utterance final replaces it. Display-only: no transcript data is mutated/de-duplicated;
+    // gated to private mode so Native/Cloud are untouched, and the detector only fires on v4-grade
+    // loops so healthy private-v2 text is unaffected. (Proper fix tracked separately: keep v4
+    // streaming hypotheses out of the committed transcript store.)
+    const withholdLoopedLive = isPrivateMode
+        && (hasSevereRepetitionLoop(transcript) || hasSevereRepetitionLoop(interimTranscript));
     const isDrafting = uiState === 'drafting';
     const showDraftTrustBanner = isListening && !isFinalizing;
     const showTrustHeader = isFinalizing || showDraftTrustBanner;
@@ -330,6 +340,17 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                     ) : (
                         <p className="text-sm font-semibold text-foreground/75 animate-pulse">{listeningEmptyText}</p>
                     )
+                ) : withholdLoopedLive ? (
+                    // A+ release containment: a severe v4 streaming repetition loop is withheld from
+                    // the surface; show Processing until the clean whole-utterance final lands.
+                    <div
+                        className="flex min-h-[120px] flex-col items-center justify-center gap-2 text-center text-foreground/80"
+                        data-testid="live-transcript-loop-withheld"
+                        data-transcript-loop-withheld="true"
+                    >
+                        <p className="text-sm font-semibold text-primary">{finalizingBannerText}</p>
+                        <p className="max-w-sm text-xs text-foreground/60">{finalizingEmptyDescription}</p>
+                    </div>
                 ) : hasTranscript || hasInterimTranscript ? (
                     <div
                         className={`text-foreground text-lg leading-relaxed ${isDrafting ? 'rounded-md border border-dashed border-primary/30 bg-primary/5 p-3 text-foreground/80' : ''}`}

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { LiveTranscriptPanel } from '@/components/session/LiveTranscriptPanel';
 import {
     collapseAdjacentRepeatedPhrases,
+    hasSevereRepetitionLoop,
     splitSettledActiveTranscript,
     trimOverlappingDraftTranscript
 } from '@/components/session/liveTranscriptUtils';
@@ -666,6 +667,53 @@ describe('LiveTranscriptPanel', () => {
             expect(slot).toContainElement(banner);
             expect(transcriptContainer).not.toContainElement(banner);
             expect(transcriptContainer).toHaveClass('overflow-y-auto');
+        });
+    });
+
+    describe('v4 repetition-loop withholding (LIVE-TRANSCRIPT-REPEATED-DISPLAY)', () => {
+        // Real failure mode from Test artifact speaksharp-official-stt-ab-targeted-trust-1781263998:
+        // the v4 rolling/streaming hypothesis loops ("It's a question" x28) in the COMMITTED store
+        // transcript during drafting/finalizing, while the final whole-utterance decode is clean.
+        // The display must WITHHOLD the looped live text (show Processing) until the clean final
+        // arrives — without mutating any transcript data.
+        const REAL_LOOP = 'Love from a return. ' + "It's a question. ".repeat(28);
+
+        it('withholds a severe v4 loop from the visible surface and shows Processing (private)', () => {
+            render(
+                <LiveTranscriptPanel transcript={REAL_LOOP} interimTranscript="" isListening={false} isFinalizing sttMode="private" />
+            );
+            const container = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+            const visibleReps = (container.textContent?.match(/it'?s a question/gi) || []).length;
+            expect(visibleReps).toBeLessThan(3);
+            expect(screen.getByTestId('live-transcript-loop-withheld')).toBeInTheDocument();
+            expect(container).toHaveTextContent(/processing speech locally/i);
+        });
+
+        it('renders a clean final transcript normally (no withhold)', () => {
+            render(
+                <LiveTranscriptPanel transcript="This is a clean final transcript with varied content and no repetition loops." interimTranscript="" isListening={false} sttMode="private" />
+            );
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+            expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveTextContent('This is a clean final transcript');
+        });
+
+        it('does NOT withhold in native (non-private) mode even with a looped transcript', () => {
+            render(
+                <LiveTranscriptPanel transcript={REAL_LOOP} interimTranscript="" isListening sttMode="native" />
+            );
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+        });
+
+        describe('hasSevereRepetitionLoop detector', () => {
+            it('flags a severe repetition loop', () => {
+                expect(hasSevereRepetitionLoop(REAL_LOOP)).toBe(true);
+            });
+            it('does NOT flag clean varied text', () => {
+                expect(hasSevereRepetitionLoop('This is a perfectly normal sentence with varied content and absolutely no loops here.')).toBe(false);
+            });
+            it('does NOT flag short text', () => {
+                expect(hasSevereRepetitionLoop('too short to judge')).toBe(false);
+            });
         });
     });
 });

--- a/frontend/src/components/session/liveTranscriptUtils.ts
+++ b/frontend/src/components/session/liveTranscriptUtils.ts
@@ -122,3 +122,46 @@ export function collapseAdjacentRepeatedPhrases(text: string): string {
 
     return wordsToText(collapsed);
 }
+
+// Conservative thresholds, grounded on the real failure artifact
+// (speaksharp-official-stt-ab-targeted-trust-1781263998): a v4 rolling-hypothesis loop has a top
+// repeated 3-gram count of 28-29 and 3-gram redundancy 0.38-0.65, while clean v4-final AND v2
+// transcripts top out at a 3-gram count of 2 and redundancy <= 0.009. The cuts below sit far from
+// any healthy transcript, so the detector fires ONLY on a severe loop.
+const SEVERE_LOOP_MIN_TOKENS = 12;
+const SEVERE_LOOP_MAX_NGRAM_COUNT = 4; // healthy max is 2; looped is 28+
+const SEVERE_LOOP_REDUNDANCY = 0.25;   // healthy is <= 0.009; looped is 0.38-0.65
+
+/**
+ * Conservative, deterministic detector for a SEVERE repetition loop in live STT text — the v4
+ * Whisper streaming/rolling-hypothesis failure mode (drift + repetition). DISPLAY-ONLY: callers use
+ * this purely to decide whether to WITHHOLD unstable live text from the surface until the clean
+ * whole-utterance final arrives. It NEVER mutates, rewrites, or de-duplicates transcript content
+ * (collapse/fuzzy-dedup is intentionally NOT used as the release fix — it can delete legitimate
+ * repeated speech and is empirically insufficient anyway). Signal = frequency of the most-repeated
+ * normalized 3-gram and overall 3-gram redundancy; both far separate looped from healthy text.
+ */
+export function hasSevereRepetitionLoop(text: string): boolean {
+    const words = (text || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9'\s]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean);
+    if (words.length < SEVERE_LOOP_MIN_TOKENS) return false;
+
+    const counts = new Map<string, number>();
+    let totalGrams = 0;
+    let maxCount = 0;
+    let repeatedGrams = 0;
+    for (let i = 0; i + 3 <= words.length; i += 1) {
+        const gram = `${words[i]} ${words[i + 1]} ${words[i + 2]}`;
+        const next = (counts.get(gram) ?? 0) + 1;
+        counts.set(gram, next);
+        totalGrams += 1;
+        if (next > maxCount) maxCount = next;
+        if (next > 1) repeatedGrams += 1;
+    }
+    if (totalGrams === 0) return false;
+    const redundancy = repeatedGrams / totalGrams;
+    return maxCount >= SEVERE_LOOP_MAX_NGRAM_COUNT || redundancy >= SEVERE_LOOP_REDUNDANCY;
+}


### PR DESCRIPTION
Port of the A+ display-layer containment ([PR #753](https://github.com/relativityE/speaksharp/pull/753), off `main`) onto the `dev/v4-integration` deploy candidate — where Private/v4 routing exists for the **real browser proof** (main cannot run Private mode locally).

Same conservative `hasSevereRepetitionLoop()` detector (top repeated 3-gram / redundancy; thresholds grounded on the real artifact — looped 28-29/0.38-0.65 vs clean v4-final AND v2 = 2/<=0.009) + WITHHOLD guard that shows the existing "Processing speech locally…" until the clean whole-utterance final lands. Layered on top of this branchs existing `collapseAdjacentRepeatedPhrases` (collapse stays; withhold takes precedence for SEVERE loops, which collapse alone does not clean — 28→2 on the real artifact).

Display-only: no transcript-data mutation, no fuzzy collapse as the release fix, no engine/store change; private-gated (Native/Cloud + healthy v2 unaffected).

**47/47 panel tests** (41 existing + 6 ported: real-artifact reproduction, clean-final-renders, native-unaffected, detector unit). tsc + eslint clean.

**Next:** Test runs the full browser proof against this v4 candidate (targeted + negative): dirty v4 live loop withheld; Processing shown; clean final renders; saved transcript not mutated; healthy v4 live renders; v2/Native unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)