### PR TITLE
fix(private-stt): keep severe v4 streaming repetition loops out of the committed transcript (LIVE-TRANSCRIPT-REPEATED-DISPLAY follow-up B)

### DIFF
--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -408,6 +408,48 @@ export function collapseTranscriptRepetitionLoops(text: string): string {
   return out.join(' ');
 }
 
+// Conservative, deterministic detector for a SEVERE repetition loop — the v4 (transformers-js-v4 /
+// WebGPU) Whisper rolling/streaming-hypothesis failure mode (drift + repetition within a decode
+// window). Used at the live-final COMMIT boundary to enforce the data-layer invariant: the committed
+// transcript must never carry an unfinalized streaming repetition loop. Signal = frequency of the
+// most-repeated normalized 3-gram and overall 3-gram redundancy.
+//
+// This intentionally MIRRORS hasSevereRepetitionLoop() in
+// components/session/liveTranscriptUtils.ts (the display-layer withhold). The copy is deliberate:
+// the engine/store boundary and the render boundary are defended INDEPENDENTLY (defense-in-depth),
+// so neither layer imports the other. Thresholds are grounded on the real failure artifact
+// (speaksharp-official-stt-ab-targeted-trust-1781263998): a looped decode has a top 3-gram count of
+// 28-29 and redundancy 0.38-0.65, while clean v4-final AND v2 transcripts top out at a 3-gram count
+// of 2 and redundancy <= 0.009 — so the cuts below fire ONLY on a severe loop.
+const SEVERE_COMMIT_LOOP_MIN_TOKENS = 12;
+const SEVERE_COMMIT_LOOP_MAX_NGRAM_COUNT = 4; // healthy max is 2; looped is 28+
+const SEVERE_COMMIT_LOOP_REDUNDANCY = 0.25;   // healthy is <= 0.009; looped is 0.38-0.65
+
+export function hasSevereTranscriptRepetitionLoop(text: string): boolean {
+  const words = (text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9'\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length < SEVERE_COMMIT_LOOP_MIN_TOKENS) return false;
+
+  const counts = new Map<string, number>();
+  let totalGrams = 0;
+  let maxCount = 0;
+  let repeatedGrams = 0;
+  for (let i = 0; i + 3 <= words.length; i += 1) {
+    const gram = `${words[i]} ${words[i + 1]} ${words[i + 2]}`;
+    const next = (counts.get(gram) ?? 0) + 1;
+    counts.set(gram, next);
+    totalGrams += 1;
+    if (next > maxCount) maxCount = next;
+    if (next > 1) repeatedGrams += 1;
+  }
+  if (totalGrams === 0) return false;
+  const redundancy = repeatedGrams / totalGrams;
+  return maxCount >= SEVERE_COMMIT_LOOP_MAX_NGRAM_COUNT || redundancy >= SEVERE_COMMIT_LOOP_REDUNDANCY;
+}
+
 function appendTranscriptWithoutDuplicate(base: string, segment: string): string {
   const baseText = base.replace(/\s+/g, ' ').trim();
   const segmentText = segment.replace(/\s+/g, ' ').trim();
@@ -1750,6 +1792,51 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
             return;
           }
         }
