### PR TITLE
feat(stt-v4): plumb allow-listed decode-option proof hook into v4 engine/worker (BL-1)

### DIFF
--- a/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
+++ b/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
@@ -15,6 +15,7 @@ import { MicStream } from '@/services/transcription/utils/types';
 import { ENV } from '@/config/TestFlags';
 import logger from '@/lib/logger';
 import { redactTranscript } from '@/lib/logRedaction';
+import { readPrivateDecodeOptionsOverride } from '@/services/transcription/engines/whisperDecodeOptions';
 import { STTEngine } from '@/contracts/STTEngine';
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_V4, PRIV_STT_V4_VARIANTS, PRIV_STT_V4_DEFAULT_VARIANT, type PrivSttV4VariantId, samplesToSeconds } from '../sttConstants';
 import { getV4ExperimentOverrides } from '../privateV4Experiment';
@@ -319,7 +320,7 @@ export class TransformersJSV4Engine extends STTEngine {
             if (this.worker) {
                 const workerAudio = audio.slice(0);
                 const response = await this.sendWorkerRequest(
-                    { type: 'transcribe', audio: workerAudio },
+                    { type: 'transcribe', audio: workerAudio, decodeOptions: readPrivateDecodeOptionsOverride() },
                     [workerAudio.buffer],
                 );
                 if (response.type !== 'result') {
@@ -495,7 +496,7 @@ export class TransformersJSV4Engine extends STTEngine {
     }
 
     private sendWorkerRequest(
-        request: { type: 'init'; isE2E: boolean; model?: string; dtype?: unknown; device?: string } | { type: 'transcribe'; audio: Float32Array } | { type: 'destroy' },
+        request: { type: 'init'; isE2E: boolean; model?: string; dtype?: unknown; device?: string } | { type: 'transcribe'; audio: Float32Array; decodeOptions?: Record<string, unknown> } | { type: 'destroy' },
         transfer?: Transferable[],
     ): Promise<WorkerResponse> {
         if (!this.worker) {

--- a/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
+++ b/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
@@ -83,7 +83,7 @@ function summarizeRawResult(result: unknown): UnknownRecord {
     return summary;
 }
 
-function getV4AsrOptions(audioLengthSeconds: number): Record<string, unknown> {
+function getV4AsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
     const options: Record<string, unknown> = {
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
@@ -93,6 +93,10 @@ function getV4AsrOptions(audioLengthSeconds: number): Record<string, unknown> {
     if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {
         options.language = 'en';
         options.task = 'transcribe';
+    }
+
+    if (decodeOptions) {
+        Object.assign(options, decodeOptions);
     }
 
     return options;
@@ -367,7 +371,7 @@ export class TransformersJSV4Engine extends STTEngine {
             }
 
             const audioLengthSeconds = samplesToSeconds(audio.length, PRIV_CLOUD_AUDIO.TARGET_SAMPLE_RATE_HZ);
-            const options = getV4AsrOptions(audioLengthSeconds);
+            const options = getV4AsrOptions(audioLengthSeconds, readPrivateDecodeOptionsOverride());
 
             const result = await (this.transcriber as (audio: Float32Array, options: Record<string, unknown>) => Promise<string | TranscriptionResult>)(audio, options);
 

--- a/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { mockPipeline } = vi.hoisted(() => ({
+    mockPipeline: vi.fn(),
+}));
+
 vi.mock('@/config/TestFlags', () => ({
     ENV: {
         isE2E: false,
@@ -15,6 +19,15 @@ vi.mock('@/lib/logger', () => ({
         warn: vi.fn(),
         error: vi.fn(),
         debug: vi.fn(),
+    },
+}));
+
+vi.mock('@huggingface/transformers', () => ({
+    pipeline: mockPipeline,
+    env: {},
+    LogLevel: {
+        ERROR: 'error',
+        INFO: 'info',
     },
 }));
 
@@ -79,6 +92,8 @@ describe('TransformersJSV4Engine worker message contract', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
+        mockPipeline.mockReset();
+        window.localStorage.clear();
         fakeWorkerMode = 'ready';
         fakeWorkerInstances.length = 0;
         vi.stubGlobal('Worker', FakeWorker);
@@ -89,6 +104,7 @@ describe('TransformersJSV4Engine worker message contract', () => {
 
     afterEach(() => {
         delete (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+        window.localStorage.clear();
         vi.useRealTimers();
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
@@ -172,6 +188,40 @@ describe('TransformersJSV4Engine worker message contract', () => {
             }),
             expect.any(Array),
         );
+
+        await engine.destroy();
+    });
+
+    it('contract: applies sanitized decode-option overrides in the v4 main-thread no-worker path', async () => {
+        const mainThreadTranscriber = vi.fn()
+            .mockResolvedValueOnce({ text: '' })
+            .mockResolvedValueOnce({ text: 'v4 main-thread transcript' });
+        mockPipeline.mockResolvedValueOnce(mainThreadTranscriber);
+        window.localStorage.setItem('speaksharp.v4.noWorker', '1');
+        (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = {
+            condition_on_previous_text: false,
+            no_repeat_ngram_size: 3,
+            unsafe_option: 'ignored',
+        };
+        const { TransformersJSV4Engine } = await import('../TransformersJSV4Engine');
+        const engine = new TransformersJSV4Engine({ onReady: vi.fn(), onTranscriptUpdate: vi.fn() });
+
+        const init = await engine.init();
+        const result = await engine.transcribe(new Float32Array(16000));
+
+        expect(init.isOk).toBe(true);
+        expect(result).toEqual(expect.objectContaining({
+            isOk: true,
+            data: 'v4 main-thread transcript',
+        }));
+        expect(fakeWorkerInstances).toHaveLength(0);
+        const transcribeOptions = mainThreadTranscriber.mock.calls[mainThreadTranscriber.mock.calls.length - 1]?.[1] as Record<string, unknown>;
+        expect(transcribeOptions).toEqual(expect.objectContaining({
+            condition_on_previous_text: false,
+            no_repeat_ngram_size: 3,
+            return_timestamps: true,
+        }));
+        expect(transcribeOptions).not.toHaveProperty('unsafe_option');
 
         await engine.destroy();
     });

--- a/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
@@ -88,6 +88,7 @@ describe('TransformersJSV4Engine worker message contract', () => {
     });
 
     afterEach(() => {
+        delete (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
         vi.useRealTimers();
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
@@ -140,6 +141,35 @@ describe('TransformersJSV4Engine worker message contract', () => {
         }));
         expect(fakeWorkerInstances[0]?.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({ type: 'transcribe', audio: expect.any(Float32Array) }),
+            expect.any(Array),
+        );
+
+        await engine.destroy();
+    });
+
+    it('contract: sends sanitized decode-option overrides from the browser proof hook', async () => {
+        fakeWorkerMode = 'transcribe-result';
+        (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = {
+            condition_on_previous_text: false,
+            compression_ratio_threshold: 2.4,
+            unsafe_option: 'ignored',
+        };
+        const { TransformersJSV4Engine } = await import('../TransformersJSV4Engine');
+        const engine = new TransformersJSV4Engine({ onReady: vi.fn(), onTranscriptUpdate: vi.fn() });
+
+        const init = await engine.init();
+        const result = await engine.transcribe(new Float32Array(16000));
+
+        expect(init.isOk).toBe(true);
+        expect(result.isOk).toBe(true);
+        expect(fakeWorkerInstances[0]?.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'transcribe',
+                decodeOptions: {
+                    condition_on_previous_text: false,
+                    compression_ratio_threshold: 2.4,
+                },
+            }),
             expect.any(Array),
         );
 

--- a/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    sanitizeDecodeOptions,
+    readPrivateDecodeOptionsOverride,
+    ALLOWED_DECODE_OPTIONS,
+} from '../whisperDecodeOptions';
+
+const setHook = (value: unknown) => {
+    (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = value;
+};
+const clearHook = () => {
+    delete (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+};
+
+describe('whisperDecodeOptions (v4 decode-option proof hook, BL-1)', () => {
+    describe('sanitizeDecodeOptions', () => {
+        it('returns undefined for non-objects', () => {
+            expect(sanitizeDecodeOptions(undefined)).toBeUndefined();
+            expect(sanitizeDecodeOptions(null)).toBeUndefined();
+            expect(sanitizeDecodeOptions('condition_on_previous_text')).toBeUndefined();
+            expect(sanitizeDecodeOptions(5)).toBeUndefined();
+        });
+
+        it('returns undefined when no allow-listed keys are present (product defaults preserved)', () => {
+            expect(sanitizeDecodeOptions({})).toBeUndefined();
+            expect(sanitizeDecodeOptions({ not_a_real_option: true, foo: 1 })).toBeUndefined();
+        });
+
+        it('keeps allow-listed boolean / number / number[] values', () => {
+            expect(sanitizeDecodeOptions({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+                compression_ratio_threshold: 2.4,
+                temperature: [0, 0.2, 0.4],
+            })).toEqual({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+                compression_ratio_threshold: 2.4,
+                temperature: [0, 0.2, 0.4],
+            });
+        });
+
+        it('drops disallowed keys but keeps allowed ones in the same object (no arbitrary injection)', () => {
+            expect(sanitizeDecodeOptions({ no_speech_threshold: 0.6, arbitrary_injection: 'rm -rf', model: 'evil' }))
+                .toEqual({ no_speech_threshold: 0.6 });
+        });
+
+        it('drops allow-listed keys whose value type is invalid', () => {
+            expect(sanitizeDecodeOptions({ condition_on_previous_text: 'false', temperature: ['x'] }))
+                .toBeUndefined();
+        });
+
+        it('exposes exactly the documented anti-loop knob set', () => {
+            expect([...ALLOWED_DECODE_OPTIONS].sort()).toEqual([
+                'compression_ratio_threshold',
+                'condition_on_previous_text',
+                'logprob_threshold',
+                'no_repeat_ngram_size',
+                'no_speech_threshold',
+                'return_timestamps',
+                'temperature',
+            ]);
+        });
+    });
+
+    describe('readPrivateDecodeOptionsOverride', () => {
+        afterEach(clearHook);
+
+        it('returns undefined when the hook is unset (product defaults preserved)', () => {
+            clearHook();
+            expect(readPrivateDecodeOptionsOverride()).toBeUndefined();
+        });
+
+        it('returns the sanitized override when the hook is set', () => {
+            setHook({ condition_on_previous_text: false, no_repeat_ngram_size: 3, bogus: 'ignored' });
+            expect(readPrivateDecodeOptionsOverride()).toEqual({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+            });
+        });
+
+        it('returns undefined when the hook holds only disallowed keys', () => {
+            setHook({ injected: true });
+            expect(readPrivateDecodeOptionsOverride()).toBeUndefined();
+        });
+    });
+});

--- a/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
+++ b/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
@@ -5,7 +5,7 @@ type Pipeline = Awaited<ReturnType<typeof import('@huggingface/transformers')['p
 
 type WorkerRequest =
     | { id: number; type: 'init'; isE2E: boolean; model?: string; dtype?: unknown; device?: string }
-    | { id: number; type: 'transcribe'; audio: Float32Array }
+    | { id: number; type: 'transcribe'; audio: Float32Array; decodeOptions?: Record<string, unknown> }
     | { id: number; type: 'destroy' };
 
 type WorkerResponse =
@@ -42,7 +42,7 @@ async function getPreferredDevice(): Promise<string | undefined> {
     return (await detectWebGPUSupport()).supported ? 'webgpu' : undefined;
 }
 
-function getAsrOptions(audioLengthSeconds: number): Record<string, unknown> {
+function getAsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
     const options: Record<string, unknown> = {
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
@@ -52,6 +52,12 @@ function getAsrOptions(audioLengthSeconds: number): Record<string, unknown> {
     if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {
         options.language = 'en';
         options.task = 'transcribe';
+    }
+
+    // Proof-hook overrides (allow-listed on the main thread) win over defaults. Inert unless the
+    // browser proof sets window.__PRIVATE_STT_DECODE_OPTIONS__ — product defaults are unchanged.
+    if (decodeOptions) {
+        Object.assign(options, decodeOptions);
     }
 
     return options;
@@ -153,7 +159,7 @@ async function init(id: number, isE2E: boolean, modelId: string, dtype: unknown,
     post({ id, type: 'ready' });
 }
 
-async function transcribe(id: number, audio: Float32Array): Promise<void> {
+async function transcribe(id: number, audio: Float32Array, decodeOptions?: Record<string, unknown>): Promise<void> {
     if (!transcriber) {
         throw new Error('TransformersJSV4 worker engine not initialized. Call init() first.');
     }
@@ -162,7 +168,7 @@ async function transcribe(id: number, audio: Float32Array): Promise<void> {
     const audioLengthSeconds = samplesToSeconds(audio.length, PRIV_CLOUD_AUDIO.TARGET_SAMPLE_RATE_HZ);
     const result = await (transcriber as (audio: Float32Array, options: Record<string, unknown>) => Promise<string | TranscriptionResult>)(
         audio,
-        getAsrOptions(audioLengthSeconds),
+        getAsrOptions(audioLengthSeconds, decodeOptions),
     );
     const transcript = typeof result === 'string'
         ? result
@@ -187,7 +193,7 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
                     await init(request.id, request.isE2E, request.model ?? PRIV_STT_V4.MODEL_ID, request.dtype ?? PRIV_STT_V4.DTYPE, request.device);
                     break;
                 case 'transcribe':
-                    await transcribe(request.id, request.audio);
+                    await transcribe(request.id, request.audio, request.decodeOptions);
                     break;
                 case 'destroy':
                     transcriber = null;

--- a/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
+++ b/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared Whisper decode-option proof hook (BL-1 / B-prevent-2).
+ *
+ * A test/release-proof seam that lets a browser proof A/B supported Whisper generation options
+ * WITHOUT changing product defaults. It is inert unless `window.__PRIVATE_STT_DECODE_OPTIONS__` is
+ * set, and only allow-listed keys are honored. The anti-loop knobs are included so Test can measure
+ * `condition_on_previous_text=false` / `no_repeat_ngram_size` / `compression_ratio_threshold` on the
+ * real WebGPU v4 model against the repetition-loop artifact, then we set a v4 default from evidence
+ * (a separate, evidence-backed change) rather than shipping a blind default.
+ *
+ * NOTE: the v2 engine (`TransformersJSEngine.ts`) currently carries its own private copy of this
+ * logic; consolidating it onto this module is a low-risk future cleanup (left out here to avoid
+ * touching the just-proven v2 path).
+ */
+
+export type WhisperDecodeOptions = Record<string, unknown>;
+
+/**
+ * Generation options a browser proof may override. Kept deliberately small and explicit — anything
+ * not in this set is ignored, so the hook can never inject arbitrary pipeline options.
+ */
+export const ALLOWED_DECODE_OPTIONS: ReadonlySet<string> = new Set([
+    'return_timestamps',
+    'condition_on_previous_text',
+    'compression_ratio_threshold',
+    'logprob_threshold',
+    'no_speech_threshold',
+    'no_repeat_ngram_size',
+    'temperature',
+]);
+
+/**
+ * Allow-list + type-guard a raw override object. Accepts only `boolean | number | number[]` values
+ * for allow-listed keys. Returns `undefined` when nothing valid is present (so callers can treat
+ * "no override" and "empty override" identically and keep product defaults).
+ */
+export function sanitizeDecodeOptions(source: unknown): WhisperDecodeOptions | undefined {
+    if (!source || typeof source !== 'object') return undefined;
+
+    const out: WhisperDecodeOptions = {};
+    for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+        if (!ALLOWED_DECODE_OPTIONS.has(key)) continue;
+        if (typeof value === 'boolean' || typeof value === 'number') {
+            out[key] = value;
+        } else if (Array.isArray(value) && value.every((item) => typeof item === 'number')) {
+            out[key] = value;
+        }
+    }
+
+    return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Main-thread only: read the proof-hook override from `window`. Returns `undefined` in a worker or
+ * SSR context (no `window`), or when the hook is unset/empty — i.e. product defaults are preserved.
+ */
+export function readPrivateDecodeOptionsOverride(): WhisperDecodeOptions | undefined {
+    if (typeof window === 'undefined') return undefined;
+    const source = (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+    return sanitizeDecodeOptions(source);
+}


### PR DESCRIPTION
Closes backlog **BL-1** (v4 decode-knob proof hook). Lets Test A/B Whisper anti-loop generation knobs on the **real WebGPU v4 model** without a product default change — the measurable prevention for the v4 repetition loop that the display/data-layer fixes (#754/#755) currently *contain*.

**Before:** the v4 worker set no anti-loop knobs and ignored `decodeOptions`; the proof hook existed only on the v2 engine.

**This PR:**
- New shared `whisperDecodeOptions.ts` — `ALLOWED_DECODE_OPTIONS` (`condition_on_previous_text`, `no_repeat_ngram_size`, `compression_ratio_threshold`, `logprob_threshold`, `no_speech_threshold`, `temperature`, `return_timestamps`) + `sanitizeDecodeOptions` (allow-list + `boolean|number|number[]` guard) + `readPrivateDecodeOptionsOverride` (main-thread reader of `window.__PRIVATE_STT_DECODE_OPTIONS__`).
- v4 engine reads the override and threads `decodeOptions` through the worker `transcribe` message; the worker merges it over `getAsrOptions` defaults (override wins).
- v4 main-thread/no-worker transcribe path also merges the sanitized override, so `?v4NoWorker=1` / `speaksharp.v4.noWorker` proof runs cannot silently use defaults.
- Test hardening added direct v4 regressions for both worker-message forwarding and main-thread no-worker option application.

**Safety:** inert in prod — returns `undefined` unless the hook is set, so **defaults are unchanged**; only allow-listed keys with valid types pass (no arbitrary pipeline-option injection).

**Next:** Test A/Bs the knobs vs the loop artifact on the real model → we set a v4 default from evidence in a **separate** PR (not a blind default).

**Review Follow-Up:** addressed the P2 main-thread/no-worker decode-hook review; thread resolved.

Verified after Test hardening: 15/15 focused tests (`whisperDecodeOptions` 9/9 + `TransformersJSV4Engine.worker` 6/6) · focused eslint clean · frontend tsc clean · diff check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)