### PR TITLE
fix(stt): keep saved transcript visible after Private sample auto-save (#772)

### DIFF
--- a/frontend/src/stores/__tests__/useSessionStore.test.ts
+++ b/frontend/src/stores/__tests__/useSessionStore.test.ts
@@ -129,6 +129,48 @@ describe('useSessionStore', () => {
             });
             expect(useSessionStore.getState().frozenTranscriptAtStop).toBe('Already committed still speaking');
         });
+
+        it('keeps the just-saved transcript visible when a Private sample auto-save forces a Browser fallback switch', () => {
+            // When a first-time Private sample auto-ends and saves, the app force-switches the
+            // mode to native/browser. The transcript the tester just recorded must stay visible
+            // on the session page (it is saved + correct in Analytics) until the next recording.
+            useSessionStore.setState({
+                runtimeState: 'READY',
+                sttMode: 'private',
+                sessionSaved: true,
+                transcript: { transcript: 'We should literally like, wait, um, basically.', partial: '' },
+                isTranscriptFinalizing: false,
+                frozenTranscriptAtStop: null,
+            });
+
+            useSessionStore.getState().setSTTMode('native');
+
+            const state = useSessionStore.getState();
+            expect(state.sttMode).toBe('native');
+            expect(state.transcript).toEqual({
+                transcript: 'We should literally like, wait, um, basically.',
+                partial: '',
+            });
+            expect(state.sessionSaved).toBe(true);
+        });
+
+        it('still clears the visible session on an ordinary mode switch before a session is saved', () => {
+            // No save has happened yet: switching modes should reset the in-progress draft as before.
+            useSessionStore.setState({
+                runtimeState: 'READY',
+                sttMode: 'native',
+                sessionSaved: false,
+                transcript: { transcript: 'unsaved draft text', partial: 'still going' },
+                isTranscriptFinalizing: false,
+                frozenTranscriptAtStop: null,
+            });
+
+            useSessionStore.getState().setSTTMode('private');
+
+            const state = useSessionStore.getState();
+            expect(state.sttMode).toBe('private');
+            expect(state.transcript).toEqual({ transcript: '', partial: '' });
+        });
     });
 
     describe('updateFillerData', () => {

--- a/frontend/src/stores/useSessionStore.ts
+++ b/frontend/src/stores/useSessionStore.ts
@@ -245,7 +245,12 @@ export const useSessionStore = create<SessionStore>((set) => {
             const resetVisibleSession =
                 state.runtimeState !== 'RECORDING' &&
                 !state.isTranscriptFinalizing &&
-                !state.frozenTranscriptAtStop;
+                !state.frozenTranscriptAtStop &&
+                // #772: when a Private sample auto-ends + saves, the app force-switches the mode
+                // to native/browser. Don't wipe the just-saved transcript on that switch — keep it
+                // visible on /session until the next recording (which resets via
+                // resetAnalysisStateForNewRecording). Saved data is untouched either way.
+                !state.sessionSaved;
             const next = {
                 ...state,
                 sttMode: mode,


### PR DESCRIPTION
## Summary

Fixes the #772 post-sample **empty visible transcript** failure from live rerun `27472526881` (after #777 merged): the saved transcript was correct in Analytics/detail, but `/session` reset to the idle placeholder (`postStopTranscriptText=""`, `visibleFinalMatchesSave=false`).

## Root cause

When a first-time Private **sample auto-ends and saves**, the app force-switches the mode to native/browser (`useSessionLifecycle` `shouldForceNativeMode` -> `setSTTMode('native')`). The store's `setSTTMode` reset (`resetVisibleSession`) then wiped the just-saved transcript — the reset guard did not account for a session that had **just been saved**.

## Fix — one narrow store guard

Add `!state.sessionSaved` to `resetVisibleSession` (`useSessionStore.setSTTMode`). The forced post-save mode switch now keeps the saved transcript visible on `/session`. It remains until the next recording, which already clears everything via `resetAnalysisStateForNewRecording` (`updateTranscript('')` + `setSessionSaved(false)`). `RECORDING`/finalizing/frozen guards are unchanged.

### Proven behaviors
- Saved transcript stays visible on `/session` after a sample auto-save + forced Browser switch.
- Saved transcript **data is untouched** (this only affects whether the visible session is reset).
- The **next recording** still starts fresh (`resetAnalysisStateForNewRecording`).
- An **ordinary mode switch before any save** still resets the in-progress draft (`sessionSaved=false`).
- No non-sample-path regression.

### Constraints honored
No saved-data mutation · no fuzzy de-dup · no `repeated_span` collapse · #773 kept · no lifecycle refactor (one guard condition) · no entitlement/Stripe/Group D changes.

## Verification (reproduce-first)
- New store test: saved transcript survives the forced Browser-fallback switch (failed before, passes after) + no-regression test that an unsaved draft still clears.
- `useSessionStore`: **18/18**.
- Affected suites: **92/92** (store + `useSessionLifecycle` + `SessionPage` ui/feedback + `LiveTranscriptPanel`).
- `tsc` clean, `eslint` clean, production build OK.

## How Test should rerun
Rerun the #765/#772 first-time-sample live proof; `postStopTranscriptText` should now equal the saved final (`visibleFinalMatchesSave=true`), with saved/detail unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
