### PR TITLE
chore: review non-blocking cleanup (P3 index dedup + P2 analytics routing)

### DIFF
--- a/backend/supabase/migrations/20260613100000_drop_redundant_trial_entitlements_index.sql
+++ b/backend/supabase/migrations/20260613100000_drop_redundant_trial_entitlements_index.sql
@@ -1,0 +1,6 @@
+-- Review follow-up (P3): trial_entitlements(user_id) had TWO indexes:
+--   * idx_trial_entitlements_user_id      (full,    20260612120000 — the FK-cascade index)
+--   * trial_entitlements_user_id_idx      (partial, 20260612205224 — WHERE user_id IS NOT NULL)
+-- The full index already covers the FK ON DELETE SET NULL cascade and all user_id lookups, so the
+-- partial index is redundant write overhead. Keep the full index; drop the partial one. Idempotent.
+DROP INDEX IF EXISTS public.trial_entitlements_user_id_idx;

--- a/frontend/src/hooks/useSessionLifecycle.ts
+++ b/frontend/src/hooks/useSessionLifecycle.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import posthog from 'posthog-js';
 import * as Sentry from '@sentry/react';
 import logger from '../lib/logger';
 import { useQueryClient } from '@tanstack/react-query';
@@ -273,7 +272,7 @@ export const useSessionLifecycle = () => {
                 const latestMode = requestedMode === 'cloud' && !canUseCloudStt ? defaultMode : requestedMode;
                 const selectedPolicy = buildPolicyForUser(canUsePrivateStt, latestMode, { allowCloud: canUseCloudStt });
                 await speechRuntimeController.startRecording(selectedPolicy, userFillerWords);
-                posthog.capture('session_started', {
+                analyticsBuffer.push('session_started', {
                     mode: latestMode,
                     requested_mode: requestedMode,
                     user_tier: effectiveSubscriptionStatus,
@@ -298,7 +297,7 @@ export const useSessionLifecycle = () => {
                     });
                     Sentry.captureException(err);
                 });
-                posthog.capture('recording_start_failed', {
+                analyticsBuffer.push('recording_start_failed', {
                     mode: latestMode,
                     requested_mode: requestedMode,
                     runtime_state: runtimeState,
@@ -411,7 +410,7 @@ export const useSessionLifecycle = () => {
                     : `⚠️ Great practice! ${minutes} minute${minutes > 1 ? 's' : ''} remaining for today's ${isProUser ? 'Pro ' : ''}practice limit.`;
                 if (sttStatus.message !== warningMsg) {
                     setSTTStatus({ type: 'info', message: warningMsg });
-                    posthog.capture('session_limit_warning', {
+                    analyticsBuffer.push('session_limit_warning', {
                         remaining_seconds: remaining,
                         tier: isProUser ? 'pro' : 'free',
                         limit_type: isPrivateSampleRecording ? 'private_sample' : 'daily',


### PR DESCRIPTION
## Address main-branch review non-blocking findings (P3 index + P2 analytics)

From the independent main-branch readiness review (verified against `main`):

**P3 — duplicate `trial_entitlements(user_id)` index.** Two indexes existed on the same column: the full `idx_trial_entitlements_user_id` (the FK-cascade index, `20260612120000`) and the partial `trial_entitlements_user_id_idx` (`WHERE user_id IS NOT NULL`, `20260612205224`). The full index already covers the `ON DELETE SET NULL` cascade and all lookups, so the partial one is redundant write overhead. New idempotent migration drops the partial index.

**P2 — direct `posthog.capture` bypassing the sanitizer.** `useSessionLifecycle` routed only `session_saved` through `analyticsBuffer.push`; `session_started`, `recording_start_failed`, `session_limit_warning` called `posthog.capture` directly (bypassing the central transcript/PII sanitizer). All three now route through `analyticsBuffer.push`; removed the now-unused `posthog` import.

### Verification
tsc clean · eslint clean · `useSessionLifecycle` 12/12 · `vite build` ✅

### Note — DB apply
Includes a migration (drop index); needs the standard `supabase db push` apply on merge/deploy (same flow as #766/#770).

### Deliberately NOT in this PR
The review's third actionable item (P3 — rename `isProUser`→`canUsePrivate`) turned out to be a **semantic refactor, not a rename**: it surfaced that `SessionPage` passes the private-capability flag into `SunsetModals.isPro` (which gates the upgrade CTA on *real* paid-pro), so a free *sample* user who hits the daily limit would wrongly see Pro messaging / no upgrade CTA. That fix touches the STT-mode gate + its test suites and warrants its own isolated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
