### PR TITLE
fix(stt): collapse post-stop visible final repetition (display-only) (#772)

### DIFF
--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Lock, Cloud } from 'lucide-react';
 import { TEST_IDS } from '@/constants/testIds';
 import { SESSION_INSET_SURFACE_CLASS, SESSION_SURFACE_CLASS } from './sessionSurface';
-import { splitSettledActiveTranscript, hasSevereRepetitionLoop } from './liveTranscriptUtils';
+import { splitSettledActiveTranscript, hasSevereRepetitionLoop, collapseRepeatedFinalForDisplay } from './liveTranscriptUtils';
 
 import { parseTranscriptForHighlighting } from '@/utils/highlightUtils';
 
@@ -83,7 +83,17 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
 }) => {
     const internalContainerRef = React.useRef<HTMLDivElement>(null);
     const transcriptContainerRef = containerRef ?? internalContainerRef;
-    const tokens = parseTranscriptForHighlighting(transcript, userWords);
+    // #772 DISPLAY-ONLY: in the settled (post-stop) view, collapse an exact whole-text
+    // repetition doubling so the VISIBLE final matches the SAVED transcript. The committed
+    // store can briefly hold a doubled streaming hypothesis after stop while the saved/detail
+    // transcript is the clean final. This never mutates stored/saved text — only what is
+    // rendered. During listening/finalizing the withhold-loop guard below handles unstable
+    // text, so we leave the raw committed transcript untouched there.
+    const isSettledView = !isListening && !isFinalizing;
+    const committedForDisplay = isSettledView
+        ? collapseRepeatedFinalForDisplay(transcript)
+        : transcript;
+    const tokens = parseTranscriptForHighlighting(committedForDisplay, userWords);
     const hasTranscript = transcript.trim() !== '';
     const displayInterimTranscript =
         transcript.trim() === interimTranscript.trim() ? '' : interimTranscript;
@@ -120,7 +130,7 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
     const showDraftTrustBanner = isListening && !isFinalizing;
     const showPrivateFeedback = isPrivateMode && isListening;
     const privateStatus = hasTranscript || hasInterimTranscript ? 'Live text' : 'Private local';
-    const visibleTranscript = [transcript.trim(), displayInterimTranscript.trim()].filter(Boolean).join(' ').trim();
+    const visibleTranscript = [committedForDisplay.trim(), displayInterimTranscript.trim()].filter(Boolean).join(' ').trim();
     const finalizingBannerText = isPrivateMode ? 'Processing speech locally…' : 'Processing transcript…';
     const finalizingEmptyTitle = isPrivateMode ? 'Finalizing local transcript…' : 'Finalizing transcript…';
     const finalizingEmptyDescription = isPrivateMode
@@ -228,11 +238,14 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
             */}
             <span
                 data-testid="transcript-text-only"
+                // Attribute keeps the RAW committed-store text as non-destructive evidence
+                // (proves the #772 fix is display-only); the rendered text is the settled-view
+                // display value that matches the SAVED transcript.
                 data-transcript-text-only={transcript.trim()}
                 className="sr-only"
                 aria-hidden="true"
             >
-                {transcript.trim()}
+                {committedForDisplay.trim()}
             </span>
             <div className="mb-2 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -725,6 +725,64 @@ describe('LiveTranscriptPanel', () => {
             expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER).textContent).toMatch(/it'?s a question/i);
         });
 