+
+        // DATA-LAYER INVARIANT (LIVE-TRANSCRIPT-REPEATED-DISPLAY follow-up B):
+        // The committed transcript must represent STABLE text — never an unfinalized v4 streaming
+        // repetition loop. The whole-utterance final already collapses loops before it becomes the
+        // saved authority; apply the SAME treatment to the live-final commit, plus a severe-loop
+        // backstop:
+        //   1. collapse in-window loops (identical to the saved-authority path), then
+        //   2. if a SEVERE loop survives collapse, or would form at the commit seam, DO NOT commit —
+        //      route the hypothesis to the interim/partial buffer ONLY and retain the audio so the
+        //      clean whole-utterance final stays the committed authority.
+        // Conservative: healthy v2/v4 text is a collapse no-op and never trips the detector, so the
+        // normal live-commit behavior is unchanged. Independent of (and complementary to) the
+        // display-layer withhold guard — defense-in-depth across the store and render boundaries.
+        const committedSegment = collapseTranscriptRepetitionLoops(textToEmit);
+        const projectedCommit = this.currentTranscript.trim()
+          ? `${this.currentTranscript} ${committedSegment}`
+          : committedSegment;
+        if (
+          !committedSegment.trim() ||
+          hasSevereTranscriptRepetitionLoop(committedSegment) ||
+          hasSevereTranscriptRepetitionLoop(projectedCommit)
+        ) {
+          pushPrivateTimeline('live_final_severe_loop_withheld_from_commit', {
+            serviceId: this.serviceId,
+            runId: this.instanceId,
+            rawPreview: redactTranscript(textToEmit),
+            collapsedPreview: redactTranscript(committedSegment),
+            currentPreview: redactTranscript(this.currentTranscript),
+          });
+          logger.info({
+            sId: this.serviceId,
+            rId: this.instanceId,
+            rawLength: textToEmit.length,
+            collapsedLength: committedSegment.length,
+          }, '[PrivateWhisper] Withholding severe streaming repetition loop from committed transcript (kept as interim; whole-utterance final remains authority)');
+          // Surface as provisional only — a looped hypothesis belongs in the interim buffer, never the
+          // committed store. The display-layer withhold then keeps it off the visible surface too.
+          if (this.onTranscriptUpdate && !this.isStopping) {
+            this.emitProvisionalPartial(textToEmit, 'severe_loop_withheld_from_commit');
+          }
+          this.retainSpeechLikeAudioForRetry(processedAudio, energy, 'severe_loop_withheld_from_commit');
+          return;
+        }
+        // Commit the collapsed (loop-free) segment, not the raw rolling decode.
+        textToEmit = committedSegment;
 
         logger.info({ sId: this.serviceId, rId: this.instanceId, newText: redactTranscript(textToEmit), latencyMs: (performance.now() - tStart).toFixed(2) }, '[PrivateWhisper] ✨ Transcription success');
         this.currentTranscript = this.currentTranscript ? `${this.currentTranscript} ${textToEmit}` : textToEmit;

--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -425,6 +425,13 @@ const SEVERE_COMMIT_LOOP_MIN_TOKENS = 12;
 const SEVERE_COMMIT_LOOP_MAX_NGRAM_COUNT = 4; // healthy max is 2; looped is 28+
 const SEVERE_COMMIT_LOOP_REDUNDANCY = 0.25;   // healthy is <= 0.009; looped is 0.38-0.65
 
