### PR TITLE
chore(audit): close codebase-audit findings (index hygiene, honest waveform, storage clarity)

### DIFF
--- a/backend/supabase/migrations/20260612120000_audit_index_hygiene.sql
+++ b/backend/supabase/migrations/20260612120000_audit_index_hygiene.sql
@@ -1,0 +1,16 @@
+-- Codebase-audit index hygiene. No behavioral/data change; index-only DDL, idempotent.
+--
+-- (D) trial_entitlements.user_id is a foreign key (REFERENCES auth.users(id) ON DELETE SET NULL)
+--     with no supporting index (the table's PRIMARY KEY is `email`). Without an index on the
+--     referencing column, deleting an auth.users row forces Postgres to sequentially scan
+--     trial_entitlements to find and NULL the matching references — an avoidable IO spike at scale.
+--     Add the FK index.
+CREATE INDEX IF NOT EXISTS idx_trial_entitlements_user_id
+    ON public.trial_entitlements (user_id);
+
+-- (E) custom_vocabulary was renamed to user_filler_words (20260103170500_rename_custom_vocabulary),
+--     but its index kept the legacy name idx_custom_vocabulary_user_id. Postgres carries the index
+--     across a table rename, so this is purely cosmetic — align the index name with the current
+--     table. IF EXISTS keeps it a safe no-op if the index was already renamed/absent.
+ALTER INDEX IF EXISTS public.idx_custom_vocabulary_user_id
+    RENAME TO idx_user_filler_words_user_id;

--- a/frontend/src/components/session/LiveRecordingCard.tsx
+++ b/frontend/src/components/session/LiveRecordingCard.tsx
@@ -49,6 +49,14 @@ import { SESSION_SURFACE_CLASS } from '@/components/session/sessionSurface';
  * timer, and start/stop button.
  * Extracted from SessionPage for better reusability and testability.
  */
+// Decorative "recording active" indicator bar heights (px). Deterministic on purpose:
+// the previous implementation used Math.random() evaluated during render, which (a) only changed
+// on a React re-render — so it froze between renders and jumped abruptly rather than animating, and
+// (b) implied a live volume meter it never was. These fixed heights + a CSS `animate-pulse` give a
+// smooth, compositor-driven activity cue with zero render coupling. A real RMS-driven meter
+// (rAF + ref, no per-frame React state) is tracked as a separate enhancement.
+const RECORDING_BAR_HEIGHTS = [6, 11, 16, 9, 13, 7, 14, 10, 12, 8] as const;
+
 const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
     mode,
     isListening,
@@ -286,18 +294,16 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
                 <div className="h-4 w-full max-w-[140px] self-center flex items-center justify-center gap-0.5 overflow-hidden opacity-60">
                     {isIndicatorVisible && (
                         <div
-                            className="flex items-center gap-0.5"
+                            className={`flex items-center gap-0.5 ${isPaused ? '' : 'animate-pulse'}`}
                             data-testid="recording-indicator"
                             data-recording={isRecordingSignal}
                             data-paused={isPaused}
                         >
-                            {[...Array(10)].map((_, i) => (
+                            {RECORDING_BAR_HEIGHTS.map((barHeight, i) => (
                                 <div
                                     key={i}
                                     className={`w-0.5 rounded-full ${isPaused ? 'bg-amber-500/40' : 'bg-primary/40'}`}
-                                    style={{
-                                        height: isPaused ? '4px' : `${Math.max(4, Math.random() * 14 + 4)}px`,
-                                    }}
+                                    style={{ height: isPaused ? '4px' : `${barHeight}px` }}
                                 />
                             ))}
                         </div>

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,3 +1,16 @@
+/**
+ * Session/profile DATABASE repository (Supabase).
+ *
+ * NOTE ON NAMING: despite the file name, this module is NOT a browser-storage utility — it does not
+ * touch localStorage/sessionStorage. It is the client-side repository/adaptor for persisting and
+ * reading practice sessions, profiles, and history from the Supabase database. For browser
+ * localStorage/sessionStorage wrappers see `safeStorage.ts`.
+ *
+ * A physical rename to `sessionRepository.ts` is intentionally deferred: this module is imported by
+ * actively-edited files (e.g. SpeechRuntimeController) and renaming it now would create avoidable
+ * merge conflicts with in-flight feature branches. Rename as a single coordinated step once those
+ * branches land. Tracked as a follow-up.
+ */
 import { getSupabaseClient } from './supabaseClient';
 import logger from './logger';
 import type { PracticeSession } from '../types/session';


### PR DESCRIPTION
Closes the independent codebase-audit findings. Each was **verified against the code first**; severities are recalibrated where the review overstated them. Scope is intentionally tight and release-safe (no churn to startup/init code or widely-imported modules during the active v4 work).

## Finding → resolution

| # | Finding (review severity) | Verdict | Resolution |
|---|---|---|---|
| 1 | Static-import contamination drags **STT engines** into main bundle **[High]** | **Refuted (real severity Low)** | **Disposition (no code change).** Build proves engines (`TransformersJSEngine` 11 KB, `…V4` 9.9 KB) + ML libs (`vendor-transformers` 824 KB, `transformers.web` 559 KB) are **separate chunks** — dynamically `import()`-ed in `PrivateSTT.ts`, worker-isolated, and `manualChunks`-split. Only the orchestration *glue* (`SpeechRuntimeController`/`SessionManager`/`TranscriptionService`) is static-in-main, which is fine. The lazy-context refactor wouldn't move the heavy assets. |
| 2 | `storage.ts` is a DB repo, not browser storage **[Low]** | **Verified** | Added a module header clarifying it's the Supabase session/DB repository (vs `safeStorage.ts`). Physical rename to `sessionRepository.ts` **deferred** — it's imported by actively-edited files (e.g. `SpeechRuntimeController`); renaming now invites merge conflicts with in-flight branches. |
| 3 | Non-reactive waveform **[Medium]** | **Verified (substance), reclassified UX** | Replaced `Math.random()` per-render heights (frozen between renders, jerky, implied a meter it never was) with deterministic heights + CSS `animate-pulse` (compositor-driven, zero render coupling). A real RMS meter (rAF + ref) is a tracked enhancement — not built here because doing it via React state would create the re-render bottleneck the audit itself warns about. |
| 4 | Missing FK index `trial_entitlements.user_id` **[Medium]** | **Verified** | New idempotent migration adds `idx_trial_entitlements_user_id` (unindexed FK with `ON DELETE SET NULL` → seq scan on `auth.users` deletes). |
| 5 | Stale index name after `custom_vocabulary`→`user_filler_words` **[Low]** | **Verified** | Same migration renames `idx_custom_vocabulary_user_id` → `idx_user_filler_words_user_id` (`IF EXISTS`, safe no-op otherwise). |
| 6 | Webhook transactional rollback **(claimed correct)** | **Verified correct end-to-end** | **No change.** Confirmed the gap the review left: the edge caller `stripe-webhook/index.ts:134` returns a non-2xx on `success:false`, so the delete-marker-on-failure correctly enables Stripe retries. |

## Bonus (plan §3, never concluded in the audit)
Worker audio transfer: **already optimal** — both engine hosts pass `[workerAudio.buffer]` in the transfer list (zero-copy), so no structured-clone GC thrash.

## Verification
- `tsc` clean, `eslint` clean, `LiveRecordingCard` tests 14/14. No test depended on the random bars.
- Migration is index-only DDL, idempotent (`IF [NOT] EXISTS`), no data/behavioral change.
- Frontend changes add no imports → bundle composition unchanged.

## Notes
- Targeted at `main` (deploy/prod line) as these are general quality/DB-hygiene fixes orthogonal to the v4 release.
- Two items are justified **dispositions** rather than code (1 refuted as overstated; 6 already correct).
- Deferred follow-ups: physical `storage.ts`→`sessionRepository.ts` rename (post-merge), and the real RMS-driven meter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
