### PR TITLE
chore(db): index hygiene on the v4 line (FK index + index rename)

### DIFF
--- a/backend/supabase/migrations/20260612120000_audit_index_hygiene.sql
+++ b/backend/supabase/migrations/20260612120000_audit_index_hygiene.sql
@@ -1,0 +1,16 @@
+-- Codebase-audit index hygiene. No behavioral/data change; index-only DDL, idempotent.
+--
+-- (D) trial_entitlements.user_id is a foreign key (REFERENCES auth.users(id) ON DELETE SET NULL)
+--     with no supporting index (the table's PRIMARY KEY is `email`). Without an index on the
+--     referencing column, deleting an auth.users row forces Postgres to sequentially scan
+--     trial_entitlements to find and NULL the matching references — an avoidable IO spike at scale.
+--     Add the FK index.
+CREATE INDEX IF NOT EXISTS idx_trial_entitlements_user_id
+    ON public.trial_entitlements (user_id);
+
+-- (E) custom_vocabulary was renamed to user_filler_words (20260103170500_rename_custom_vocabulary),
+--     but its index kept the legacy name idx_custom_vocabulary_user_id. Postgres carries the index
+--     across a table rename, so this is purely cosmetic — align the index name with the current
+--     table. IF EXISTS keeps it a safe no-op if the index was already renamed/absent.
+ALTER INDEX IF EXISTS public.idx_custom_vocabulary_user_id
+    RENAME TO idx_user_filler_words_user_id;


### PR DESCRIPTION
Cherry-pick of the index-hygiene migration from [#756](https://github.com/relativityE/speaksharp/pull/756) (→ `main`) onto `dev/v4-integration`, so the index fixes ride the v4 merge too and apply on whichever branch reaches prod first.

- `idx_trial_entitlements_user_id` — unindexed FK (`ON DELETE SET NULL`) → seq scan on `auth.users` delete.
- rename `idx_custom_vocabulary_user_id` → `idx_user_filler_words_user_id` (table renamed earlier).

Idempotent index-only DDL (`IF [NOT] EXISTS`); identical file to #756. Migration-only (no frontend changes — those stay on #756).

🤖 Generated with [Claude Code](https://claude.com/claude-code)