### PR TITLE
fix(session): reset final transcript viewport

### DIFF
--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -81,6 +81,8 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
     isFinalizing = false,
     nativeFormatting = { status: 'idle', startedAt: null },
 }) => {
+    const internalContainerRef = React.useRef<HTMLDivElement>(null);
+    const transcriptContainerRef = containerRef ?? internalContainerRef;
     const tokens = parseTranscriptForHighlighting(transcript, userWords);
     const hasTranscript = transcript.trim() !== '';
     const displayInterimTranscript =
@@ -112,6 +114,7 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
     // loops so healthy private-v2 text is unaffected. (Proper fix tracked separately: keep v4
     // streaming hypotheses out of the committed transcript store.)
     const withholdLoopedLive = isPrivateMode
+        && (isListening || isFinalizing)
         && (hasSevereRepetitionLoop(transcript) || hasSevereRepetitionLoop(interimTranscript));
     const isDrafting = uiState === 'drafting';
     const showDraftTrustBanner = isListening && !isFinalizing;
@@ -126,6 +129,10 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
     const listeningEmptyText = isPrivateMode
         ? (hasSpeechActivity ? 'Processing speech locally…' : 'Listening locally…')
         : (hasSpeechActivity ? 'Processing speech…' : 'Listening...');
+    const transcriptViewportClass = uiState === 'final'
+        ? 'max-h-[18rem] sm:max-h-[20rem] lg:max-h-[22rem]'
+        : 'flex-1 min-h-[160px]';
+    const shouldAutoscrollTranscript = uiState !== 'final';
 
     // Threshold-only Native formatting notice: post-stop, the raw transcript is already
     // saved+shown; punctuation/casing is polished in the background. We surface a notice
@@ -165,6 +172,16 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             traceWindow.__SS_TRANSCRIPT_TRACE__.shift();
         }
     }, [visibleTranscript]);
+
+    React.useEffect(() => {
+        const node = transcriptContainerRef.current;
+        if (!node) return;
+        if (uiState === 'final') {
+            node.scrollTop = 0;
+            return;
+        }
+        node.scrollTop = node.scrollHeight;
+    }, [visibleTranscript, history.length, uiState]);
 
     // #33 Native trust-disclaimer proof hooks: publish a timestamped trust-state
     // snapshot (+ append-only trace) so the harness can prove WHEN each trust state
@@ -229,10 +246,11 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                 )}
             </div>
             <div
-                ref={containerRef}
-                className={`live-transcript-scroll flex-1 overflow-y-auto p-3 pr-5 ${SESSION_INSET_SURFACE_CLASS} leading-relaxed transition-all min-h-[160px]`}
+                ref={transcriptContainerRef}
+                className={`live-transcript-scroll ${transcriptViewportClass} overflow-y-auto p-3 pr-5 ${SESSION_INSET_SURFACE_CLASS} leading-relaxed transition-all`}
                 data-testid={TEST_IDS.TRANSCRIPT_CONTAINER}
                 data-scrollable-transcript="true"
+                data-autoscroll-transcript={shouldAutoscrollTranscript ? 'true' : 'false'}
                 data-transcript-state={uiState}
                 aria-live="polite"
                 aria-label="Live transcript of your speech"

--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -181,7 +181,7 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             return;
         }
         node.scrollTop = node.scrollHeight;
-    }, [visibleTranscript, history.length, uiState]);
+    }, [visibleTranscript, history.length, uiState, transcriptContainerRef]);
 
     // #33 Native trust-disclaimer proof hooks: publish a timestamped trust-state
     // snapshot (+ append-only trace) so the harness can prove WHEN each trust state

--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -180,8 +180,9 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             node.scrollTop = 0;
             return;
         }
+        if (containerRef) return;
         node.scrollTop = node.scrollHeight;
-    }, [visibleTranscript, history.length, uiState, transcriptContainerRef]);
+    }, [visibleTranscript, history.length, uiState, transcriptContainerRef, containerRef]);
 
     // #33 Native trust-disclaimer proof hooks: publish a timestamped trust-state
     // snapshot (+ append-only trace) so the harness can prove WHEN each trust state

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -211,6 +211,37 @@ describe('LiveTranscriptPanel', () => {
         expect(transcriptContainer.scrollTop).toBe(1200);
     });
 
