### PR TITLE
docs(release): closeout ledger + SLO/SLC & Stripe-live prep checklists

### DIFF
--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -16,7 +16,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #772 visible-final fix | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 raised; Test to review/merge + rerun proof |
 | #765/#772 proof | Test | Rerun live proof after Dev #772 fix | Pending — rerun on PR #777 |
 | SLO/SLC | Test | Refresh current-SHA evidence | Done — run `27468651667` PASS on `main@9d4b90be` |
-| Stripe live cutover | Ops/Test/Product | Live paid launch (IS in scope) | Blocked — needs live Stripe keys + real-money authorization |
+| Stripe paths/journey | Test (proof) → Ops (cutover) | Prove billing journey + flip live at launch | Journey PROVEN with TEST keys (PASS); live launch = config cutover (swap test→live keys), not a money-test |
 | Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
 | Group D branches | Test/release-owner | Classify keep / delete / backlog | Pending — owner decision (none confirmed merged to `main`) |
 
@@ -70,22 +70,22 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 - **CI:** SLO/SLC workflow (last green run `27441628586` on `b0227ed8`) — re-dispatch on the current release SHA.
 - **Targets present in rig:** auth_p95, usage_edge_p95, session_rpc_p95 (< 2000 ms release floor), stress_failure_rate (0%).
 
-## D. Prep-only checklist — #3 Stripe live cutover (Ops/Test; Dev verified paths, touched NO live keys)
+## D. #3 Stripe — journey PROVEN with TEST-mode keys; going live = config cutover (NOT a money-test)
 
-> Live paid launch IS in scope for this RC (release-owner). BLOCKED until live Stripe keys are provisioned. Dev does NOT enter live keys or run live-money proofs.
+> **Correction (release-owner):** Stripe **live** keys are not — and cannot be — "tested" (no real-money transactions are run as a proof). The checkout → webhook → billing-portal **paths and full journey are proven with Stripe TEST-mode keys**, and they **PASS**. That test-mode journey is the accepted proof. Going to live paid launch is a **deployment/config cutover** (swap test keys for live keys + register the live webhook), performed by Ops at launch on the business go-decision — not a Dev/CI/QA money proof. Dev does not enter live keys.
 
+- **Accepted proof (test mode) — PASS:** `27441691671` test-mode spine, `27441691174` price audit (checkout/webhook/portal journey exercised with `sk_test_…`). No real-money proof exists or is required.
 - **Functions:** `stripe-checkout`, `stripe-billing-portal`, `stripe-webhook` (`backend/supabase/functions/`).
-- **LIVE env vars to set (deploy env):**
+- **Go-live config cutover (Ops, at launch):** swap deploy-env vars from test → live:
   - `STRIPE_SECRET_KEY` = `sk_live_…`
   - `STRIPE_WEBHOOK_SECRET` = live `whsec_…` (from the live webhook endpoint)
   - `STRIPE_PRO_PRICE_ID`, `STRIPE_BASIC_PRICE_ID` = LIVE price IDs
-  - `SITE_URL` = production URL
-  - confirm `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
-- **Webhook endpoint:** register `{prod}/functions/v1/stripe-webhook` in the Stripe LIVE dashboard → copy the live `whsec_` → set `STRIPE_WEBHOOK_SECRET`.
-- **Webhook security (already correct):** signature-verified via `constructEventAsync`/`constructEvent` (`stripe-webhook/index.ts:171-175`, secret L188); fails closed (non-2xx → Stripe retries).
+  - `SITE_URL` = production URL; confirm `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+- **Webhook endpoint (cutover step):** register `{prod}/functions/v1/stripe-webhook` in the Stripe LIVE dashboard → copy the live `whsec_` → set `STRIPE_WEBHOOK_SECRET`.
+- **Webhook security (already correct, mode-agnostic):** signature-verified via `constructEventAsync`/`constructEvent` (`stripe-webhook/index.ts:171-175`, secret L188); fails closed (non-2xx → Stripe retries).
 - **Return URLs (already correct):** `success_url`/`cancel_url` server-derived from `SITE_URL` (`stripe-checkout/index.ts:258-259`); portal `return_url` from `SITE_URL`. No client-supplied URLs → open-redirect safe.
-- **Customer-id persistence (already correct):** `process_stripe_webhook_event(p_stripe_customer_id)` (migration `20260608190000`) — verify on one live test event.
-- **Ops/Test live-money proof (NOT Dev):** real checkout → webhook round-trip → subscription status + customer-id persisted → billing-portal open. Safe (test-key) checks already PASS (`27441691174` price audit, `27441691671` test-mode spine).
+- **Customer-id persistence (already correct):** `process_stripe_webhook_event(p_stripe_customer_id)` (migration `20260608190000`) — exercised in the test-mode journey.
+- **Not blocked on a proof.** The journey is proven (test mode). The only remaining item is the business decision to flip live keys at cutover.
 
 ## Dev posture
 

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -15,8 +15,8 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
 | #772 post-stop doubling | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 merged `18b2a30f` |
 | #772 post-stop empty-after-sample | Dev → Test | Keep saved transcript visible after sample auto-save | Done — PR #778 merged `d06700b5` (narrow store-reset guard: post-sample saved transcript remains visible on `/session` after the forced native/browser mode switch, until the next recording). Test reruns live proof. |
