### PR TITLE
fix(stt): collapse repetition loops at the final stop-transcript boundary

### DIFF
--- a/frontend/src/services/transcription/TranscriptionService.ts
+++ b/frontend/src/services/transcription/TranscriptionService.ts
@@ -2,6 +2,7 @@ import { Session } from '@supabase/supabase-js';
 import { NavigateFunction } from 'react-router-dom';
 import { isEqual } from 'lodash-es';
 import { TranscriptionModeOptions, Transcript } from '@/services/transcription/modes/types';
+import { collapseTranscriptRepetitionLoops } from '@/utils/repetitionRisk';
 
 import { TranscriptionError } from './errors';
 import { STTStrategy } from './STTStrategy';
@@ -1112,6 +1113,12 @@ export default class TranscriptionService {
         transcript = visibleTranscript.length > strategyTranscript.length
           ? visibleTranscript
           : strategyTranscript || visibleTranscript;
+        // Final-result repetition guard (saved-transcript integrity). The length-preferring
+        // selection above can pick a streaming-accumulated `visibleTranscript` that bypassed
+        // the per-segment collapse, producing a near_whole_doubling in the saved transcript
+        // (service_result / selectedForSave). Collapse the authoritative final transcript here
+        // so the persisted value can never contain a whole-text/multi-word repetition loop.
+        transcript = collapseTranscriptRepetitionLoops(transcript);
         logger.info({
           sId: this.serviceId,
           rId: this.runId,

--- a/frontend/src/services/transcription/__tests__/TranscriptionService.pause.test.ts
+++ b/frontend/src/services/transcription/__tests__/TranscriptionService.pause.test.ts
@@ -4,6 +4,7 @@ import { STTStrategy } from '../STTStrategy';
 import { STTStrategyFactory } from '../STTStrategyFactory';
 import { Result } from '../modes/types';
 import { NavigateFunction } from 'react-router-dom';
+import { detectRepetitionRisk } from '@/utils/repetitionRisk';
 
 vi.mock('../STTStrategyFactory');
 vi.mock('../utils/audioUtils', () => ({
@@ -126,5 +127,23 @@ describe('TranscriptionService Pause/Resume', () => {
     await service.resumeTranscription();
     expect(service.getState()).toBe('RECORDING');
     expect(mockStrategy.resume).not.toHaveBeenCalled();
+  });
+
+  it('collapses a whole-text repetition loop in the final saved transcript (regression: near_whole_doubling)', async () => {
+    // Live Private-sample regression: the final stop transcript (service_result / selectedForSave)
+    // saved a 100% doubled transcript that the per-segment collapse missed. stopTranscription must
+    // collapse-guard the authoritative final transcript so the persisted value has no whole-text loop.
+    const doubled = 'We should literally like, wait, um, basically, we should literally like, wait, um, basically.';
+    expect(detectRepetitionRisk(doubled).repetitionRisk).toBe(true); // sanity: input IS doubled
+    vi.mocked(mockStrategy.getTranscript).mockResolvedValue(doubled);
+    await moveToRecording();
+
+    const result = await service.stopTranscription();
+    const out = result?.transcript ?? '';
+
+    expect(out).toBeTruthy(); // not the empty-catch path
+    expect(out.toLowerCase()).toContain('we should literally like'); // content preserved once
+    expect(detectRepetitionRisk(out).repetitionRisk).toBe(false); // no whole-text loop
+    expect(out.length).toBeLessThan(doubled.length); // collapsed
   });
 });

--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -33,6 +33,7 @@
 import logger from '../../../lib/logger';
 import { redactTranscript } from '../../../lib/logRedaction';
 import { sanitizeTranscriptText } from '../transcriptSanitizer';
+import { collapseTranscriptRepetitionLoops } from '../../../utils/repetitionRisk';
 import { createPrivateSTT, EngineType } from '../engines';
 import { IPrivateSTT } from '../../../contracts/IPrivateSTT';
 import type { PrivateSTTInitOptions } from '../../../contracts/IPrivateSTT';
@@ -351,62 +352,8 @@ function wordOverlapRatio(left: string, right: string): number {
   return overlap / rightWords.length;
 }
 
-/**
- * Collapse Whisper repetition loops in a DECODED transcript. Whisper can loop a
- * phrase/sentence many times on short or ambiguous audio (e.g. "we should wait we
- * should wait we should wait …"), inflating the saved transcript (verdict-A
- * duplication in `service_result`). This collapses an immediately-repeated
- * multi-word unit (>= 2 words repeated >= 3 times back-to-back), and an exact
- * verbatim whole-text doubling, down to a single instance.
- *
- * It is deliberately CONSERVATIVE so it can never alter a legitimate transcript
- * (the evidence layer): a 2+ word phrase repeated 3+ times in a row, or a verbatim
- * first-half doubling, are loop signatures natural speech does not produce. Single
- * words ("no no no") and 2x phrase repeats ("I think, I think") are left untouched.
- */
-export function collapseTranscriptRepetitionLoops(text: string): string {
-  const raw = (text || '').replace(/\s+/g, ' ').trim();
-  if (!raw) return raw;
-  const tokens = raw.split(' ');
-  const n = tokens.length;
-  if (n < 4) return raw;
-
-  const norm = tokens.map((t) => t.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''));
-  const seqEq = (a: number, b: number, k: number): boolean => {
-    for (let x = 0; x < k; x++) {
-      if (norm[a + x] !== norm[b + x]) return false;
-    }
-    return true;
-  };
-
-  // 1. Exact verbatim whole-text doubling (the first half repeated once).
-  if (n % 2 === 0 && n >= 8 && seqEq(0, n / 2, n / 2)) {
-    return tokens.slice(0, n / 2).join(' ');
-  }
-
-  // 2. Immediate multi-word loop: a k-word unit (2..40) repeated >= 3 times.
-  const out: string[] = [];
-  let i = 0;
-  while (i < n) {
-    let collapsed = false;
-    const maxK = Math.min(40, Math.floor((n - i) / 3));
-    for (let k = 2; k <= maxK; k++) {
-      let reps = 1;
-      while (i + (reps + 1) * k <= n && seqEq(i, i + reps * k, k)) reps++;
-      if (reps >= 3) {
-        for (let x = 0; x < k; x++) out.push(tokens[i + x]);
-        i += reps * k;
-        collapsed = true;
-        break;
-      }
-    }
-    if (!collapsed) {
-      out.push(tokens[i]);
-      i++;
-    }
-  }
-  return out.join(' ');
-}
+// collapseTranscriptRepetitionLoops moved to @/utils/repetitionRisk
+// (shared with TranscriptionService's final stop-result guard).
 
 function appendTranscriptWithoutDuplicate(base: string, segment: string): string {
   const baseText = base.replace(/\s+/g, ' ').trim();

--- a/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
+++ b/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
@@ -12,7 +12,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ✅ CRITICAL: Unmock for THIS file only (Prevent Over-Mocking)
 vi.unmock('../PrivateWhisper');
 
-import PrivateWhisper, { buildPrivateTimingSummary, collapseTranscriptRepetitionLoops } from '../PrivateWhisper';
+import PrivateWhisper, { buildPrivateTimingSummary } from '../PrivateWhisper';
+import { collapseTranscriptRepetitionLoops } from '@/utils/repetitionRisk';
 import { Result } from '../types';
 import { MicStream } from '../../utils/types';
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_DERIVED, SESSION_PAUSE } from '../../sttConstants';

--- a/frontend/src/utils/repetitionRisk.ts
+++ b/frontend/src/utils/repetitionRisk.ts
@@ -107,3 +107,63 @@ export function detectRepetitionRisk(text: string): RepetitionRiskResult {
 
   return NO_RISK;
 }
+
+/**
+ * Collapse Whisper repetition loops in a DECODED transcript. Whisper can loop a
+ * phrase/sentence many times on short or ambiguous audio (e.g. "we should wait we
+ * should wait we should wait …"), inflating the saved transcript (verdict-A
+ * duplication in `service_result`). This collapses an immediately-repeated
+ * multi-word unit (>= 2 words repeated >= 3 times back-to-back), and an exact
+ * verbatim whole-text doubling, down to a single instance.
+ *
+ * It is deliberately CONSERVATIVE so it can never alter a legitimate transcript:
+ * a 2+ word phrase repeated 3+ times in a row, or a verbatim first-half doubling,
+ * are loop signatures natural speech does not produce. Single words ("no no no")
+ * and 2x phrase repeats ("I think, I think") are left untouched.
+ *
+ * Unlike `detectRepetitionRisk` (flag-only), this MUTATES — it is the engine/final-
+ * result guard applied at decode and at the authoritative stop-transcript boundary.
+ */
+export function collapseTranscriptRepetitionLoops(text: string): string {
+  const raw = (text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return raw;
+  const tokens = raw.split(' ');
+  const n = tokens.length;
+  if (n < 4) return raw;
+
+  const norm = tokens.map((t) => t.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''));
+  const seqEq = (a: number, b: number, k: number): boolean => {
+    for (let x = 0; x < k; x++) {
+      if (norm[a + x] !== norm[b + x]) return false;
+    }
+    return true;
+  };
+
+  // 1. Exact verbatim whole-text doubling (the first half repeated once).
+  if (n % 2 === 0 && n >= 8 && seqEq(0, n / 2, n / 2)) {
+    return tokens.slice(0, n / 2).join(' ');
+  }
+
+  // 2. Immediate multi-word loop: a k-word unit (2..40) repeated >= 3 times.
+  const out: string[] = [];
+  let i = 0;
+  while (i < n) {
+    let collapsed = false;
+    const maxK = Math.min(40, Math.floor((n - i) / 3));
+    for (let k = 2; k <= maxK; k++) {
+      let reps = 1;
+      while (i + (reps + 1) * k <= n && seqEq(i, i + reps * k, k)) reps++;
+      if (reps >= 3) {
+        for (let x = 0; x < k; x++) out.push(tokens[i + x]);
+        i += reps * k;
+        collapsed = true;
+        break;
+      }
+    }
+    if (!collapsed) {
+      out.push(tokens[i]);
+      i++;
+    }
+  }
+  return out.join(' ');
+}


### PR DESCRIPTION
## Collapse repetition loops at the final stop-transcript boundary (launch-blocking)

Fixes the saved-transcript integrity failure exposed by the live first-time Private sample proof (#765 / run `27450396493`): the persisted transcript was 100% doubled (`repetitionRiskReason=near_whole_doubling`), e.g. *"We should literally like, wait, um, basically"* ×2.

### Root cause (artifact-confirmed)
`saveCandidateReason=service_result` (len 93, doubled). `TranscriptionService.stopTranscription()` selects the **longer** of `strategy.getTranscript()` vs the streaming-accumulated `visibleTranscript`. A doubled streaming transcript can win by length and **bypass PrivateWhisper's per-segment collapse**, persisting the loop as `service_result` / `selectedForSave`.

### Fix
- Move the conservative `collapseTranscriptRepetitionLoops` guard from `PrivateWhisper` to **`@/utils/repetitionRisk`** (pure util, alongside `detectRepetitionRisk`). This also avoids a circular/heavy service→mode import.
- Apply it to the **final selected transcript** in `stopTranscription` so the persisted value can never contain a whole-text / multi-word loop, regardless of which source won.
- **Reproduce-first regression** in `TranscriptionService.pause.test.ts` (verified it fails without the guard).

### Scope / safety
- **Not a #770 regression** — pre-existing v4/Private assembly behavior, first exercised live by the sample path.
- The **save layer stays flag-only** (`detectRepetitionRisk`); this extends the engine's *existing* mutating collapse to the authoritative final boundary. The guard is conservative (only collapses verbatim whole-text doubling / 3×+ adjacent loops — signatures natural speech doesn't produce).

### Verification
tsc clean · eslint clean · **57/57** affected unit tests (incl. `PrivateWhisper` 43, `repetitionRisk` 6, `TranscriptionService.pause` 8) · `vite build` OK.

**Acceptance (Test):** rerun #772/#765 — `selectedForSave` must have no `near_whole_doubling`; save/history/Browser-fallback still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
