### PR TITLE
fix(entitlement): align Pro tier config + copy to DB enforcement (#1)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -842,7 +842,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                     testId={TEST_IDS.ANALYTICS_EMPTY_STATE}
                     // Subtle upgrade option for Free users — only when payments are live (no dead button)
                     secondaryAction={!isProUser && arePaymentsEnabled() ? {
-                        prefix: "Want unlimited sessions?",
+                        prefix: "Need more recording time?",
                         label: "Upgrade to Pro",
                         onClick: onUpgrade,
                         testId: TEST_IDS.ANALYTICS_UPGRADE_BUTTON

--- a/frontend/src/constants/__tests__/subscriptionTiers.test.ts
+++ b/frontend/src/constants/__tests__/subscriptionTiers.test.ts
@@ -183,7 +183,8 @@ describe('subscriptionTiers', () => {
 
         it('Limits have Infinity where appropriate', () => {
             const proLimits = TIER_LIMITS[SUBSCRIPTION_TIERS.PRO];
-            expect(proLimits.dailySeconds).toBe(Infinity);
+            // Pro daily usage is NOT unlimited: it is capped, matching the DB enforcement source.
+            expect(proLimits.dailySeconds).toBe(7200);
             expect(proLimits.maxSessionDuration).toBe(Infinity);
 
             const basicLimits = TIER_LIMITS[SUBSCRIPTION_TIERS.BASIC];
@@ -195,7 +196,7 @@ describe('subscriptionTiers', () => {
         it('getDailyLimit returns correct values', () => {
             expect(getDailyLimit('free')).toBe(3600);
             expect(getDailyLimit('basic')).toBe(3600);
-            expect(getDailyLimit('pro')).toBe(Infinity);
+            expect(getDailyLimit('pro')).toBe(7200);
         });
 
         it('getMaxFillerWords returns 100 for all active tiers', () => {
@@ -223,7 +224,21 @@ describe('subscriptionTiers', () => {
         it('PRO tier has correct alpha launch limits', () => {
             const proLimits = TIER_LIMITS[SUBSCRIPTION_TIERS.PRO];
             expect(proLimits.maxCustomWords).toBe(100);
-            expect(proLimits.dailySeconds).toBe(Infinity);
+            expect(proLimits.dailySeconds).toBe(7200);
+        });
+    });
+
+    // Entitlement consistency guard: the front-end tier-limit config MUST match the effective
+    // DB enforcement source (backend tier_configs). These caps are the release-of-record values;
+    // Pro is NOT unlimited. If the DB tier_configs change, update these AND the constant together.
+    describe('config matches DB tier_configs (no stale "unlimited" drift)', () => {
+        it('FREE/BASIC daily = 3600s, PRO daily = 7200s (finite, not unlimited)', () => {
+            expect(TIER_LIMITS[SUBSCRIPTION_TIERS.FREE].dailySeconds).toBe(3600);
+            expect(TIER_LIMITS[SUBSCRIPTION_TIERS.BASIC].dailySeconds).toBe(3600);
+            expect(TIER_LIMITS[SUBSCRIPTION_TIERS.PRO].dailySeconds).toBe(7200);
+        });
+        it('PRO daily limit is a finite number (never Infinity for this release)', () => {
+            expect(Number.isFinite(TIER_LIMITS[SUBSCRIPTION_TIERS.PRO].dailySeconds)).toBe(true);
         });
     });
 });

--- a/frontend/src/constants/subscriptionTiers.ts
+++ b/frontend/src/constants/subscriptionTiers.ts
@@ -108,9 +108,12 @@ export const TIER_LIMITS = {
         maxSessionDuration: Infinity, // No session-level cap, only daily
     },
     [SUBSCRIPTION_TIERS.PRO]: {
-        dailySeconds: Infinity,
+        // 2h/day — MUST match the effective enforcement source: DB tier_configs 'pro'
+        // (daily_limit_seconds = 7200, monthly 180000). Pro is NOT unlimited for this release;
+        // raising it is a deliberate Product/pricing decision, not a stale-config drift.
+        dailySeconds: 7200,
         maxCustomWords: 100,
-        maxSessionDuration: Infinity,
+        maxSessionDuration: Infinity, // No session-level cap, only daily
     },
 } as const;
 


### PR DESCRIPTION
Implements the release-owner call on the #1 finding: **Pro = 2h/day, 50h/month for this release; DB `tier_configs` is the source of truth; do not raise the DB to unlimited** (separate Product/pricing decision). Removes the stale "unlimited" claims that contradicted the deployed cap.

- `subscriptionTiers.ts`: Pro `dailySeconds` `Infinity` → **7200** (matches DB `tier_configs` `pro`). The constant has **no app consumers** (live usage reads the DB via `useUsageLimit`), so this is a **zero-behavior-change** correctness fix.
- `AnalyticsDashboard` upsell: **"Want unlimited sessions?" → "Need more recording time?"** (truthful).
- `subscriptionTiers.test.ts`: updated stale `Infinity` assertions → `7200` and added an **entitlement-consistency guard** (FREE/BASIC=3600, PRO=7200 finite, never Infinity) so config cant drift back to a false "unlimited" claim.

UI still reads effective limits from the DB/`check_usage_limit` (verified, unchanged). **33/33** tier tests; tsc + eslint clean.

Companion to the #1 evidence doc (#768). Raising Pro to true unlimited remains a post-release Product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)