+        describe('#772 post-stop visible final repetition (display-only)', () => {
+            // Real #772 live-proof shape (run 27468782976): the SAVED/detail transcript is the clean
+            // single sentence, while the committed store briefly holds a DOUBLED streaming hypothesis
+            // after stop (a late v4 update re-doubles it). The post-stop VISIBLE final must match the
+            // SAVED text. The fix is DISPLAY-ONLY: the stored/saved transcript is never mutated.
+            const SAVED = 'We should literally like, wait, um, basically.';
+            const DOUBLED = 'We should literally like, wait, um, basically, we should literally like, wait, um, basically.';
+
+            it('shows the single saved sentence (not the doubled text) in the post-stop final view', () => {
+                render(
+                    <LiveTranscriptPanel
+                        transcript={DOUBLED}
+                        interimTranscript=""
+                        isListening={false}
+                        isFinalizing={false}
+                        sttMode="private"
+                    />
+                );
+                const container = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
+                expect(container).toHaveAttribute('data-transcript-state', 'final');
+                // The clean read surface the live proof scrapes equals the SAVED transcript.
+                expect(screen.getByTestId('transcript-text-only').textContent?.trim()).toBe(SAVED);
+                // The looped sentence appears exactly once on the visible surface.
+                const reps = (container.textContent?.match(/we should literally like/gi) || []).length;
+                expect(reps).toBe(1);
+            });
+
+            it('preserves the raw committed store transcript as non-destructive evidence', () => {
+                render(
+                    <LiveTranscriptPanel
+                        transcript={DOUBLED}
+                        interimTranscript=""
+                        isListening={false}
+                        isFinalizing={false}
+                        sttMode="private"
+                    />
+                );
+                // Display-only: the committed store data hook still exposes the raw (doubled) text,
+                // proving nothing was deleted from the stored/saved transcript.
+                expect(screen.getByTestId('transcript-text-only'))
+                    .toHaveAttribute('data-transcript-text-only', DOUBLED.trim());
+            });
+
+            it('does not alter a clean (non-looped) final transcript', () => {
+                const clean = 'We practiced the opening line and the timing felt much better today.';
+                render(
+                    <LiveTranscriptPanel
+                        transcript={clean}
+                        interimTranscript=""
+                        isListening={false}
+                        isFinalizing={false}
+                        sttMode="private"
+                    />
+                );
+                expect(screen.getByTestId('transcript-text-only').textContent?.trim()).toBe(clean);
+            });
+        });
+
         describe('hasSevereRepetitionLoop detector', () => {
             it('flags a severe repetition loop', () => {
                 expect(hasSevereRepetitionLoop('Love from a return. ' + "It's a question. ".repeat(28))).toBe(true);

--- a/frontend/src/components/session/liveTranscriptUtils.ts
+++ b/frontend/src/components/session/liveTranscriptUtils.ts
@@ -1,3 +1,31 @@
+import { collapseTranscriptRepetitionLoops } from '@/utils/repetitionRisk';
+
+/**
+ * #772 DISPLAY-ONLY post-stop repetition collapse for the settled (final) view.
+ *
+ * After Stop, the committed store can briefly hold a DOUBLED streaming hypothesis
+ * (a late v4 update re-doubles it), while the SAVED/detail transcript is the clean
+ * collapsed final. The post-stop visible final must match the saved transcript, so
+ * here we collapse the SAME exact whole-text doubling / >=3x adjacent loop accepted in
+ * #773 — purely for rendering. The stored/saved transcript is NEVER mutated. We do NOT
+ * collapse ambiguous interleaved spans, and there is NO fuzzy de-duplication.
+ *
+ * Collapse cuts at the loop seam, which can leave a trailing separator (e.g. the join
+ * comma in "…basically, …basically." -> "…basically,"). Only WHEN a loop was actually
+ * collapsed do we restore terminal punctuation so the visible final matches the saved
+ * transcript (which is terminal-punctuated at the save boundary). A clean, non-looped
+ * transcript is returned untouched.
+ */
+export function collapseRepeatedFinalForDisplay(text: string): string {
+    const raw = (text || '').trim();
+    if (!raw) return raw;
+    const collapsed = collapseTranscriptRepetitionLoops(raw).trim();
+    if (collapsed === raw) return raw; // no loop collapsed — leave display untouched
+    if (/[,:;]$/.test(collapsed)) return `${collapsed.slice(0, -1)}.`;
+    if (!/[.!?]["'’”)\]]?$/.test(collapsed)) return `${collapsed}.`;
+    return collapsed;
+}
+
 /**
  * Split live draft text into completed sentences ("settled" — render calm/recognized)
  * and the trailing in-progress sentence ("active" — render as Draft). Live-view only:


### PR DESCRIPTION
## Summary

Fixes the concrete visible product failure from #772 live proof `27468782976`: the saved/detail transcript was the clean single sentence, but the **post-stop visible final** showed the whole text **doubled** (`visibleFinalMatchesSave=false`, `finalTranscriptPreserved=true`).

**Failure class: display-only duplication.** The saved transcript is preserved; only the post-stop visible surface was wrong.

## Root cause

After Stop, the committed store can briefly hold a doubled streaming hypothesis (a late v4 update re-doubles it after the controller writes the clean final at `SpeechRuntimeController` L2084). The existing withhold-loop guard (`LIVE-TRANSCRIPT-REPEATED-DISPLAY`) only fires during `isListening || isFinalizing`, so the **settled (post-stop final) view** renders the committed store unfiltered.

## Fix (display-only — saved transcript never mutated)

In the settled view, `LiveTranscriptPanel` renders the committed transcript through `collapseRepeatedFinalForDisplay` — the **same conservative exact whole-text doubling / ≥3× adjacent collapse accepted in #773**. Terminal punctuation is restored only when a loop was actually collapsed, so the visible final matches the saved transcript; a clean transcript renders unchanged. The `data-transcript-text-only` attribute still exposes the RAW committed text as non-destructive evidence.

### Policy compliance
- No fuzzy de-duplication.
- Ambiguous interleaved `repeated_span` is **not** collapsed (guardrail-only stays).
- Stored/saved transcript is never mutated.
- #773 stays (no revert).

## Verification (reproduce-first)
- New failing-before test: post-stop visible final equals the saved single sentence (was the doubled text) + non-destructive-evidence + clean-final guards.
- `LiveTranscriptPanel.component.test.tsx`: **48/48**.
- Affected suites (panel + TranscriptPanel + repetitionRisk + SessionPage ui/feedback + TranscriptionService.pause): **85/85**.
- `tsc` clean, `eslint` clean, production build OK.

## How Test should rerun
Rerun the #765/#772 first-time-sample live proof; `postStopTranscriptText` should now equal `selectedForSave` (`visibleFinalMatchesSave=true`), with the saved/detail transcript unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)