+// When deciding whether committing the new segment would FORM a loop at the boundary, inspect only
+// this many trailing words of the already-committed transcript (the "commit seam"), never the full
+// history. A full-history scan made the withhold sticky: one legitimate earlier repeated phrase
+// (e.g. an emphatic "thank you so much" x4) would trip the detector forever and withhold every later
+// CLEAN segment. A bounded seam still catches a loop spanning the segment boundary.
+const COMMIT_SEAM_CONTEXT_WORDS = 24;
+
 export function hasSevereTranscriptRepetitionLoop(text: string): boolean {
   const words = (text || '')
     .toLowerCase()
@@ -1806,13 +1813,18 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
         // normal live-commit behavior is unchanged. Independent of (and complementary to) the
         // display-layer withhold guard — defense-in-depth across the store and render boundaries.
         const committedSegment = collapseTranscriptRepetitionLoops(textToEmit);
-        const projectedCommit = this.currentTranscript.trim()
-          ? `${this.currentTranscript} ${committedSegment}`
-          : committedSegment;
+        // Inspect only the COMMIT SEAM (a bounded tail of the already-committed transcript + the new
+        // segment), never the full accumulated transcript. Scanning the whole history made the
+        // withhold sticky — a single legitimate earlier repeated phrase would trip the detector
+        // forever and withhold every later CLEAN segment. The seam window still catches a loop that
+        // forms across the segment boundary.
+        const committedWords = this.currentTranscript.trim().split(/\s+/).filter(Boolean);
+        const commitSeamTail = committedWords.slice(-COMMIT_SEAM_CONTEXT_WORDS).join(' ');
+        const commitSeamWindow = commitSeamTail ? `${commitSeamTail} ${committedSegment}` : committedSegment;
         if (
           !committedSegment.trim() ||
           hasSevereTranscriptRepetitionLoop(committedSegment) ||
-          hasSevereTranscriptRepetitionLoop(projectedCommit)
+          hasSevereTranscriptRepetitionLoop(commitSeamWindow)
         ) {
           pushPrivateTimeline('live_final_severe_loop_withheld_from_commit', {
             serviceId: this.serviceId,

--- a/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
+++ b/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ✅ CRITICAL: Unmock for THIS file only (Prevent Over-Mocking)
 vi.unmock('../PrivateWhisper');
 
-import PrivateWhisper, { buildPrivateTimingSummary, collapseTranscriptRepetitionLoops } from '../PrivateWhisper';
+import PrivateWhisper, { buildPrivateTimingSummary, collapseTranscriptRepetitionLoops, hasSevereTranscriptRepetitionLoop } from '../PrivateWhisper';
 import { Result } from '../types';
 import { MicStream } from '../../utils/types';
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_DERIVED, SESSION_PAUSE } from '../../sttConstants';
@@ -1125,6 +1125,99 @@ describe('PrivateWhisper (Facade Wrapper)', () => {
 
         await privateWhisper.stop();
         vi.useRealTimers();
+    });
+
+    // LIVE-TRANSCRIPT-REPEATED-DISPLAY follow-up B (data-layer invariant):
+    // A v4 rolling/streaming decode can loop within its window ("It's a question" x28 in the real
+    // artifact). The committed transcript must represent STABLE text — it must never carry an
+    // unfinalized streaming repetition loop. Before this fix, the live-final commit path appended the
+    // raw rolling decode to currentTranscript and emitted { final } with no loop guard (unlike the
+    // whole-utterance final, which collapses loops), so the user-visible committed transcript looped
+    // during drafting/finalizing. Reproduce-first: drive a looped rolling decode into the commit path
+    // and assert the loop never reaches the committed transcript / { final } emit.
+    it('REGRESSION (B): withholds a severe v4 streaming loop from the live-final committed transcript', async () => {
+        await privateWhisper.init();
+        const engine = privateWhisper as unknown as {
+            status: string;
+            currentTranscript: string;
+            audioChunks: Float32Array[];
+            bufferedSampleCount: number;
+            hasDetectedSpeech: boolean;
+            processAudio: (options?: { force?: boolean }) => Promise<void>;
+        };
+
+        const LOOP = "It's a question. ".repeat(28).trim();
+        // A first transcript is already committed (the realistic mid-recording state).
+        engine.status = 'transcribing';
+        engine.currentTranscript = 'Love from a return.';
+        // Strong, clearly-voiced audio so the silence/low-energy gates pass and the decode commits.
+        const speech = new Float32Array(PRIV_STT_DERIVED.MIN_TRANSCRIPTION_SAMPLES + 4000).fill(0.5);
+        engine.audioChunks = [speech];
+        engine.bufferedSampleCount = speech.length;
+        engine.hasDetectedSpeech = true;
+        mocks.transcribe.mockResolvedValueOnce(Result.ok(LOOP));
+
+        await engine.processAudio();
+
+        const countReps = (s: string) => (s.toLowerCase().match(/it'?s a question/g) || []).length;
+
+        // INVARIANT: the committed transcript must not contain the severe streaming loop.
+        expect(countReps(engine.currentTranscript)).toBeLessThan(3);
+
+        // INVARIANT: no committed { final } emit may carry the severe loop. (A looped hypothesis may
+        // still be surfaced as a { partial } interim — the display-layer withhold guard owns that —
+        // but it must never be committed as { final }.)
+        const finalEmits = (mockCallbacks.onTranscriptUpdate.mock.calls as Array<[{ transcript?: { final?: string } }]>)
+            .map((call) => call[0]?.transcript?.final)
+            .filter((v): v is string => typeof v === 'string');
+        for (const emitted of finalEmits) {
+            expect(countReps(emitted)).toBeLessThan(3);
+        }
+    });
+
+    it('REGRESSION (B): still commits a normal (non-looped) rolling decode as { final }', async () => {
+        await privateWhisper.init();
+        const engine = privateWhisper as unknown as {
+            status: string;
+            currentTranscript: string;
+            audioChunks: Float32Array[];
+            bufferedSampleCount: number;
+            hasDetectedSpeech: boolean;
+            processAudio: (options?: { force?: boolean }) => Promise<void>;
+        };
+
+        engine.status = 'transcribing';
+        engine.currentTranscript = 'Love from a return.';
+        const speech = new Float32Array(PRIV_STT_DERIVED.MIN_TRANSCRIPTION_SAMPLES + 4000).fill(0.5);
+        engine.audioChunks = [speech];
+        engine.bufferedSampleCount = speech.length;
+        engine.hasDetectedSpeech = true;
+        mocks.transcribe.mockResolvedValueOnce(Result.ok('and the audience listened closely to every word'));
+
+        await engine.processAudio();
+
+        expect(mockCallbacks.onTranscriptUpdate).toHaveBeenCalledWith({
+            transcript: { final: 'and the audience listened closely to every word' },
+        });
+        expect(engine.currentTranscript).toContain('and the audience listened closely to every word');
+    });
+});
+
+describe('hasSevereTranscriptRepetitionLoop (committed-store loop guard, follow-up B)', () => {
+    it('flags a severe v4 streaming repetition loop', () => {
+        expect(hasSevereTranscriptRepetitionLoop("It's a question. ".repeat(28))).toBe(true);
+    });
+    it('does NOT flag clean varied text', () => {
+        expect(hasSevereTranscriptRepetitionLoop('The quick brown fox jumps over the lazy dog and then it runs far away today.')).toBe(false);
+    });
+    it('does NOT flag a clean whole-utterance-style transcript', () => {
+        expect(hasSevereTranscriptRepetitionLoop('Love from a return. I want to talk about why questions matter and how we should ask them.')).toBe(false);
+    });
+    it('does NOT flag short text (below the min-token floor)', () => {
+        expect(hasSevereTranscriptRepetitionLoop("It's a question.")).toBe(false);
+    });
+    it('does NOT flag a benign 2x phrase repeat', () => {
+        expect(hasSevereTranscriptRepetitionLoop('I think I think we should go to the store and buy some milk today')).toBe(false);
     });
 });
 

--- a/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
+++ b/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
@@ -1201,6 +1201,45 @@ describe('PrivateWhisper (Facade Wrapper)', () => {
         });
         expect(engine.currentTranscript).toContain('and the audience listened closely to every word');
     });
+
+    it('REGRESSION (B-P2): a legitimate earlier repeated phrase must NOT withhold later clean segments', async () => {
+        await privateWhisper.init();
+        const engine = privateWhisper as unknown as {
+            status: string;
+            currentTranscript: string;
+            audioChunks: Float32Array[];
+            bufferedSampleCount: number;
+            hasDetectedSpeech: boolean;
+            processAudio: (options?: { force?: boolean }) => Promise<void>;
+        };
+
+        // currentTranscript holds an EARLY, legitimate emphatic repeat ("thank you so much" x4) that
+        // trips the loop detector on the FULL text, followed by enough clean speech that the early
+        // repeat sits OUTSIDE the bounded commit seam. Before the seam fix the full-history scan made
+        // the withhold STICKY — every later clean segment got withheld indefinitely.
+        const earlyRepeat = 'thank you so much thank you so much thank you so much thank you so much';
+        const cleanTail = 'and then the team reviewed the quarterly numbers carefully before we agreed on the final plan for shipping the new release to every customer region without any further delay';
+        engine.status = 'transcribing';
+        engine.currentTranscript = `${earlyRepeat} ${cleanTail}`;
+        // Precondition proving this is a real P2 reproduction: the FULL accumulated transcript trips the
+        // detector, so the old full-history scan WOULD withhold the next clean segment.
+        expect(hasSevereTranscriptRepetitionLoop(engine.currentTranscript)).toBe(true);
+
+        const speech = new Float32Array(PRIV_STT_DERIVED.MIN_TRANSCRIPTION_SAMPLES + 4000).fill(0.5);
+        engine.audioChunks = [speech];
+        engine.bufferedSampleCount = speech.length;
+        engine.hasDetectedSpeech = true;
+        mocks.transcribe.mockResolvedValueOnce(Result.ok('which the whole room applauded warmly'));
+
+        await engine.processAudio();
+
+        // The clean new segment MUST be committed — the stale early repeat must not withhold it.
+        expect(engine.currentTranscript).toContain('which the whole room applauded warmly');
+        const finalEmits = (mockCallbacks.onTranscriptUpdate.mock.calls as Array<[{ transcript?: { final?: string } }]>)
+            .map((call) => call[0]?.transcript?.final)
+            .filter((v): v is string => typeof v === 'string');
+        expect(finalEmits.some((f) => /which the whole room applauded warmly/.test(f))).toBe(true);
+    });
 });
 
 describe('hasSevereTranscriptRepetitionLoop (committed-store loop guard, follow-up B)', () => {


### PR DESCRIPTION
**The architecturally-correct data-layer fix** for the v4 repetition loop. The PR #753/#754 **display-layer withhold stays as defense-in-depth** — this PR does not touch it (untouched: `LiveTranscriptPanel.tsx`, `liveTranscriptUtils.ts`).

## Root cause (read from `PrivateWhisper.processAudio`)
The **live-final commit path** appended the raw rolling v4 decode to `currentTranscript` and emitted `{ final }` with **no loop guard**, while the **whole-utterance final** (the saved authority, line ~2252) *does* `collapseTranscriptRepetitionLoops(...)`. So a v4 (`transformers-js-v4`/WebGPU) rolling hypothesis that loops within its decode window reached the user-visible **committed** transcript during drafting/finalizing — `"It's a question"` x28 (2401-4340 chars) in the real artifact — even though the final saved transcript was clean (974 chars, 0 reps). That asymmetry is the bug.

## Fix (single commit-convergence point)
1. `collapseTranscriptRepetitionLoops(textToEmit)` — identical treatment to the saved-authority path, so in-window loops never enter the committed store.
2. **Severe-loop backstop:** if a severe loop survives collapse, or would form at the commit seam, **do not commit** — route the hypothesis to the interim/partial buffer only and retain the audio, so the clean whole-utterance final stays the committed authority.

**Invariant enforced:** the committed transcript never contains an unfinalized v4 streaming repetition loop.

Conservative + engine-agnostic: healthy v2/v4 text is a collapse no-op and never trips the detector (thresholds grounded on the real artifact — looped 3-gram count 28-29 / redundancy 0.38-0.65 vs clean <= 2 / <= 0.009), so **normal live-commit behavior is unchanged**. New `hasSevereTranscriptRepetitionLoop` mirrors the display-layer detector **independently** (no cross-layer import).

## Reconciles Test's collapse-at-merge WIP
Collapse alone was insufficient (the reviewer's 28->2 / run-on-near-dups finding). Here collapse is the **first tier** and the severe-loop **withhold** is the backstop that actually enforces the invariant — applied at the **commit boundary**, not the partial-merge path where the WIP put it.

## Prevention (decoder/streaming knobs) — investigated, deliberately not shipped blind
The v4 worker (`transformers-js-v4.worker.ts` `getAsrOptions`) sets **no** anti-loop generation knobs (`condition_on_previous_text`, `compression_ratio_threshold`, `no_speech_threshold`, `no_repeat_ngram_size`, `temperature`) and **ignores `decodeOptions`**; the allow-listed proof hook exists only on the **v2** engine. A generation-param effect is **unprovable in unit tests** (`transcribe` is mocked) and a blind default change is the engine-boundary risk that caused prior regressions — so it's filed as a **measurable follow-up** (plumb the proof hook into v4 -> Test A/Bs the knobs on the real WebGPU model against the loop artifact -> set the default from evidence).

## Verification (reproduce -> fix -> confirm)
- Failing **pipeline reproduction**: a looped rolling decode reaches `currentTranscript` (28 reps) -> **passes** after the guard (withheld).
- Normal-commit control (non-looped decode still commits as `{ final }`) + `hasSevereTranscriptRepetitionLoop` detector unit tests.
- **PrivateWhisper suite 50/50; full transcription suite 512/512; tsc + eslint clean.**

## Next (Test)
Browser proof on the v4 candidate: targeted Pro + negative control — confirm the **committed/saved** transcript carries no severe loop during drafting/finalizing (`visibleTranscriptRepetitionRisk.pass=true`), healthy v4/v2 unaffected, Native untouched. This is complementary to the #754 display withhold (both guards present once both merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