+    it('does not override parent-managed scroll position when an external container ref is supplied', async () => {
+        const containerRef = React.createRef<HTMLDivElement>();
+        const { rerender } = render(
+            <LiveTranscriptPanel
+                transcript="first sentence"
+                interimTranscript=""
+                isListening={true}
+                containerRef={containerRef}
+            />
+        );
+
+        const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+        Object.defineProperty(transcriptContainer, 'scrollHeight', {
+            configurable: true,
+            value: 1200,
+        });
+        transcriptContainer.scrollTop = 240;
+
+        rerender(
+            <LiveTranscriptPanel
+                transcript={Array.from({ length: 80 }, (_, index) => `sentence ${index + 1}`).join(' ')}
+                interimTranscript="latest words"
+                isListening={true}
+                containerRef={containerRef}
+            />
+        );
+
+        await act(async () => {});
+        expect(transcriptContainer.scrollTop).toBe(240);
+    });
+
     it('shows Private-only processing feedback before transcript text arrives', () => {
         render(
             <LiveTranscriptPanel

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -137,6 +137,78 @@ describe('LiveTranscriptPanel', () => {
         expect(transcriptContainer).toHaveAttribute('data-scrollable-transcript', 'true');
         expect(transcriptContainer).toHaveClass('overflow-y-auto');
         expect(transcriptContainer).toHaveClass('live-transcript-scroll');
+        expect(transcriptContainer).toHaveClass('flex-1');
+        expect(transcriptContainer).toHaveClass('min-h-[160px]');
+    });
+
+    it('returns the finalized transcript to the top and releases the fixed live viewport height', async () => {
+        const { rerender } = render(
+            <LiveTranscriptPanel
+                transcript="live words are still growing"
+                interimTranscript="latest draft words"
+                isListening={true}
+                sttMode="private"
+            />
+        );
+
+        const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+        Object.defineProperty(transcriptContainer, 'scrollHeight', {
+            configurable: true,
+            value: 1200,
+        });
+        transcriptContainer.scrollTop = 900;
+
+        rerender(
+            <LiveTranscriptPanel
+                transcript="final transcript starts at the beginning"
+                interimTranscript=""
+                isListening={false}
+                isFinalizing={false}
+                sttMode="private"
+            />
+        );
+
+        await act(async () => {});
+        expect(transcriptContainer).toHaveAttribute('data-transcript-state', 'final');
+        expect(transcriptContainer).toHaveAttribute('data-autoscroll-transcript', 'false');
+        expect(transcriptContainer.scrollTop).toBe(0);
+        expect(transcriptContainer).toHaveClass('max-h-[18rem]');
+        expect(transcriptContainer).toHaveClass('sm:max-h-[20rem]');
+        expect(transcriptContainer).toHaveClass('lg:max-h-[22rem]');
+        expect(transcriptContainer).not.toHaveClass('flex-1');
+        expect(transcriptContainer).not.toHaveClass('min-h-[160px]');
+    });
+
+    it('keeps new transcript text pinned inside the fixed scroll region', async () => {
+        const { rerender } = render(
+            <LiveTranscriptPanel
+                transcript="first sentence"
+                interimTranscript=""
+                isListening={true}
+            />
+        );
+
+        const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+        Object.defineProperty(transcriptContainer, 'scrollHeight', {
+            configurable: true,
+            value: 1200,
+        });
+        Object.defineProperty(transcriptContainer, 'clientHeight', {
+            configurable: true,
+            value: 320,
+        });
+        transcriptContainer.scrollTop = 0;
+
+        rerender(
+            <LiveTranscriptPanel
+                transcript={Array.from({ length: 80 }, (_, index) => `sentence ${index + 1}`).join(' ')}
+                interimTranscript="latest words"
+                isListening={true}
+            />
+        );
+
+        await act(async () => {});
+        expect(transcriptContainer.scrollTop).toBe(1200);
     });
 
     it('shows Private-only processing feedback before transcript text arrives', () => {
@@ -594,6 +666,23 @@ describe('LiveTranscriptPanel', () => {
             );
             expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
             expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveTextContent('hello world this is going fine');
+        });
+
+        it('does not let stale looped interim text hide the clean final transcript', () => {
+            render(
+                <LiveTranscriptPanel
+                    transcript="This is the clean final transcript after local processing finishes."
+                    interimTranscript={REAL_LOOP}
+                    isListening={false}
+                    isFinalizing={false}
+                    sttMode="private"
+                />
+            );
+            const container = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+            expect(container).toHaveAttribute('data-transcript-state', 'final');
+            expect(screen.queryByTestId('live-transcript-loop-withheld')).not.toBeInTheDocument();
+            expect(container).toHaveTextContent('This is the clean final transcript');
+            expect(container).not.toHaveTextContent(/processing speech locally/i);
         });
 
         it('does NOT withhold in native (non-private) mode even with a looped transcript', () => {

--- a/scripts/manual-stt-corpus-proof.mjs
+++ b/scripts/manual-stt-corpus-proof.mjs
@@ -325,6 +325,8 @@ async function loadFixtures() {
 async function signIn(page) {
   if (AUTH_MODE === 'fresh') {
     await page.goto(`${BASE_URL}/auth/signup`, { waitUntil: 'domcontentloaded' });
+    await waitForAuthFormReady(page, 'sign-up-submit');
+    await assertVisualStylePreflight(page, 'auth_signup_pre_login');
     await page.getByTestId('email-input').fill(SIGNUP_EMAIL);
     await page.getByTestId('password-input').fill(SIGNUP_PASSWORD);
     await Promise.all([
@@ -345,6 +347,8 @@ async function signIn(page) {
   }
 
   await page.goto(`${BASE_URL}/auth/signin`, { waitUntil: 'domcontentloaded' });
+  await waitForAuthFormReady(page, 'sign-in-submit');
+  await assertVisualStylePreflight(page, 'auth_signin_pre_login');
   await page.getByTestId('email-input').fill(EMAIL);
   await page.getByTestId('password-input').fill(PASSWORD);
   await Promise.all([
@@ -352,6 +356,76 @@ async function signIn(page) {
     page.getByTestId('sign-in-submit').click(),
   ]);
   await page.waitForURL(/\/session/, { timeout: 60_000 });
+}
+
+async function waitForAuthFormReady(page, submitTestId) {
+  await page.locator('html[data-app-visible-ready="true"]').waitFor({ timeout: 60_000 }).catch(() => undefined);
+  await page.getByTestId(submitTestId).waitFor({ state: 'visible', timeout: 60_000 });
+}
+
+async function collectVisualStyleProof(page, label) {
+  return page.evaluate((proofLabel) => {
+    const button =
+      document.querySelector('[data-testid="session-start-stop-button"]') ||
+      document.querySelector('[data-testid="sign-in-submit"]') ||
+      document.querySelector('[data-testid="sign-up-submit"]') ||
+      document.querySelector('button');
+    const root = document.getElementById('root');
+    const buttonStyle = button ? getComputedStyle(button) : null;
+    const rootRect = root?.getBoundingClientRect();
+    const buttonRect = button?.getBoundingClientRect();
+    const buttonClass = typeof button?.className === 'string' ? button.className : '';
+    const hasExpectedUtilityClasses = /inline-flex/.test(buttonClass)
+      && /rounded/.test(buttonClass)
+      && (/(^|\s)(bg-primary|bg-destructive|bg-secondary)(\s|$)/.test(buttonClass) || /bg-primary/.test(buttonClass));
+    const display = buttonStyle?.display ?? null;
+    const borderRadiusPx = buttonStyle ? Number.parseFloat(buttonStyle.borderRadius || '0') : 0;
+    const paddingLeftPx = buttonStyle ? Number.parseFloat(buttonStyle.paddingLeft || '0') : 0;
+    const widthPx = buttonRect?.width ?? 0;
+    const heightPx = buttonRect?.height ?? 0;
+    const rootLeftPx = rootRect?.left ?? null;
+    const appliedUtilityStyles = Boolean(
+      button &&
+      (display === 'flex' || display === 'inline-flex') &&
+      borderRadiusPx >= 8 &&
+      (paddingLeftPx >= 8 || (widthPx >= 36 && heightPx >= 36)) &&
+      heightPx >= 36
+    );
+    const ok = Boolean(hasExpectedUtilityClasses && appliedUtilityStyles);
+
+    return {
+      label: proofLabel,
+      ok,
+      reason: ok ? null : 'tailwind_utility_styles_not_applied',
+      hasButton: Boolean(button),
+      hasExpectedUtilityClasses,
+      appliedUtilityStyles,
+      display,
+      borderRadiusPx,
+      paddingLeftPx,
+      widthPx,
+      heightPx,
+      rootLeftPx,
+      buttonText: button?.textContent?.replace(/\s+/g, ' ').trim().slice(0, 80) ?? null,
+      buttonClassSample: buttonClass.slice(0, 240),
+      bodyClass: document.body?.className ?? '',
+      rootTextSample: root?.textContent?.replace(/\s+/g, ' ').trim().slice(0, 240) ?? '',
+    };
+  }, label);
+}
+
+async function assertVisualStylePreflight(page, label) {
+  const proof = await collectVisualStyleProof(page, label);
+  evidence.visualStyleProofs ??= [];
+  evidence.visualStyleProofs.push(proof);
+  if (!proof.ok) {
+    const error = new Error(`VISUAL_STYLE_PREFLIGHT_FAILED ${label}: ${proof.reason}`);
+    error.invalidForSttEvidence = true;
+    error.invalidReason = proof.reason;
+    error.preflight = proof;
+    throw error;
+  }
+  return proof;
 }
 
 async function clearPrivateModelStorage(page) {
@@ -1244,6 +1318,8 @@ async function runFixture(page, mode, fixture) {
   await page.locator('html[data-app-visible-ready="true"]').waitFor({ timeout: 60_000 });
   await assertModePreflight(page, mode);
   await selectMode(page, mode);
+  await page.getByTestId('session-start-stop-button').waitFor({ state: 'visible', timeout: 60_000 });
+  await assertVisualStylePreflight(page, 'session_ready_pre_recording');
 
   await page.evaluate(() => {
     window.__STT_CORPUS_PHASES__ = [];


### PR DESCRIPTION
## Summary

Small follow-up from the stacked STT A/B proof and release-owner UI feedback.

- Reset the transcript scroll position to the top when the final transcript replaces the live draft.
- Release the fixed live-processing transcript height in the final state so a long live draft does not leave empty whitespace after final text renders.
- Keep the severe-loop withhold guard limited to active listening/finalizing, so stale looped interim text cannot hide the clean final transcript after processing is complete.
- Preserve `SessionPage`'s parent-managed guarded live autoscroll/manual-scroll behavior when it supplies the transcript container ref.
- Harden `manual-stt-corpus-proof.mjs` visual preflight so it waits for auth/session readiness and selects the intended auth/session button instead of a generic page button.

## Verification

- `pnpm exec vitest run frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx --config frontend/vitest.config.mjs --coverage=false` → 45/45 pass
- focused eslint on touched files → pass
- `pnpm exec tsc --noEmit --project frontend/tsconfig.json` → pass
- `node --check scripts/manual-stt-corpus-proof.mjs` → pass
- `git diff --check` → pass

## Review Follow-Up

- Addressed the P2 scroll review: live bottom-pinning now only runs when the panel owns its internal fallback ref; external refs are left to the parent guarded autoscroll path. Review thread resolved.

## Notes

This is not required to prove `POSTHOG-STT-A/B`; that task already passed on the stacked #754 + #755 candidate. This PR carries the polish/harness follow-up that was included in Test's proof workspace and requested for final UX quality.