-| #765/#772 proof | Test | Rerun live proof after the #778 fix | Pending — rerun on `main` (post-#778, `d06700b5`); expect `visibleFinalMatchesSave=true` |
-| SLO/SLC | Test | Refresh evidence on current SHA | PASS on `main@9d4b90be` (`27468651667`); needs rerun on post-#777/#778 `main` (`d06700b5`) for final sign-off |
+| #765/#772 proof | Test | Rerun live proof after the #778 fix | Done — PASS. Live proof `27474247308` on `main@243fae42`; `selectedForSave == postStopTranscriptText`, `visibleFinalMatchesSave=true`, `finalTranscriptPreserved=true`, saved/detail preserved |
+| SLO/SLC | Test | Refresh evidence on current SHA | In progress on `main@243fae42`: latency-only flake on `27474441503`, rerun `27474811615` recovered backend latency but browser-endurance setup failed (`max_concurrent_sessions_reached`); Test classifying fixture vs real |
 | Stripe paths/journey | Test (proof) → Ops (cutover) | Prove billing journey + flip live at launch | Journey PROVEN with TEST keys (PASS); live launch = config cutover (swap test→live keys), not a money-test |
 | Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
 | Group D branches | Test/release-owner | Classify keep / delete / backlog | Pending — owner decision (none confirmed merged to `main`) |
@@ -33,8 +33,10 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
 | #772 post-stop visible-final repetition (doubling) | Closed — merged | — | PR #777 `18b2a30f`; display-only collapse in settled view; panel 48/48, affected 85/85; saved transcript untouched |
 | #772 post-stop visible-final empty (after sample auto-end) | Closed — merged | — | PR #778 `d06700b5`; narrow store-reset guard (`!sessionSaved` in `setSTTMode`): post-sample saved transcript stays visible on `/session` after the forced native/browser switch, until next recording; store 18/18, affected 92/92, tsc+eslint+build OK; saved data untouched |
-| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on `main` (post-#778, `d06700b5`); expect `visibleFinalMatchesSave=true`; `repeated_span` accepted as guardrail, not the blocker |
-| SLO/SLC service-level evidence | Open — rerun needed | Test | PASS on `main@9d4b90be` (`27468651667`); rerun on post-#777/#778 `main` (`d06700b5`) for final sign-off |
+| #772 selector disambiguation (test-only) | Closed — merged | — | `37627c4a`; narrows the broad `getByText` proof locator to stable test IDs |
+| #779 preserved-transcript proof (test-only) | Closed — merged | — | `243fae42` (current `main`) |
+| #765/#772 first-time-sample proof | Closed — PASS | Test | live proof `27474247308` on `main@243fae42`; artifact `7613048636`, digest `sha256:76dd49c6a3f1dcb34e432fd8184aff6787ae1f1ec97ca037ea667d75a5c028b2`; `selectedForSave == postStopTranscriptText`, `visibleFinalMatchesSave=true`, `finalTranscriptPreserved=true`, saved/detail preserved, `repeated_span` guardrail-only |
+| SLO/SLC service-level evidence | Open — Test rerunning | Test (+ Dev read-only support) | current-SHA refresh on `main@243fae42`: latency-only flake `27474441503`, rerun `27474811615` recovered backend latency but browser-endurance setup failed (`max_concurrent_sessions_reached`); classifying fixture-cleanup vs real usage-limit |
 | `repeated_span` policy | Closed — explicit release-owner disposition | — | non-destructive guardrail: preserved, NOT collapsed, no fuzzy de-dup |
 
 ### #775 merge invariants (Test must confirm)
@@ -64,7 +66,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## C. Prep-only checklist — #2 SLO/SLC (rig verified by Dev; RUN by Test)
 
-> **Status: PASS on `main@9d4b90be` (`27468651667`); RERUN NEEDED.** #777 and #778 have since merged (current `main` = `d06700b5`), so Test should re-dispatch this on post-#778 `main` for final sign-off. The rig reference below stays for the re-run.
+> **Status: prior PASS on `main@9d4b90be` (`27468651667`); current-SHA rerun in progress on `main@243fae42`.** Run `27474441503` flagged latency only (auth p95 `3970 ms`, usage-edge p95 `2349 ms` over the `2000 ms` floor; backend 45/45 success). Rerun `27474811615` recovered backend latency (auth `778 ms`, usage `455 ms`, session RPC `73 ms`) but browser-endurance setup failed: both soak users hit `max_concurrent_sessions_reached` (start button stayed `data-recording=false`). Test is classifying fixture/session-cleanup vs a real usage-limit blocker; Dev read-only support only. The rig reference below stays for the re-run.
 
 - **Commands:** `pnpm ops:health` → `ops-health/ops-health.summary.json`; `pnpm metrics:service-levels` (synthesizes); full dry: `pnpm rc:slo:dry`.
 - **Inputs read by `scripts/write-service-level-evidence.mjs`:** `product_release/evidence/software-quality.latest.json`, `test-results/stress/backend-stress.latest.json`, `test-results/endurance/browser-endurance.latest.json`, `ops-health/ops-health.summary.json`.
@@ -91,6 +93,6 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## Dev posture
 
-Active Dev work: **none in flight.** Both #772 failures are fixed and merged: the post-stop doubling (PR #777 `18b2a30f`) and the post-sample empty-visible (PR #778 `d06700b5`, narrow store-reset guard). Test reruns the #765/#772 live proof on post-#778 `main`. Per release-owner, **#778 is the last authorized product-code fix unless Test finds a new concrete release-blocking failure.**
+Active Dev work: **none in flight.** Both #772 failures are fixed, merged, and **proven live**: the post-stop doubling (PR #777 `18b2a30f`) and the post-sample empty-visible (PR #778 `d06700b5`, narrow store-reset guard). The #765/#772 first-time-sample live proof **PASSED** (`27474247308` on `main@243fae42`: `visibleFinalMatchesSave=true`, saved/detail preserved). Per release-owner, **#778 was the last authorized product-code fix unless Test finds a new concrete release-blocking failure.**
 
 Reopen Dev work only on: (1) a *new* concrete failure in #777/#778/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (merged + applied, workflow `27470518053` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -1,0 +1,85 @@
+# Release Closeout Ledger
+
+Dev-owned closeout per release-owner directive (2026-06-13). Every pending item has a single
+status + named owner. Dev is review/support-only; this doc is documentation/disposition, not code.
+
+## Target state (release-owner)
+
+| Lane | Owner | Goal |
+|---|---|---|
+| #774 db push | Test/Ops | Apply migration and record proof |
+| #775 merge | Test | Merge after green CI/review |
+| #765/#772 proof | Test | Rerun under revised `repeated_span` acceptance |
+| SLO/SLC | Test | Refresh current-SHA evidence |
+| Stripe live cutover | Ops/Test/Product | Blocked until live Stripe keys (live paid launch IS in scope) |
+| Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) |
+| Group D branches | Test | Classify keep / delete / backlog |
+
+## Live release lane — current status
+
+| Item | Status | Owner | Proof |
+|---|---|---|---|
+| #770 migration reconciliation | Closed — merged | — | `46e0fd97`; prod migration run `27450253678` PASS |
+| #771 recovery actions | Closed — merged | — | `c11789ef` |
+| #773 exact-doubling collapse | Closed — merged (KEEP, do not revert) | — | `8cee74fe` |
+| #774 index dedup + analytics routing | Closed — merged | — | `75fb9ac0` (branch deleted) |
+| #774 migration apply (`supabase db push`) | Open — active Test/Ops | Test/Ops | migration `20260613100000`; record evidence |
+| #775 canUsePrivate split + SunsetModals fix | Open — active Test | Test | CI 17/17 green; review/merge under invariants below |
+| #765/#772 first-time-sample proof | Open — active Test | Test | rerun under revised acceptance (Section C) |
+| `repeated_span` policy | Closed — explicit release-owner disposition | — | Option A non-destructive guardrail |
+
+### #775 merge invariants (Test must confirm)
+1. Paid Pro users still get Private.
+2. Free users with a valid sample get Private only while the sample is valid.
+3. Expired-sample users are locked again.
+4. `SunsetModals` receives real paid-Pro status, not sample access.
+
+## A. Backlog / disposition ledger (deferred, non-blocking)
+
+| # | Item | Why non-blocking | Owner (post-release) | Next action | Needs |
+|---|---|---|---|---|---|
+| A1 | v4 app-path lifecycle proof, flag-on (#76) | transformers-js-v4 is behind a PostHog flag, OFF by default; shipped Private path is base Whisper | Dev | run flag-on lifecycle proof when v4 rollout scheduled | code + Test proof |
+| A2 | Real RMS recording meter (#96 / AUDIT-C2) | current indicator is honest/decorative (not fake data); release-owner accepted decorative until RMS | Dev | wire `LiveRecordingCard` to real `micLevel` RMS | code |
+| A3 | `repeated_span` principled fix (VAD/segmentation) | release uses non-destructive guardrail (Option A); transcript preserved + loop contained | Dev (STT lane) | VAD/segmentation to prevent loops at decode | code + Test proof |
+| A4 | v4 cross-utterance context / decode tuning (#37) | v4 flag-gated / experimental | Dev | continue under v4 lane | code + Test proof |
+| A5 | Test/naming-debt cleanup (chip `task_9633953d` remainder) | rename DONE (#775), collapse moved to util (#773); remaining = consolidate 3 e2e usage-limit mock layers into one + make e2e bootable locally | Dev/Test | consolidate mock source + fix local e2e boot | code (test infra) |
+| A6 | Stale-branch cleanup: 7 `dev/v4-integration`-merged branches + closed `#767` branch | housekeeping; content reaches `main` only when `dev/v4-integration` merges | Test/release-owner | delete after `dev/v4-integration` lands (or convert to tracked) | Ops/Test access |
+
+## B. Documentation-gap closures (recorded statuses)
+
+- **#1 live DB entitlement evidence — Closed — merged** (#768/#769; `ENTITLEMENT_PRO_LIMIT_EVIDENCE.md`).
+- **#4 Stripe customer-id persistence — Closed — verified already implemented.** `stripe-webhook` → `process_stripe_webhook_event(p_stripe_customer_id)` (migration `20260608190000_store_stripe_customer_id_in_webhook.sql`); 11 customer-id test assertions in `stripe-webhook/index.test.ts`.
+- **#5 AI suggestion server-side quota — Closed — verified already implemented.** `get-ai-suggestions` → `consume_ai_suggestion_quota` (atomic `SECURITY DEFINER` counter, HTTP 429 on exhaustion, cached results bypass quota).
+- **#6 session save / draft recovery — Closed — merged.** `services/sessionRecoveryDraft.ts` + `App.tsx` (`beforeunload`/`pagehide`/`visibilitychange`) + `SessionPage` restore + visible recovery actions (#771).
+- **#85 Private sample entitlement — Closed — merged** (#770; live-verified end-to-end). Do NOT reopen.
+
+## C. Prep-only checklist — #2 SLO/SLC (Dev verified the rig; Test RUNS it)
+
+> Dev does NOT claim SLO/SLC passed. Test must run current-release-SHA evidence and confirm Verdict PASS.
+
+- **Commands:** `pnpm ops:health` → `ops-health/ops-health.summary.json`; `pnpm metrics:service-levels` (synthesizes); full dry: `pnpm rc:slo:dry`.
+- **Inputs read by `scripts/write-service-level-evidence.mjs`:** `product_release/evidence/software-quality.latest.json`, `test-results/stress/backend-stress.latest.json`, `test-results/endurance/browser-endurance.latest.json`, `ops-health/ops-health.summary.json`.
+- **Outputs:** `product_release/evidence/service-levels.latest.json` + `service-levels-summary.latest.md`.
+- **CI:** SLO/SLC workflow (last green run `27441628586` on `b0227ed8`) — re-dispatch on the current release SHA.
+- **Targets present in rig:** auth_p95, usage_edge_p95, session_rpc_p95 (< 2000 ms release floor), stress_failure_rate (0%).
+
+## D. Prep-only checklist — #3 Stripe live cutover (Ops/Test; Dev verified paths, touched NO live keys)
+
+> Live paid launch IS in scope for this RC (release-owner). BLOCKED until live Stripe keys are provisioned. Dev does NOT enter live keys or run live-money proofs.
+
+- **Functions:** `stripe-checkout`, `stripe-billing-portal`, `stripe-webhook` (`backend/supabase/functions/`).
+- **LIVE env vars to set (deploy env):**
+  - `STRIPE_SECRET_KEY` = `sk_live_…`
+  - `STRIPE_WEBHOOK_SECRET` = live `whsec_…` (from the live webhook endpoint)
+  - `STRIPE_PRO_PRICE_ID`, `STRIPE_BASIC_PRICE_ID` = LIVE price IDs
+  - `SITE_URL` = production URL
+  - confirm `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+- **Webhook endpoint:** register `{prod}/functions/v1/stripe-webhook` in the Stripe LIVE dashboard → copy the live `whsec_` → set `STRIPE_WEBHOOK_SECRET`.
+- **Webhook security (already correct):** signature-verified via `constructEventAsync`/`constructEvent` (`stripe-webhook/index.ts:171-175`, secret L188); fails closed (non-2xx → Stripe retries).
+- **Return URLs (already correct):** `success_url`/`cancel_url` server-derived from `SITE_URL` (`stripe-checkout/index.ts:258-259`); portal `return_url` from `SITE_URL`. No client-supplied URLs → open-redirect safe.
+- **Customer-id persistence (already correct):** `process_stripe_webhook_event(p_stripe_customer_id)` (migration `20260608190000`) — verify on one live test event.
+- **Ops/Test live-money proof (NOT Dev):** real checkout → webhook round-trip → subscription status + customer-id persisted → billing-portal open. Safe (test-key) checks already PASS (`27441691174` price audit, `27441691671` test-mode spine).
+
+## Dev posture
+
+Open — active Dev work: **none.** Dev is review/support-only. Reopen only on: (1) #775 CI re-fails with a concrete failure; (2) Test proves a concrete #765/#772 product failure under revised acceptance; (3) Test/Ops hits a concrete #774 migration-apply blocker; (4) release-owner assigns a specific backlog item. Dev will not mutate transcripts, implement fuzzy collapse, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup.

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -13,8 +13,9 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 |---|---|---|---|
 | #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`; migration workflow `27470518053` PASS (push-deploy skips DB by design) |
 | #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
-| #772 visible-final fix | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 raised; Test to review/merge + rerun proof |
-| #765/#772 proof | Test | Rerun live proof after Dev #772 fix | Pending — rerun on PR #777 |
+| #772 visible-final (doubling) | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 merged `18b2a30f` |
+| #772 visible-final (empty after sample reset) | release-owner (scope) → Dev/Test | Decide fix vs. relax acceptance | **Pending release-owner decision.** Rerun `27472526881` RED: after a Private sample auto-ends+saves, the forced Browser/native switch clears the visible final (`postStopTranscriptText=""`). Fix is in store mode-switch reset (lifecycle, not display) — brushes "don't broaden architecture". Options: (A) narrow store guard so saved transcript stays visible until next recording; (B) treat reset as intended + Test asserts saved text on detail page instead. Saved transcript correct either way. |
+| #765/#772 proof | Test | Rerun live proof after the above decision | RED — blocked on the #772 empty-visible decision |
 | SLO/SLC | Test | Refresh current-SHA evidence | Done — run `27468651667` PASS on `main@9d4b90be` |
 | Stripe paths/journey | Test (proof) → Ops (cutover) | Prove billing journey + flip live at launch | Journey PROVEN with TEST keys (PASS); live launch = config cutover (swap test→live keys), not a money-test |
 | Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
@@ -30,8 +31,9 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #774 index dedup + analytics routing | Closed — merged | — | `75fb9ac0` (branch deleted) |
 | #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; dispatched migration workflow `27470518053` PASS (deploy-production-db + push-migrations PASS) |
 | #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
-| #772 post-stop visible-final repetition | Open — active Dev→Test (PR #777) | Dev (fix) → Test (proof) | display-only collapse in settled view; panel 48/48, affected 85/85, tsc+eslint+build OK; saved transcript untouched |
-| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on PR #777; expect `visibleFinalMatchesSave=true` (Section C) |
+| #772 post-stop visible-final repetition (doubling) | Closed — merged | — | PR #777 `18b2a30f`; display-only collapse in settled view; panel 48/48, affected 85/85; saved transcript untouched |
+| #772 post-stop visible-final EMPTY (after sample auto-end) | Open — pending release-owner scope decision | release-owner → Dev/Test | rerun `27472526881` RED: sample-end forced-native switch clears the saved final (`postStopTranscriptText=""`); fix is lifecycle (store reset), not display — Option A (store guard) vs Option B (relax acceptance) |
+| #765/#772 first-time-sample proof | Open — RED (blocked on decision above) | Test | rerun after the empty-visible decision; `repeated_span` accepted as guardrail, not the blocker |
 | SLO/SLC service-level evidence | Closed — verified | — | run `27468651667` PASS on `main@9d4b90be` |
 | `repeated_span` policy | Closed — explicit release-owner disposition | — | Option A non-destructive guardrail (NOT collapsed; no fuzzy de-dup) |
 
@@ -89,6 +91,6 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## Dev posture
 
-Open — active Dev work: **one** — #772 post-stop visible-final repetition (concrete Test-routed failure), fixed display-only in **PR #777**, awaiting Test review/merge + live-proof rerun. After PR #777 lands, Dev returns to review/support-only.
+Active Dev work: **none in flight; one pending a release-owner decision.** #772 doubling is fixed + merged (PR #777 `18b2a30f`). The live rerun surfaced a *second*, distinct issue — the post-stop visible final goes EMPTY after a Private sample auto-ends (forced Browser/native switch clears it via the store mode-switch reset). The fix is in **session lifecycle (store reset), not display**, so it brushes the "don't broaden transcript architecture" guardrail — Dev is holding for a release-owner scope decision: **(A)** narrow store guard (keep saved transcript visible until next recording) vs **(B)** treat the reset as intended + Test asserts the saved text on the detail page. Dev makes no lifecycle change until that call.
 
-Reopen further Dev work only on: (1) a concrete failure in #777/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (currently merged + applied, migration workflow `27470518053` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).
+Reopen further Dev work only on: (1) the release-owner picks Option A above; (2) a *new* concrete failure in #777/#765/#772; (3) Test/Ops hits a concrete #774 migration-apply blocker (merged + applied, workflow `27470518053` PASS — not expected); (4) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -13,9 +13,9 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 |---|---|---|---|
 | #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`; migration workflow `27470518053` PASS (push-deploy skips DB by design) |
 | #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
-| #772 visible-final (doubling) | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 merged `18b2a30f` |
-| #772 visible-final (empty after sample reset) | release-owner (scope) → Dev/Test | Decide fix vs. relax acceptance | **Pending release-owner decision.** Rerun `27472526881` RED: after a Private sample auto-ends+saves, the forced Browser/native switch clears the visible final (`postStopTranscriptText=""`). Fix is in store mode-switch reset (lifecycle, not display) — brushes "don't broaden architecture". Options: (A) narrow store guard so saved transcript stays visible until next recording; (B) treat reset as intended + Test asserts saved text on detail page instead. Saved transcript correct either way. |
-| #765/#772 proof | Test | Rerun live proof after the above decision | RED — blocked on the #772 empty-visible decision |
+| #772 post-stop doubling | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 merged `18b2a30f` |
+| #772 post-stop empty-after-sample | Dev → Test | Keep saved transcript visible after sample auto-save | Done — PR #778 (release-owner-authorized narrow store-reset guard: saved transcript stays visible on /session until the next recording). Awaiting Test live-proof rerun. |
+| #765/#772 proof | Test | Rerun live proof after the #778 fix | Pending — rerun on PR #778; expect `visibleFinalMatchesSave=true` |
 | SLO/SLC | Test | Refresh current-SHA evidence | Done — run `27468651667` PASS on `main@9d4b90be` |
 | Stripe paths/journey | Test (proof) → Ops (cutover) | Prove billing journey + flip live at launch | Journey PROVEN with TEST keys (PASS); live launch = config cutover (swap test→live keys), not a money-test |
 | Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
@@ -32,10 +32,10 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; dispatched migration workflow `27470518053` PASS (deploy-production-db + push-migrations PASS) |
 | #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
 | #772 post-stop visible-final repetition (doubling) | Closed — merged | — | PR #777 `18b2a30f`; display-only collapse in settled view; panel 48/48, affected 85/85; saved transcript untouched |
-| #772 post-stop visible-final EMPTY (after sample auto-end) | Open — pending release-owner scope decision | release-owner → Dev/Test | rerun `27472526881` RED: sample-end forced-native switch clears the saved final (`postStopTranscriptText=""`); fix is lifecycle (store reset), not display — Option A (store guard) vs Option B (relax acceptance) |
-| #765/#772 first-time-sample proof | Open — RED (blocked on decision above) | Test | rerun after the empty-visible decision; `repeated_span` accepted as guardrail, not the blocker |
+| #772 post-stop visible-final empty (after sample auto-end) | Open — active Dev→Test (PR #778) | Dev (fix) → Test (proof) | release-owner-authorized narrow store-reset guard (`!sessionSaved` in `setSTTMode`): saved transcript stays visible until next recording; store 18/18, affected 92/92, tsc+eslint+build OK; saved data untouched |
+| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on PR #778; expect `visibleFinalMatchesSave=true`; `repeated_span` accepted as guardrail, not the blocker |
 | SLO/SLC service-level evidence | Closed — verified | — | run `27468651667` PASS on `main@9d4b90be` |
-| `repeated_span` policy | Closed — explicit release-owner disposition | — | Option A non-destructive guardrail (NOT collapsed; no fuzzy de-dup) |
+| `repeated_span` policy | Closed — explicit release-owner disposition | — | non-destructive guardrail: preserved, NOT collapsed, no fuzzy de-dup |
 
 ### #775 merge invariants (Test must confirm)
 1. Paid Pro users still get Private.
@@ -91,6 +91,6 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## Dev posture
 
-Active Dev work: **none in flight; one pending a release-owner decision.** #772 doubling is fixed + merged (PR #777 `18b2a30f`). The live rerun surfaced a *second*, distinct issue — the post-stop visible final goes EMPTY after a Private sample auto-ends (forced Browser/native switch clears it via the store mode-switch reset). The fix is in **session lifecycle (store reset), not display**, so it brushes the "don't broaden transcript architecture" guardrail — Dev is holding for a release-owner scope decision: **(A)** narrow store guard (keep saved transcript visible until next recording) vs **(B)** treat the reset as intended + Test asserts the saved text on the detail page. Dev makes no lifecycle change until that call.
+Active Dev work: **none in flight.** Both #772 failures are fixed: the post-stop doubling (PR #777 `18b2a30f`, merged) and the post-sample empty-visible (PR #778, release-owner-authorized narrow store-reset guard — awaiting Test live-proof rerun). Per release-owner, **#778 is the last authorized product-code fix unless Test finds a new concrete release-blocking failure.**
 
-Reopen further Dev work only on: (1) the release-owner picks Option A above; (2) a *new* concrete failure in #777/#765/#772; (3) Test/Ops hits a concrete #774 migration-apply blocker (merged + applied, workflow `27470518053` PASS — not expected); (4) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).
+Reopen Dev work only on: (1) a *new* concrete failure in #777/#778/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (merged + applied, workflow `27470518053` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -1,19 +1,24 @@
 # Release Closeout Ledger
 
 Dev-owned closeout per release-owner directive (2026-06-13). Every pending item has a single
-status + named owner. Dev is review/support-only; this doc is documentation/disposition, not code.
+status + named owner. This doc is documentation/disposition. Dev is review/support-only EXCEPT
+for the one concrete code task currently routed to Dev (#772 post-stop visible-final repetition,
+fixed in PR #777 — see live-lane table).
+
+_Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #777)._
 
 ## Target state (release-owner)
 
-| Lane | Owner | Goal |
-|---|---|---|
-| #774 db push | Test/Ops | Apply migration and record proof |
-| #775 merge | Test | Merge after green CI/review |
-| #765/#772 proof | Test | Rerun under revised `repeated_span` acceptance |
-| SLO/SLC | Test | Refresh current-SHA evidence |
-| Stripe live cutover | Ops/Test/Product | Blocked until live Stripe keys (live paid launch IS in scope) |
-| Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) |
-| Group D branches | Test | Classify keep / delete / backlog |
+| Lane | Owner | Goal | State |
+|---|---|---|---|
+| #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`, deploy `27468363004` PASS |
+| #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
+| #772 visible-final fix | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 raised; Test to review/merge + rerun proof |
+| #765/#772 proof | Test | Rerun live proof after Dev #772 fix | Pending — rerun on PR #777 |
+| SLO/SLC | Test | Refresh current-SHA evidence | Done — run `27468651667` PASS on `main@9d4b90be` |
+| Stripe live cutover | Ops/Test/Product | Live paid launch (IS in scope) | Blocked — needs live Stripe keys + real-money authorization |
+| Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
+| Group D branches | Test/release-owner | Classify keep / delete / backlog | Pending — owner decision (none confirmed merged to `main`) |
 
 ## Live release lane — current status
 
@@ -23,10 +28,12 @@ status + named owner. Dev is review/support-only; this doc is documentation/disp
 | #771 recovery actions | Closed — merged | — | `c11789ef` |
 | #773 exact-doubling collapse | Closed — merged (KEEP, do not revert) | — | `8cee74fe` |
 | #774 index dedup + analytics routing | Closed — merged | — | `75fb9ac0` (branch deleted) |
-| #774 migration apply (`supabase db push`) | Open — active Test/Ops | Test/Ops | migration `20260613100000`; record evidence |
-| #775 canUsePrivate split + SunsetModals fix | Open — active Test | Test | CI 17/17 green; review/merge under invariants below |
-| #765/#772 first-time-sample proof | Open — active Test | Test | rerun under revised acceptance (Section C) |
-| `repeated_span` policy | Closed — explicit release-owner disposition | — | Option A non-destructive guardrail |
+| #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; Supabase deploy `27468363004` PASS |
+| #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
+| #772 post-stop visible-final repetition | Open — active Dev→Test (PR #777) | Dev (fix) → Test (proof) | display-only collapse in settled view; panel 48/48, affected 85/85, tsc+eslint+build OK; saved transcript untouched |
+| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on PR #777; expect `visibleFinalMatchesSave=true` (Section C) |
+| SLO/SLC service-level evidence | Closed — verified | — | run `27468651667` PASS on `main@9d4b90be` |
+| `repeated_span` policy | Closed — explicit release-owner disposition | — | Option A non-destructive guardrail (NOT collapsed; no fuzzy de-dup) |
 
 ### #775 merge invariants (Test must confirm)
 1. Paid Pro users still get Private.
@@ -53,9 +60,9 @@ status + named owner. Dev is review/support-only; this doc is documentation/disp
 - **#6 session save / draft recovery — Closed — merged.** `services/sessionRecoveryDraft.ts` + `App.tsx` (`beforeunload`/`pagehide`/`visibilitychange`) + `SessionPage` restore + visible recovery actions (#771).
 - **#85 Private sample entitlement — Closed — merged** (#770; live-verified end-to-end). Do NOT reopen.
 
-## C. Prep-only checklist — #2 SLO/SLC (Dev verified the rig; Test RUNS it)
+## C. Prep-only checklist — #2 SLO/SLC (rig verified by Dev; RUN by Test)
 
-> Dev does NOT claim SLO/SLC passed. Test must run current-release-SHA evidence and confirm Verdict PASS.
+> **Status: RUN — PASS.** Test executed service-level evidence on `main@9d4b90be` (run `27468651667` PASS; artifact `7611416017`). Re-dispatch on the current release SHA after PR #777 merges. The rig reference below stays for the re-run.
 
 - **Commands:** `pnpm ops:health` → `ops-health/ops-health.summary.json`; `pnpm metrics:service-levels` (synthesizes); full dry: `pnpm rc:slo:dry`.
 - **Inputs read by `scripts/write-service-level-evidence.mjs`:** `product_release/evidence/software-quality.latest.json`, `test-results/stress/backend-stress.latest.json`, `test-results/endurance/browser-endurance.latest.json`, `ops-health/ops-health.summary.json`.
@@ -82,4 +89,6 @@ status + named owner. Dev is review/support-only; this doc is documentation/disp
 
 ## Dev posture
 
-Open — active Dev work: **none.** Dev is review/support-only. Reopen only on: (1) #775 CI re-fails with a concrete failure; (2) Test proves a concrete #765/#772 product failure under revised acceptance; (3) Test/Ops hits a concrete #774 migration-apply blocker; (4) release-owner assigns a specific backlog item. Dev will not mutate transcripts, implement fuzzy collapse, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup.
+Open — active Dev work: **one** — #772 post-stop visible-final repetition (concrete Test-routed failure), fixed display-only in **PR #777**, awaiting Test review/merge + live-proof rerun. After PR #777 lands, Dev returns to review/support-only.
+
+Reopen further Dev work only on: (1) a concrete failure in #777/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (currently merged + applied, deploy `27468363004` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -14,9 +14,9 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`; migration workflow `27470518053` PASS (push-deploy skips DB by design) |
 | #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
 | #772 post-stop doubling | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 merged `18b2a30f` |
-| #772 post-stop empty-after-sample | Dev → Test | Keep saved transcript visible after sample auto-save | Done — PR #778 (release-owner-authorized narrow store-reset guard: saved transcript stays visible on /session until the next recording). Awaiting Test live-proof rerun. |
-| #765/#772 proof | Test | Rerun live proof after the #778 fix | Pending — rerun on PR #778; expect `visibleFinalMatchesSave=true` |
-| SLO/SLC | Test | Refresh current-SHA evidence | Done — run `27468651667` PASS on `main@9d4b90be` |
+| #772 post-stop empty-after-sample | Dev → Test | Keep saved transcript visible after sample auto-save | Done — PR #778 merged `d06700b5` (narrow store-reset guard: post-sample saved transcript remains visible on `/session` after the forced native/browser mode switch, until the next recording). Test reruns live proof. |
+| #765/#772 proof | Test | Rerun live proof after the #778 fix | Pending — rerun on `main` (post-#778, `d06700b5`); expect `visibleFinalMatchesSave=true` |
+| SLO/SLC | Test | Refresh evidence on current SHA | PASS on `main@9d4b90be` (`27468651667`); needs rerun on post-#777/#778 `main` (`d06700b5`) for final sign-off |
 | Stripe paths/journey | Test (proof) → Ops (cutover) | Prove billing journey + flip live at launch | Journey PROVEN with TEST keys (PASS); live launch = config cutover (swap test→live keys), not a money-test |
 | Backlog ledger | Dev | Convert deferred items into explicit non-blocking entries (this doc) | Done — this doc |
 | Group D branches | Test/release-owner | Classify keep / delete / backlog | Pending — owner decision (none confirmed merged to `main`) |
@@ -32,9 +32,9 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; dispatched migration workflow `27470518053` PASS (deploy-production-db + push-migrations PASS) |
 | #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
 | #772 post-stop visible-final repetition (doubling) | Closed — merged | — | PR #777 `18b2a30f`; display-only collapse in settled view; panel 48/48, affected 85/85; saved transcript untouched |
-| #772 post-stop visible-final empty (after sample auto-end) | Open — active Dev→Test (PR #778) | Dev (fix) → Test (proof) | release-owner-authorized narrow store-reset guard (`!sessionSaved` in `setSTTMode`): saved transcript stays visible until next recording; store 18/18, affected 92/92, tsc+eslint+build OK; saved data untouched |
-| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on PR #778; expect `visibleFinalMatchesSave=true`; `repeated_span` accepted as guardrail, not the blocker |
-| SLO/SLC service-level evidence | Closed — verified | — | run `27468651667` PASS on `main@9d4b90be` |
+| #772 post-stop visible-final empty (after sample auto-end) | Closed — merged | — | PR #778 `d06700b5`; narrow store-reset guard (`!sessionSaved` in `setSTTMode`): post-sample saved transcript stays visible on `/session` after the forced native/browser switch, until next recording; store 18/18, affected 92/92, tsc+eslint+build OK; saved data untouched |
+| #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on `main` (post-#778, `d06700b5`); expect `visibleFinalMatchesSave=true`; `repeated_span` accepted as guardrail, not the blocker |
+| SLO/SLC service-level evidence | Open — rerun needed | Test | PASS on `main@9d4b90be` (`27468651667`); rerun on post-#777/#778 `main` (`d06700b5`) for final sign-off |
 | `repeated_span` policy | Closed — explicit release-owner disposition | — | non-destructive guardrail: preserved, NOT collapsed, no fuzzy de-dup |
 
 ### #775 merge invariants (Test must confirm)
@@ -49,7 +49,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 |---|---|---|---|---|---|
 | A1 | v4 app-path lifecycle proof, flag-on (#76) | transformers-js-v4 is behind a PostHog flag, OFF by default; shipped Private path is base Whisper | Dev | run flag-on lifecycle proof when v4 rollout scheduled | code + Test proof |
 | A2 | Real RMS recording meter (#96 / AUDIT-C2) | current indicator is honest/decorative (not fake data); release-owner accepted decorative until RMS | Dev | wire `LiveRecordingCard` to real `micLevel` RMS | code |
-| A3 | `repeated_span` principled fix (VAD/segmentation) | release uses non-destructive guardrail (Option A); transcript preserved + loop contained | Dev (STT lane) | VAD/segmentation to prevent loops at decode | code + Test proof |
+| A3 | `repeated_span` principled fix (VAD/segmentation) | release uses the non-destructive guardrail (ambiguous repeated spans preserved, not collapsed); transcript preserved + loop contained | Dev (STT lane) | VAD/segmentation to prevent loops at decode | code + Test proof |
 | A4 | v4 cross-utterance context / decode tuning (#37) | v4 flag-gated / experimental | Dev | continue under v4 lane | code + Test proof |
 | A5 | Test/naming-debt cleanup (chip `task_9633953d` remainder) | rename DONE (#775), collapse moved to util (#773); remaining = consolidate 3 e2e usage-limit mock layers into one + make e2e bootable locally | Dev/Test | consolidate mock source + fix local e2e boot | code (test infra) |
 | A6 | Stale-branch cleanup: 7 `dev/v4-integration`-merged branches + closed `#767` branch | housekeeping; content reaches `main` only when `dev/v4-integration` merges | Test/release-owner | delete after `dev/v4-integration` lands (or convert to tracked) | Ops/Test access |
@@ -64,7 +64,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## C. Prep-only checklist — #2 SLO/SLC (rig verified by Dev; RUN by Test)
 
-> **Status: RUN — PASS.** Test executed service-level evidence on `main@9d4b90be` (run `27468651667` PASS; artifact `7611416017`). Re-dispatch on the current release SHA after PR #777 merges. The rig reference below stays for the re-run.
+> **Status: PASS on `main@9d4b90be` (`27468651667`); RERUN NEEDED.** #777 and #778 have since merged (current `main` = `d06700b5`), so Test should re-dispatch this on post-#778 `main` for final sign-off. The rig reference below stays for the re-run.
 
 - **Commands:** `pnpm ops:health` → `ops-health/ops-health.summary.json`; `pnpm metrics:service-levels` (synthesizes); full dry: `pnpm rc:slo:dry`.
 - **Inputs read by `scripts/write-service-level-evidence.mjs`:** `product_release/evidence/software-quality.latest.json`, `test-results/stress/backend-stress.latest.json`, `test-results/endurance/browser-endurance.latest.json`, `ops-health/ops-health.summary.json`.
@@ -91,6 +91,6 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 ## Dev posture
 
-Active Dev work: **none in flight.** Both #772 failures are fixed: the post-stop doubling (PR #777 `18b2a30f`, merged) and the post-sample empty-visible (PR #778, release-owner-authorized narrow store-reset guard — awaiting Test live-proof rerun). Per release-owner, **#778 is the last authorized product-code fix unless Test finds a new concrete release-blocking failure.**
+Active Dev work: **none in flight.** Both #772 failures are fixed and merged: the post-stop doubling (PR #777 `18b2a30f`) and the post-sample empty-visible (PR #778 `d06700b5`, narrow store-reset guard). Test reruns the #765/#772 live proof on post-#778 `main`. Per release-owner, **#778 is the last authorized product-code fix unless Test finds a new concrete release-blocking failure.**
 
 Reopen Dev work only on: (1) a *new* concrete failure in #777/#778/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (merged + applied, workflow `27470518053` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).

--- a/product_release/RELEASE_CLOSEOUT_LEDGER.md
+++ b/product_release/RELEASE_CLOSEOUT_LEDGER.md
@@ -11,7 +11,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 | Lane | Owner | Goal | State |
 |---|---|---|---|
-| #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`, deploy `27468363004` PASS |
+| #774 db push | Test/Ops | Apply migration + record proof | Done — merged `75fb9ac0`; migration workflow `27470518053` PASS (push-deploy skips DB by design) |
 | #775 merge | Test | Merge after green CI/review | Done — merged `9d4b90be` |
 | #772 visible-final fix | Dev | Fix post-stop visible duplication (display-only) | Done — PR #777 raised; Test to review/merge + rerun proof |
 | #765/#772 proof | Test | Rerun live proof after Dev #772 fix | Pending — rerun on PR #777 |
@@ -28,7 +28,7 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 | #771 recovery actions | Closed — merged | — | `c11789ef` |
 | #773 exact-doubling collapse | Closed — merged (KEEP, do not revert) | — | `8cee74fe` |
 | #774 index dedup + analytics routing | Closed — merged | — | `75fb9ac0` (branch deleted) |
-| #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; Supabase deploy `27468363004` PASS |
+| #774 migration apply (`supabase db push`) | Closed — merged | — | migration `20260613100000`; dispatched migration workflow `27470518053` PASS (deploy-production-db + push-migrations PASS) |
 | #775 canUsePrivate split + SunsetModals fix | Closed — merged | — | `9d4b90be`; deploy `27468389396`, canary `27468389402`, main CI `27468389406` PASS |
 | #772 post-stop visible-final repetition | Open — active Dev→Test (PR #777) | Dev (fix) → Test (proof) | display-only collapse in settled view; panel 48/48, affected 85/85, tsc+eslint+build OK; saved transcript untouched |
 | #765/#772 first-time-sample proof | Open — active Test | Test | rerun live proof on PR #777; expect `visibleFinalMatchesSave=true` (Section C) |
@@ -91,4 +91,4 @@ _Last refreshed: 2026-06-13 (post #774/#775 merge; #772 Dev fix raised as PR #77
 
 Open — active Dev work: **one** — #772 post-stop visible-final repetition (concrete Test-routed failure), fixed display-only in **PR #777**, awaiting Test review/merge + live-proof rerun. After PR #777 lands, Dev returns to review/support-only.
 
-Reopen further Dev work only on: (1) a concrete failure in #777/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (currently merged + applied, deploy `27468363004` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).
+Reopen further Dev work only on: (1) a concrete failure in #777/#765/#772 under the live proof; (2) Test/Ops hits a concrete #774 migration-apply blocker (currently merged + applied, migration workflow `27470518053` PASS — not expected); (3) release-owner assigns a specific backlog item. Dev will not mutate the saved/stored transcript, implement fuzzy collapse, collapse ambiguous `repeated_span`, broaden the entitlement refactor, touch Group D, reopen #85, or start speculative cleanup. #773 stays (no revert).


### PR DESCRIPTION
Dev-owned closeout per release-owner directive (docs-only, no code). Backlog/disposition ledger (every deferred item: why non-blocking, post-release owner, next action, needs code/Test/Product/Ops), documentation-gap closures (#1/#4/#5/#6/#85), and prep-only checklists for #2 SLO/SLC and #3 Stripe live cutover (Dev verified paths/commands; touched no live keys; Test/Ops run the actual proofs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)