### PR TITLE
db: index trial entitlements user lookup

### DIFF
--- a/backend/supabase/migrations/20260612205224_add_trial_entitlements_user_id_index.sql
+++ b/backend/supabase/migrations/20260612205224_add_trial_entitlements_user_id_index.sql
@@ -1,0 +1,8 @@
+-- Add a targeted index for release/audit lookup paths that join or repair
+-- trial entitlements by auth user id. The table remains email-keyed for the
+-- historical one-trial-per-email contract, so keep this as a partial helper
+-- index instead of changing the primary key.
+
+CREATE INDEX IF NOT EXISTS trial_entitlements_user_id_idx
+  ON public.trial_entitlements (user_id)
+  WHERE user_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds a partial `trial_entitlements(user_id)` index for non-null user ids.
- Keeps the historical email primary key / one-trial-per-email contract unchanged.
- Addresses the independent review low-risk DB indexing finding without touching product behavior.

## Validation
- Migration-only PR; awaiting CI / Supabase migration checks.

diff scope: one migration file.