### PR TITLE
fix(session): surface recovery draft actions (#6)

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -73,6 +73,7 @@ export const SessionPage: React.FC = () => {
     } = useSessionLifecycle();
 
     const restoreRecoveryDraft = useCallback((draft: SessionRecoveryDraft) => {
+        clearSessionRecoveryDraft(draft.sessionId);
         updateRecoveredTranscript(draft.transcript, '');
         setRecoveredChunks([{
             transcript: draft.transcript,

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Settings } from 'lucide-react';
 import { Link } from 'react-router-dom';
 // ... existing imports ...
@@ -21,7 +21,7 @@ import {
     getSessionCoachingAssignment,
 } from '@/services/sessionCoachingExperiment';
 import { useUsageLimit } from '@/hooks/useUsageLimit';
-import { getSessionRecoveryDraft } from '@/services/sessionRecoveryDraft';
+import { clearSessionRecoveryDraft, getSessionRecoveryDraft, type SessionRecoveryDraft } from '@/services/sessionRecoveryDraft';
 import { useSessionStore } from '@/stores/useSessionStore';
 
 /**
@@ -32,6 +32,7 @@ import { useSessionStore } from '@/stores/useSessionStore';
  */
 export const SessionPage: React.FC = () => {
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+    const [recoveryDraft, setRecoveryDraft] = useState<SessionRecoveryDraft | null>(null);
     const { runtimeState } = useTranscriptionContext();
     const transcriptContainerRef = useRef<HTMLDivElement>(null);
     const previousTranscriptScrollHeightRef = useRef(0);
@@ -71,11 +72,7 @@ export const SessionPage: React.FC = () => {
         history
     } = useSessionLifecycle();
 
-    useEffect(() => {
-        if (isListening || transcriptContent.trim()) return;
-        const draft = getSessionRecoveryDraft();
-        if (!draft) return;
-
+    const restoreRecoveryDraft = useCallback((draft: SessionRecoveryDraft) => {
         updateRecoveredTranscript(draft.transcript, '');
         setRecoveredChunks([{
             transcript: draft.transcript,
@@ -87,7 +84,20 @@ export const SessionPage: React.FC = () => {
             message: 'Recovered unsaved session draft.',
             detail: 'Your last transcript was kept on this device after a save issue.',
         });
-    }, [isListening, setRecoveredChunks, setRecoveredStatus, transcriptContent, updateRecoveredTranscript]);
+        setRecoveryDraft(null);
+    }, [setRecoveredChunks, setRecoveredStatus, updateRecoveredTranscript]);
+
+    useEffect(() => {
+        if (isListening) {
+            setRecoveryDraft(null);
+            return;
+        }
+        const draft = getSessionRecoveryDraft();
+        setRecoveryDraft(draft);
+        if (!draft || transcriptContent.trim()) return;
+
+        restoreRecoveryDraft(draft);
+    }, [isListening, restoreRecoveryDraft, transcriptContent]);
 
     // Keep live transcript pinned only while the user is already reading the latest text.
     useEffect(() => {
@@ -186,6 +196,39 @@ export const SessionPage: React.FC = () => {
             {/* Status Bar - Spans full width of the main content area */}
             <div className="max-w-7xl mx-auto px-4 sm:px-6 mb-0">
                 <StatusNotificationBar status={displayStatus} />
+                {recoveryDraft && !isListening && (
+                    <div
+                        className="mt-3 flex flex-col gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between"
+                        data-testid="session-recovery-actions"
+                    >
+                        <span className="font-medium text-foreground/80">
+                            An unsaved transcript draft is available from this browser.
+                        </span>
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => restoreRecoveryDraft(recoveryDraft)}
+                                data-testid="session-recovery-restore"
+                            >
+                                Restore draft
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => {
+                                    clearSessionRecoveryDraft(recoveryDraft.sessionId);
+                                    setRecoveryDraft(null);
+                                }}
+                                data-testid="session-recovery-dismiss"
+                            >
+                                Dismiss
+                            </Button>
+                        </div>
+                    </div>
+                )}
                 {showAnalyticsPrompt && (
                     <div
                         className="mt-3 flex flex-col gap-2 rounded-md border border-border bg-card p-3 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between"

--- a/frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx
+++ b/frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx
@@ -43,6 +43,11 @@ vi.mock('@/hooks/useUserFillerWords', () => ({
     useUserFillerWords: () => ({ userFillerWords: [] }),
 }));
 
+vi.mock('@/services/sessionRecoveryDraft', () => ({
+    getSessionRecoveryDraft: vi.fn(),
+    clearSessionRecoveryDraft: vi.fn(),
+}));
+
 // Mock child components to verify props passed to them
 vi.mock('@/components/session/StatusNotificationBar', () => ({
     StatusNotificationBar: ({ status }: { status: { message?: string, type?: string } }) => (
@@ -71,6 +76,7 @@ vi.mock('@/components/LocalErrorBoundary', () => ({
 
 // Import hook for mocking responses
 import { useSessionLifecycle } from '@/hooks/useSessionLifecycle';
+import { clearSessionRecoveryDraft, getSessionRecoveryDraft } from '@/services/sessionRecoveryDraft';
 
 describe('SessionPage Feedback Logic', () => {
     const defaultMock = {
@@ -105,6 +111,7 @@ describe('SessionPage Feedback Logic', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(getSessionRecoveryDraft).mockReturnValue(null);
         vi.mocked(useSessionLifecycle).mockReturnValue(defaultMock as unknown as ReturnType<typeof useSessionLifecycle>);
     });
 
@@ -156,6 +163,54 @@ describe('SessionPage Feedback Logic', () => {
         expect(privateCta).toHaveTextContent(/Private/i);
         fireEvent.click(privateCta);
         expect(setMode).toHaveBeenCalledWith('private');
+    });
+
+    it('shows a same-page recovery action when an unsaved draft exists after a save issue', async () => {
+        vi.mocked(getSessionRecoveryDraft).mockReturnValue({
+            sessionId: 'draft-session',
+            transcript: 'Recovered words from a failed save',
+            durationSeconds: 42,
+            mode: 'private',
+            savedAt: new Date('2026-06-12T18:00:00Z').toISOString(),
+        });
+        vi.mocked(useSessionLifecycle).mockReturnValue({
+            ...defaultMock,
+            isListening: false,
+            transcriptContent: 'Visible transcript is still on screen after save failure',
+            sttStatus: {
+                type: 'warning',
+                message: 'Session was not saved yet.',
+                detail: 'A local recovery draft was kept in this browser after a save issue.',
+            },
+        } as unknown as ReturnType<typeof useSessionLifecycle>);
+
+        render(<SessionPage />);
+
+        expect(await screen.findByTestId('session-recovery-actions')).toHaveTextContent(/unsaved transcript draft/i);
+        expect(screen.getByTestId('session-recovery-restore')).toHaveTextContent(/Restore draft/i);
+        expect(screen.getByTestId('session-recovery-dismiss')).toHaveTextContent(/Dismiss/i);
+    });
+
+    it('dismisses only the available local recovery draft', async () => {
+        vi.mocked(getSessionRecoveryDraft).mockReturnValue({
+            sessionId: 'draft-session',
+            transcript: 'Recovered words from a failed save',
+            durationSeconds: 42,
+            mode: 'private',
+            savedAt: new Date('2026-06-12T18:00:00Z').toISOString(),
+        });
+        vi.mocked(useSessionLifecycle).mockReturnValue({
+            ...defaultMock,
+            isListening: false,
+            transcriptContent: 'Visible transcript is still on screen after save failure',
+        } as unknown as ReturnType<typeof useSessionLifecycle>);
+
+        render(<SessionPage />);
+
+        fireEvent.click(await screen.findByTestId('session-recovery-dismiss'));
+
+        expect(clearSessionRecoveryDraft).toHaveBeenCalledWith('draft-session');
+        expect(screen.queryByTestId('session-recovery-actions')).not.toBeInTheDocument();
     });
 
     it('should show listening state in status bar when hook indicates listening', async () => {

--- a/frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx
+++ b/frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx
@@ -191,6 +191,28 @@ describe('SessionPage Feedback Logic', () => {
         expect(screen.getByTestId('session-recovery-dismiss')).toHaveTextContent(/Dismiss/i);
     });
 
+    it('clears the restored local recovery draft so the action resolves', async () => {
+        vi.mocked(getSessionRecoveryDraft).mockReturnValue({
+            sessionId: 'draft-session',
+            transcript: 'Recovered words from a failed save',
+            durationSeconds: 42,
+            mode: 'private',
+            savedAt: new Date('2026-06-12T18:00:00Z').toISOString(),
+        });
+        vi.mocked(useSessionLifecycle).mockReturnValue({
+            ...defaultMock,
+            isListening: false,
+            transcriptContent: 'Visible transcript is still on screen after save failure',
+        } as unknown as ReturnType<typeof useSessionLifecycle>);
+
+        render(<SessionPage />);
+
+        fireEvent.click(await screen.findByTestId('session-recovery-restore'));
+
+        expect(clearSessionRecoveryDraft).toHaveBeenCalledWith('draft-session');
+        expect(screen.queryByTestId('session-recovery-actions')).not.toBeInTheDocument();
+    });
+
     it('dismisses only the available local recovery draft', async () => {
         vi.mocked(getSessionRecoveryDraft).mockReturnValue({
             sessionId: 'draft-session',


### PR DESCRIPTION
## Summary

Closes the visible UX gap in #6: when stop/save fails and the runtime keeps a local recovery draft, the session page now surfaces an explicit same-page recovery action instead of only relying on passive localStorage recovery.

## Behavior

- Detects an available local recovery draft when the user is not actively recording.
- Shows a compact warning action band above the session workflow.
- `Restore draft` hydrates the saved transcript/chunk/status immediately and clears that restored local draft by `sessionId` so the action resolves.
- `Dismiss` clears only that draft by `sessionId`.
- Existing auto-restore behavior for an empty transcript remains intact.

## Verification

Run from the rebased #771 worktree after the P2 review fix:

- `pnpm exec vitest run --config frontend/vitest.config.mjs frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx frontend/src/services/__tests__/sessionRecoveryDraft.test.ts frontend/src/services/__tests__/sessionRecoveryDraft.tabclose.test.ts frontend/src/services/__tests__/SpeechRuntimeController.test.ts --coverage.enabled=false --reporter=dot` → 4 files / 41 tests passed
- `pnpm exec eslint frontend/src/pages/SessionPage.tsx frontend/src/pages/__tests__/SessionPage.feedback.component.test.tsx` → passed
- `pnpm exec tsc --noEmit -p frontend/tsconfig.json` → passed
- GitHub CI run `27450871281` → 17/17 passed

## Release note

This is intentionally scoped to the core value proposition: if a user records and save fails, the transcript is visibly recoverable. It does not redesign the persistence layer or change the stop/save contract.