### PR TITLE
feat(stt-v4): wire decode_complete + session_saved Stage-B telemetry (#84)

### DIFF
--- a/frontend/src/services/SpeechRuntimeController.ts
+++ b/frontend/src/services/SpeechRuntimeController.ts
@@ -1,5 +1,6 @@
 import logger from '@/lib/logger';
 import { syncSTTReady, syncSTTIdentity, syncForensicAnchors as syncRuntimeState, syncEngineReady, syncSessionPersisted, syncNegotiatorDecision, syncProfileReady } from '@/lib/forensicAnchors';
+import { emitV4SessionSaved } from '@/services/transcription/privateV4Telemetry';
 import { safeLocalStorageGet, safeLocalStorageSet } from '@/lib/safeStorage';
 import TranscriptionService, { getTranscriptionService } from '@/services/transcription/TranscriptionService';
 import type { TranscriptionPolicy } from '@/services/transcription/TranscriptionPolicy';
@@ -749,13 +750,18 @@ export class SpeechRuntimeController {
 
     private updateSessionPersisted(
         persisted: boolean,
-        details?: { sessionId?: string | null; mode?: string | null },
+        details?: { sessionId?: string | null; mode?: string | null; engineType?: string | null },
     ): void {
         useSessionStore.getState().setSessionSaved(persisted);
         if (useSessionStore.getState().sessionSaved !== persisted) {
             useSessionStore.setState({ sessionSaved: persisted });
         }
         syncSessionPersisted(persisted, details);
+        // Stage-B v4 telemetry: one session_saved per save, only for a v4 private session. Non-PII
+        // allowlist (engine/saved/journey flags only); never throws into the save path.
+        if (persisted && details?.engineType === 'transformers-js-v4') {
+            emitV4SessionSaved({ engine: 'transformers-js-v4', saved: true, recordStarted: true, stopSucceeded: true });
+        }
     }
 
     /**
@@ -1761,7 +1767,7 @@ export class SpeechRuntimeController {
                 // Identity-bearing persisted-session marker (blocker #5): captured on
                 // successful completion so the post-READY persistence write can carry
                 // the exact session id + mode for proofs (data-session-persisted-id).
-                let persistedSessionMarker: { sessionId: string; mode: string | null } | null = null;
+                let persistedSessionMarker: { sessionId: string; mode: string | null; engineType?: string | null } | null = null;
                 logger.info({ wasRecording, state: this.state, sessionId: this.sessionId }, '[DEBUG-STOP] state-check');
                 if (wasRecording) {
                     let sessionId = this.sessionId;
@@ -2136,7 +2142,12 @@ export class SpeechRuntimeController {
                             logger.info({ sessionId }, '[DEBUG-STOP] completeSession completed-status done');
                             sessionCompleted = true;
                             persistedSessionMarker = sessionId
-                                ? { sessionId, mode: modeForFinalization ?? stopEntryMode }
+                                ? {
+                                    sessionId,
+                                    mode: modeForFinalization ?? stopEntryMode,
+                                    // v4-gate for session_saved telemetry — undefined for non-private/v2 strategies.
+                                    engineType: (service.getStrategy?.() as { getEngineType?: () => string } | undefined)?.getEngineType?.() ?? null,
+                                }
                                 : null;
                             this.updateSessionPersisted(true, persistedSessionMarker ?? undefined);
                             useSessionStore.getState().setSessionSaved(true);

--- a/frontend/src/services/SpeechRuntimeController.ts
+++ b/frontend/src/services/SpeechRuntimeController.ts
@@ -748,6 +748,11 @@ export class SpeechRuntimeController {
         return this.state;
     }
 
+    // Dedupe key so the v4 session_saved telemetry fires EXACTLY ONCE per saved session:
+    // updateSessionPersisted(true, …) is invoked at multiple successful-stop checkpoints for a single
+    // save, so we key on the persisted sessionId.
+    private lastV4SessionSavedId: string | null = null;
+
     private updateSessionPersisted(
         persisted: boolean,
         details?: { sessionId?: string | null; mode?: string | null; engineType?: string | null },
@@ -757,9 +762,16 @@ export class SpeechRuntimeController {
             useSessionStore.setState({ sessionSaved: persisted });
         }
         syncSessionPersisted(persisted, details);
-        // Stage-B v4 telemetry: one session_saved per save, only for a v4 private session. Non-PII
-        // allowlist (engine/saved/journey flags only); never throws into the save path.
-        if (persisted && details?.engineType === 'transformers-js-v4') {
+        // Stage-B v4 telemetry: EXACTLY ONE session_saved per saved v4 session. updateSessionPersisted(true)
+        // fires at multiple successful-stop checkpoints for one save, so dedupe by sessionId. v4-only;
+        // non-PII allowlist (engine/saved/journey flags only); never throws into the save path.
+        if (
+            persisted &&
+            details?.engineType === 'transformers-js-v4' &&
+            details.sessionId &&
+            details.sessionId !== this.lastV4SessionSavedId
+        ) {
+            this.lastV4SessionSavedId = details.sessionId;
             emitV4SessionSaved({ engine: 'transformers-js-v4', saved: true, recordStarted: true, stopSucceeded: true });
         }
     }

--- a/frontend/src/services/__tests__/SpeechRuntimeController.v4telemetry.test.ts
+++ b/frontend/src/services/__tests__/SpeechRuntimeController.v4telemetry.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Spy on the v4 telemetry emitter (the unit under regression).
+vi.mock('@/services/transcription/privateV4Telemetry', () => ({
+    emitV4SessionSaved: vi.fn(),
+}));
+// Minimal deps so the controller singleton constructs without side effects.
+vi.mock('../../lib/logger', () => ({
+    default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../lib/sessionRepository', () => ({
+    saveSession: vi.fn().mockResolvedValue({ session: { id: 'test-sess' }, usageExceeded: false }),
+    heartbeatSession: vi.fn().mockResolvedValue({ success: true }),
+    completeSession: vi.fn().mockResolvedValue({ success: true }),
+    updateSession: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('../../lib/supabaseClient', () => ({
+    getSupabaseClient: vi.fn(() => ({
+        auth: { getSession: vi.fn().mockResolvedValue({ data: { session: { user: { id: 'u' } } } }) },
+    })),
+}));
+
+import { SpeechRuntimeController } from '../SpeechRuntimeController';
+import { emitV4SessionSaved } from '@/services/transcription/privateV4Telemetry';
+
+type PersistDetails = { sessionId?: string | null; mode?: string | null; engineType?: string | null };
+type PersistableController = {
+    updateSessionPersisted: (persisted: boolean, details?: PersistDetails) => void;
+    lastV4SessionSavedId: string | null;
+};
+
+/**
+ * PR #763 regression: private_stt_v4_session_saved must fire EXACTLY ONCE per saved v4 session.
+ * updateSessionPersisted(true, …) is invoked at three successful-stop checkpoints for one save, so a
+ * naive emit fired up to 3x. The fix dedupes by sessionId.
+ */
+describe('SpeechRuntimeController — v4 session_saved telemetry idempotence (PR #763)', () => {
+    let controller: PersistableController;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        controller = SpeechRuntimeController.getInstance() as unknown as PersistableController;
+        controller.lastV4SessionSavedId = null; // reset singleton dedupe state between tests
+    });
+
+    it('emits session_saved exactly ONCE for one v4 save across 3 persist checkpoints', () => {
+        const v4 = { engineType: 'transformers-js-v4', sessionId: 'sess-1', mode: 'private' };
+        controller.updateSessionPersisted(true, v4);
+        controller.updateSessionPersisted(true, v4);
+        controller.updateSessionPersisted(true, v4);
+        expect(emitV4SessionSaved).toHaveBeenCalledTimes(1);
+        expect(emitV4SessionSaved).toHaveBeenCalledWith(
+            expect.objectContaining({ engine: 'transformers-js-v4', saved: true }),
+        );
+    });
+
+    it('emits again for a DIFFERENT saved v4 session', () => {
+        controller.updateSessionPersisted(true, { engineType: 'transformers-js-v4', sessionId: 'sess-1' });
+        controller.updateSessionPersisted(true, { engineType: 'transformers-js-v4', sessionId: 'sess-2' });
+        expect(emitV4SessionSaved).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a NO-OP for v2 / native / cloud saves', () => {
+        controller.updateSessionPersisted(true, { engineType: 'transformers-js', sessionId: 'sess-1' });
+        controller.updateSessionPersisted(true, { sessionId: 'sess-2', mode: 'native' });
+        controller.updateSessionPersisted(true, { engineType: 'cloud', sessionId: 'sess-3' });
+        expect(emitV4SessionSaved).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit on un-persist (persisted=false)', () => {
+        controller.updateSessionPersisted(false, { engineType: 'transformers-js-v4', sessionId: 'sess-1' });
+        expect(emitV4SessionSaved).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -45,6 +45,7 @@ import { TranscriptUpdate, SttStatus } from '../../../types/transcription';
 import { ENV } from '../../../config/TestFlags';
 import { PauseDetector } from '../../audio/pauseDetector';
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_DERIVED, SESSION_PAUSE, samplesToSeconds, secondsToSamples } from '../sttConstants';
+import { emitV4DecodeComplete, buildV4LifecycleProps } from '../privateV4Telemetry';
 
 // Extend Window interface for E2E test flags
 declare global {
@@ -2334,6 +2335,18 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
         if (result.isOk) captured.transcript = rawText;
         else captured.error = result.error?.message;
       }
+    }
+
+    // Stage-B v4 telemetry: exactly one decode_complete per session on the whole-utterance final
+    // decode (authoritative decodeMs/rtf), NOT per rolling decode. v4-gated, non-PII allowlisted,
+    // never throws — telemetry must not affect the transcription path.
+    if (result.isOk && this.privateSTT.getEngineType() === 'transformers-js-v4') {
+      const audioDurationMs = samplesToSeconds(audio.length, PRIVATE_STT_SAMPLE_RATE) * 1000;
+      emitV4DecodeComplete(buildV4LifecycleProps({
+        finalEngine: 'transformers-js-v4',
+        decodeMs,
+        rtf: audioDurationMs > 0 ? Number((decodeMs / audioDurationMs).toFixed(4)) : null,
+      }));
     }
 
     if (!result.isOk) {


### PR DESCRIPTION
Closes **#84** (v4 rollout telemetry, Stage B). The telemetry module, non-PII allowlist, and the engine-init lifecycle (`ready`/`fallback`/`error`) were already built/wired; this adds the **two remaining emitters** with conservative placement.

- **decode_complete** (`PrivateWhisper`): exactly **one** emit per session on the **whole-utterance final** decode (authoritative `decodeMs` + derived `rtf`), **not** per rolling decode — avoids telemetry noise / hot-path overhead. v4-gated via `this.privateSTT.getEngineType()`.
- **session_saved** (`SpeechRuntimeController`): emitted from the single persist convergence point `updateSessionPersisted()` when `persisted===true` AND the active strategy is v4. Engine type is attached **once** to `persistedSessionMarker` (`service.getStrategy().getEngineType()`), so all three save-success call sites propagate it.

**Safety:** both v4-gated, non-PII (allowlist drops everything but `engine`/`decodeMs`/`rtf`/`saved`/journey flags), and **never throw** into the transcription/save path. Inert for v2/Native/Cloud.

**Verification:** tsc clean · PrivateWhisper + SpeechRuntimeController + statetruth + privateV4Telemetry suites **93/93** (no regression) · eslint clean. The emitter/allowlist module is independently unit-tested; the added wiring is trivial gated, non-throwing calls (type-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)