### PR TITLE
feat(stt): converge dormant flag-OFF v4 infrastructure onto main (closes dev/v4-integration)

### DIFF
--- a/frontend/src/services/transcription/__tests__/privateV4Experiment.test.ts
+++ b/frontend/src/services/transcription/__tests__/privateV4Experiment.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getV4ExperimentOverrides } from '../privateV4Experiment';
+
+// Injectable window (matches the codebase pattern, e.g. collectSttIdentityFromWindow) so
+// the reader is testable without happy-dom history/location plumbing.
+function mockWin(search: string, storage: Record<string, string> = {}): Window {
+    return {
+        location: { search } as Location,
+        localStorage: { getItem: (k: string) => storage[k] ?? null } as unknown as Storage,
+    } as unknown as Window;
+}
+
+describe('getV4ExperimentOverrides — dev/test-gated v4 decode A/B knobs', () => {
+    // gate = import.meta.env.DEV || ENV.isTest; __TEST__ keeps the gate open in unit tests.
+    beforeEach(() => { (globalThis as { __TEST__?: boolean }).__TEST__ = true; });
+    afterEach(() => { (globalThis as { __TEST__?: boolean }).__TEST__ = true; });
+
+    it('defaults to no overrides', () => {
+        expect(getV4ExperimentOverrides(mockWin(''))).toEqual({ noWorker: false, forceAuto: false });
+    });
+
+    it('reads device + decoderDtype + variant + noWorker from query params', () => {
+        expect(getV4ExperimentOverrides(mockWin('?v4Device=wasm&v4DecoderDtype=fp32&v4Variant=distil_q4&v4NoWorker=1')))
+            .toEqual({ device: 'wasm', decoderDtype: 'fp32', variant: 'distil_q4', noWorker: true, forceAuto: false });
+    });
+
+    it('reads v4ForceAuto (the headless-CI AUTO fallback knob)', () => {
+        expect(getV4ExperimentOverrides(mockWin('?v4ForceAuto=1&v4Device=wasm')))
+            .toEqual({ device: 'wasm', noWorker: false, forceAuto: true });
+    });
+
+    it('falls back to localStorage when no query param', () => {
+        expect(getV4ExperimentOverrides(mockWin('', { 'speaksharp.v4.device': 'webgpu', 'speaksharp.v4.decoderDtype': 'int8', 'speaksharp.v4.variant': 'base_q4', 'speaksharp.v4.forceAuto': '1' })))
+            .toEqual({ device: 'webgpu', decoderDtype: 'int8', variant: 'base_q4', noWorker: false, forceAuto: true });
+    });
+
+    it('rejects invalid device/dtype/variant values', () => {
+        expect(getV4ExperimentOverrides(mockWin('?v4Device=banana&v4DecoderDtype=fp64&v4Variant=turbo'))).toEqual({ noWorker: false, forceAuto: false });
+    });
+
+    it('undefined window -> no overrides', () => {
+        expect(getV4ExperimentOverrides(undefined)).toEqual({ noWorker: false, forceAuto: false });
+    });
+});

--- a/frontend/src/services/transcription/__tests__/privateV4Telemetry.test.ts
+++ b/frontend/src/services/transcription/__tests__/privateV4Telemetry.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const captureMock = vi.fn();
+vi.mock('posthog-js', () => ({
+    default: {
+        capture: (...args: unknown[]) => captureMock(...args),
+    },
+}));
+vi.mock('@/lib/logger', () => ({
+    default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+    sanitizeV4TelemetryProps,
+    emitV4Telemetry,
+    emitV4Ready,
+    emitV4DecodeComplete,
+    emitV4Fallback,
+    emitV4SessionSaved,
+    emitV4Error,
+    buildV4LifecycleProps,
+    V4_TELEMETRY_EVENTS,
+    V4_TELEMETRY_ALLOWED_PROPS,
+} from '../privateV4Telemetry';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('sanitizeV4TelemetryProps — privacy allowlist', () => {
+    it('keeps every allowlisted non-PII property', () => {
+        const input = {
+            engine: 'transformers-js-v4',
+            variant: 'base_q4',
+            model: 'onnx-community/whisper-base.en',
+            dtype: 'encoder_model=fp32,decoder_model_merged=q4',
+            requestedDevice: 'webgpu',
+            resolvedDevice: 'webgpu',
+            webgpuAvailable: true,
+            fallbackAttempted: false,
+            fallbackReason: null,
+            loadMs: 1200,
+            decodeMs: 800,
+            rtf: 0.4,
+            recordStarted: true,
+            stopSucceeded: true,
+            saved: true,
+            historyOpened: false,
+            errorClass: 'TimeoutError',
+        };
+        const out = sanitizeV4TelemetryProps(input);
+        expect(out).toEqual(input);
+        expect(Object.keys(out).sort()).toEqual([...V4_TELEMETRY_ALLOWED_PROPS].sort());
+    });
+
+    it('DROPS PII / unsafe keys (email, transcript, audio, raw stack, secrets, provider payload)', () => {
+        const out = sanitizeV4TelemetryProps({
+            variant: 'base_q4',
+            email: 'user@example.com',
+            transcript: 'the user said something private',
+            audio: new Float32Array(16000),
+            stack: 'Error: boom\n at foo (x.ts:1:1)',
+            errorStack: 'Error: boom\n at bar',
+            sk_live: 'sk_live_abc123',
+            providerPayload: { nested: 'secret' },
+            userId: 'user-uuid-123',
+            distinctId: 'abc',
+        });
+        expect(out).toEqual({ variant: 'base_q4' });
+        for (const banned of ['email', 'transcript', 'audio', 'stack', 'errorStack', 'sk_live', 'providerPayload', 'userId', 'distinctId']) {
+            expect(out).not.toHaveProperty(banned);
+        }
+    });
+
+    it('drops objects/arrays even under an allowlisted key (no nested PII can ride along)', () => {
+        const out = sanitizeV4TelemetryProps({
+            variant: { evil: 'object' } as unknown as string,
+            model: ['array'] as unknown as string,
+            loadMs: 10,
+        });
+        expect(out).toEqual({ loadMs: 10 });
+    });
+
+    it('omits undefined but preserves null', () => {
+        const out = sanitizeV4TelemetryProps({ variant: undefined, fallbackReason: null, loadMs: 0 });
+        expect(out).toEqual({ fallbackReason: null, loadMs: 0 });
+        expect(out).not.toHaveProperty('variant');
+    });
+
+    it('returns empty object for undefined/empty input', () => {
+        expect(sanitizeV4TelemetryProps(undefined)).toEqual({});
+        expect(sanitizeV4TelemetryProps({})).toEqual({});
+    });
+
+    it('allowlist contains no obviously-PII keys', () => {
+        for (const banned of ['email', 'transcript', 'audio', 'stack', 'userId', 'token', 'secret']) {
+            expect(V4_TELEMETRY_ALLOWED_PROPS as readonly string[]).not.toContain(banned);
+        }
+    });
+});
+
+describe('emitV4Telemetry — events + capture', () => {
+    it('exposes exactly the six Stage-B event names', () => {
+        expect(V4_TELEMETRY_EVENTS).toEqual({
+            ATTEMPT: 'private_stt_v4_attempt',
+            READY: 'private_stt_v4_ready',
+            DECODE_COMPLETE: 'private_stt_v4_decode_complete',
+            FALLBACK: 'private_stt_v4_fallback',
+            SESSION_SAVED: 'private_stt_v4_session_saved',
+            ERROR: 'private_stt_v4_error',
+        });
+    });
+
+    it('captures the event with sanitized props only (PII stripped before send)', () => {
+        emitV4Telemetry(V4_TELEMETRY_EVENTS.READY, {
+            variant: 'base_q4',
+            loadMs: 900,
+            email: 'leak@example.com',
+            transcript: 'secret words',
+        });
+        expect(captureMock).toHaveBeenCalledTimes(1);
+        const [event, props] = captureMock.mock.calls[0];
+        expect(event).toBe('private_stt_v4_ready');
+        expect(props).toEqual({ variant: 'base_q4', loadMs: 900 });
+        expect(props).not.toHaveProperty('email');
+        expect(props).not.toHaveProperty('transcript');
+    });
+
+    it('convenience emitters fire the correct event names', () => {
+        emitV4Ready({ variant: 'base_q4' });
+        emitV4DecodeComplete({ decodeMs: 700, rtf: 0.3 });
+        emitV4Fallback({ fallbackAttempted: true, fallbackReason: 'v4_init_failed' });
+        emitV4SessionSaved({ saved: true });
+        emitV4Error({ errorClass: 'LoadError' });
+        const events = captureMock.mock.calls.map((c) => c[0]);
+        expect(events).toEqual([
+            'private_stt_v4_ready',
+            'private_stt_v4_decode_complete',
+            'private_stt_v4_fallback',
+            'private_stt_v4_session_saved',
+            'private_stt_v4_error',
+        ]);
+    });
+
+    it('never throws when posthog.capture throws (telemetry must not break the STT path)', () => {
+        captureMock.mockImplementationOnce(() => { throw new Error('posthog down'); });
+        expect(() => emitV4Ready({ variant: 'base_q4' })).not.toThrow();
+    });
+});
+
+describe('buildV4LifecycleProps — pure mapper (allowlisted, fallbackAttempted derived)', () => {
+    it('maps a successful v4 decision to allowlisted props (fallbackAttempted=false)', () => {
+        const props = buildV4LifecycleProps({
+            finalEngine: 'transformers-js-v4',
+            variant: 'base_q4',
+            model: 'onnx-community/whisper-base.en',
+            dtype: '{"encoder_model":"fp32","decoder_model_merged":"q4"}',
+            requestedDevice: 'webgpu',
+            resolvedDevice: 'webgpu',
+            webgpuAvailable: true,
+            fallbackReason: null,
+            loadMs: 1200,
+        });
+        expect(props).toEqual({
+            engine: 'transformers-js-v4',
+            variant: 'base_q4',
+            model: 'onnx-community/whisper-base.en',
+            dtype: '{"encoder_model":"fp32","decoder_model_merged":"q4"}',
+            requestedDevice: 'webgpu',
+            resolvedDevice: 'webgpu',
+            webgpuAvailable: true,
+            fallbackAttempted: false,
+            fallbackReason: null,
+            loadMs: 1200,
+        });
+    });
+
+    it('derives fallbackAttempted=true when a fallback reason is present', () => {
+        const props = buildV4LifecycleProps({
+            finalEngine: 'transformers-js',
+            variant: 'base_q4',
+            fallbackReason: 'v4_init_failed',
+            loadMs: 50,
+        });
+        expect(props.fallbackAttempted).toBe(true);
+        expect(props.fallbackReason).toBe('v4_init_failed');
+        expect(props.engine).toBe('transformers-js');
+    });
+
+    it('omits undefined inputs and carries no key outside the allowlist', () => {
+        const props = buildV4LifecycleProps({ variant: 'base_q4' });
+        for (const key of Object.keys(props)) {
+            expect(V4_TELEMETRY_ALLOWED_PROPS as readonly string[]).toContain(key);
+        }
+        expect(props).not.toHaveProperty('requestedDevice'); // undefined input dropped
+    });
+});

--- a/frontend/src/services/transcription/engines/PrivateSTT.ts
+++ b/frontend/src/services/transcription/engines/PrivateSTT.ts
@@ -1,6 +1,7 @@
 /**
- * 🚨 READ-ONLY: This file is part of the core engine routing logic.
- * No modifications are allowed unless directed by User.
+ * ⚠️ CORE ENGINE ROUTING. Simple/localized changes are OK; notify the User
+ * if a design or significant change (engine-selection semantics, fallback policy,
+ * or the manifest control-plane contract).
  * 
  * Frozen Gate: Authoritative STT engine selection.
  * Ensures the manifest is the sole control plane for engine intent.
@@ -35,13 +36,18 @@ import { IPrivateSTTEngine, EngineType } from '@/contracts/IPrivateSTTEngine';
 import { STTEngine, validateEngine } from '@/contracts/STTEngine';
 import { PrivateSTTInitOptions } from '@/contracts/IPrivateSTT';
 import logger from '@/lib/logger';
+import posthog from 'posthog-js';
+import { ENV } from '@/config/TestFlags';
 import { ModelManager } from '@/services/transcription/ModelManager';
 import { MicStream } from '@/services/transcription/utils/types';
 import { getEngine } from '@/services/transcription/STTRegistry';
-import { PRIV_STT_V4 } from '../sttConstants';
+import { PRIV_STT_V4, PRIV_STT_V4_DEFAULT_VARIANT, PRIV_STT_V4_VARIANTS, PRIVATE_ENGINE_OVERRIDE_KEY } from '../sttConstants';
 import { getDefaultProviderForMode, getProviderIdsForMode } from '../providers/sttProviderConfig';
 import type { PrivateSttProvider } from '../providers/types';
 import { resolvePrivateRuntimePath, type PrivateRuntimeDecision } from '../utils/privateRuntimePath';
+import { getV4FlagState } from '../privateV4Flags';
+import { getV4ExperimentOverrides } from '../privateV4Experiment';
+import { buildV4LifecycleProps, emitV4Ready, emitV4Fallback, emitV4Error } from '../privateV4Telemetry';
 // Stale import removed
 
 declare global {
@@ -54,8 +60,6 @@ declare global {
         __PRIVATE_STT_RUNTIME_DEBUG__?: PrivateRuntimeDecision & { selectedAt: string };
     }
 }
-
-const PRIVATE_ENGINE_OVERRIDE_KEY = 'speaksharp.private.engine';
 
 /**
  * Publish the resolved runtime decision to a stable window debug object so the
@@ -86,8 +90,23 @@ function getConfiguredPrivateEngine(): PrivateEngineType {
     return provider;
 }
 
+/**
+ * Whether the explicit private-engine override (`?privateEngine` / localStorage) may
+ * be honored. MERGE-SAFETY: this is a DEV / TEST / E2E affordance ONLY. In a production
+ * build a normal user must NOT be able to force an engine (e.g. v4) via a public URL or
+ * localStorage and thereby bypass the PostHog flag. `import.meta.env.DEV` is the dev
+ * server; `ENV.isTest` covers unit + E2E. Both are false in the production build, so a
+ * normal production user always falls through to the flag-gated resolver (v2-base when
+ * flags are off). `forceEngine` (a programmatic option, not publicly settable) is
+ * unaffected and still honored.
+ */
+function isPrivateOverrideContextAllowed(): boolean {
+    return import.meta.env.DEV === true || ENV.isTest;
+}
+
 function getPrivateEngineOverride(): PrivateEngineType | null {
     if (typeof window === 'undefined') return null;
+    if (!isPrivateOverrideContextAllowed()) return null;
 
     const queryValue = new URLSearchParams(window.location.search).get('privateEngine');
     const storedValue = window.localStorage.getItem(PRIVATE_ENGINE_OVERRIDE_KEY);
@@ -103,6 +122,11 @@ function getPrivateEngineOverride(): PrivateEngineType | null {
 /**
  * Dual-engine Private STT facade
  */
+/** Upper bound on a v4 AUTO-path decode. A base_q4-on-WASM decode can HANG and never return;
+ *  past this bound we treat it as a failure and fall back to v2-base. Kept comfortably under the
+ *  app-path proof's first-text window so the v2 re-transcribe still fits inside it. */
+const V4_AUTO_DECODE_TIMEOUT_MS = 40_000;
+
 export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscriptionEngine {
     public readonly type: EngineType = 'transformers-js'; // Primary type for this facade
 
@@ -111,6 +135,9 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
     protected serviceId: string = 'unknown';
     protected runId: string = 'unknown';
     private runtimePath: PrivateRuntimeDecision | null = null;
+    // True ONLY when the AUTO (flag) path successfully initialized v4. Gates the
+    // decode-time fallback to v2-base; the strict explicit-override path never sets it.
+    private v4AutoFallbackEligible = false;
 
     /**
      * PrivateSTT manages the dual-engine strategy for on-device transcription.
@@ -144,6 +171,7 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
 
         this.serviceId = options.serviceId || 'unknown';
         this.runId = options.runId || 'unknown';
+        this.v4AutoFallbackEligible = false; // reset per init; only auto-path v4 success re-enables
 
         logger.info({ sId: this.serviceId, rId: this.runId }, '[PrivateSTT] 🚀 Privacy-first engine selection started...');
 
@@ -195,9 +223,23 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
         // surface the error rather than loop.
         const autoEngine = await this.resolveAutoPrivateEngine(selectedEngine);
         logger.info({ sId: this.serviceId, rId: this.runId, provider: autoEngine, configured: selectedEngine, source: 'auto' }, '[PrivateSTT] Initializing auto-selected private provider');
+        const initStart = performance.now();
         const primary = await this.initSelectedEngine(autoEngine, timeoutMs, isMock);
         if (primary.isOk) {
+            // Eligible for a one-shot decode-time fallback ONLY when the AUTO path chose v4.
+            this.v4AutoFallbackEligible = autoEngine === 'transformers-js-v4';
+            this.emitV4FlagTelemetry(null, Math.round(performance.now() - initStart));
             return Result.ok(undefined);
+        }
+
+        // v4 → v2-base fallback (AUTO path only; the explicit-override path stays
+        // strict). A flagged v4 user must never be stranded: if v4 init/load fails,
+        // fall back to the proven v2-base engine.
+        if (autoEngine === 'transformers-js-v4') {
+            logger.warn({ sId: this.serviceId, rId: this.runId, error: (primary as { error?: Error }).error }, '[PrivateSTT] v4 init failed; falling back to v2-base');
+            const fallback = await this.initSafeEngine(timeoutMs, isMock);
+            this.emitV4FlagTelemetry('v4_init_failed', Math.round(performance.now() - initStart));
+            return fallback.isOk ? Result.ok(undefined) : (fallback as Result<void, Error>);
         }
 
         return primary as Result<void, Error>;
@@ -227,11 +269,105 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
      * ever promoted when its model was pre-cached, which no production flow did.
      */
     private async resolveAutoPrivateEngine(configured: SelectedPrivateEngine): Promise<SelectedPrivateEngine> {
-        const decision = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false });
+        // v4 flag-gated tiering (post-paid-soft-launch). When the flag is OFF, `v4`
+        // is omitted, so the resolver returns the EXACT v2/CPU decision as before —
+        // flag-off is byte-identical to the v2-base default (no v4 ever selected).
+        const v4Flags = getV4FlagState();
+        // DEV/TEST-only force-AUTO knob: attempt v4 on the AUTO path even without WebGPU so
+        // headless CI can prove the decode-fallback contract. Inert in production.
+        const v4Experiment = getV4ExperimentOverrides();
+        const forceAuto = v4Experiment.forceAuto;
+        // Gate A candidate selection uses the dev/test forceAuto shim and must be able to compare
+        // base_q4 vs distil_q4 under identical WebGPU conditions. This variant override is honored
+        // ONLY when forceAuto is active; real PostHog selection still uses the real distil flag.
+        const distilEnabled = v4Flags.distilEnabled || (forceAuto && v4Experiment.variant === 'distil_q4');
+        const decision = await resolvePrivateRuntimePath({
+            webgpuPromotionAllowed: false,
+            turboModelCached: false,
+            v4: (v4Flags.v4Enabled || forceAuto)
+                ? {
+                    enabled: true,
+                    distilEnabled,
+                    forceAuto,
+                    // Honest provenance: the REAL flag wins when on (even if forceAuto is also set);
+                    // forceAuto-only is the dev/test harness shim. This — not `reason` — drives the
+                    // artifact's selectionSource, since on real WebGPU `reason` is identical for both.
+                    selectionSource: v4Flags.v4Enabled ? 'posthog_flag' : 'dev_harness',
+                  }
+                : undefined,
+        });
         this.runtimePath = decision;
         publishPrivateRuntimeDebug(decision);
         logger.info({ sId: this.serviceId, rId: this.runId, runtimeDecision: decision, configured }, '[PrivateSTT] Resolved private runtime decision');
+
+        // Route to v4 ONLY when the resolver actually selected it (flag on + confirmed
+        // WebGPU). Otherwise stay on the configured v2 engine. v4 init failure falls
+        // back to v2-base in onInit (auto path only).
+        if (decision.provider === 'transformers-js-v4') {
+            return 'transformers-js-v4';
+        }
         return configured;
+    }
+
+    /**
+     * Internal-only v4 flag telemetry. Emitted only when the v4 flag is on, so the
+     * default v2 path stays silent. Records the attempted/selected variant, device,
+     * and any fallback reason — never user-facing engine internals. Never throws.
+     */
+    private emitV4FlagTelemetry(fallbackReason: string | null, loadMs?: number, errorClass?: string | null): void {
+        try {
+            const flags = getV4FlagState();
+            if (!flags.v4Enabled) return;
+            const d = this.runtimePath;
+            const variant = d?.v4Variant ?? null;
+            const variantCfg = variant ? PRIV_STT_V4_VARIANTS[variant] : null;
+            const payload = {
+                v4FlagEnabled: flags.v4Enabled,
+                distilFlagEnabled: flags.distilEnabled,
+                // Provenance of the selection so evidence can distinguish a REAL PostHog-flag
+                // selection from the dev/test forceAuto shim. Read from the decision (computed at
+                // selection time from flag-vs-forceAuto) — NOT derived from `reason`, which on real
+                // WebGPU reads `webgpu_available_v4_flag` for forceAuto too and would mislabel it.
+                selectionSource: d?.selectionSource ?? 'posthog_flag',
+                selectedVariant: variant,
+                model: variantCfg?.MODEL_ID ?? null,
+                dtype: variantCfg ? JSON.stringify(variantCfg.DTYPE) : null,
+                requestedDevice: d?.provider === 'transformers-js-v4' ? 'webgpu' : 'cpu',
+                resolvedDevice: d?.runtime ?? null,
+                attemptedProvider: d?.provider ?? null,
+                finalProvider: this._engineType ?? null,
+                fallbackProvider: fallbackReason ? (this._engineType ?? null) : null,
+                fallbackReason,
+                loadMs: loadMs ?? null,
+                errorClass: errorClass ?? null, // class name only — never message/stack (no PII)
+            };
+            // Internal log (always) + PostHog event (analytics) for flagged v4 attempts.
+            // No user-facing engine internals; safe to capture for cohort validation.
+            logger.info({ sId: this.serviceId, rId: this.runId, ...payload }, '[V4_FLAG_TELEMETRY]');
+            try { posthog?.capture?.('private_stt_v4_attempt', payload); } catch { /* posthog optional */ }
+
+            // Stage-B structured lifecycle events (allowlisted, no PII): ready on success;
+            // fallback + error when v4 init/load fell back to the v2-base floor.
+            const lifecycle = buildV4LifecycleProps({
+                finalEngine: this._engineType ?? null,
+                variant,
+                model: variantCfg?.MODEL_ID ?? null,
+                dtype: variantCfg ? JSON.stringify(variantCfg.DTYPE) : null,
+                requestedDevice: d?.provider === 'transformers-js-v4' ? 'webgpu' : 'cpu',
+                resolvedDevice: d?.runtime ?? null,
+                webgpuAvailable: d?.webgpuAvailable,
+                fallbackReason,
+                loadMs: loadMs ?? null,
+            });
+            if (fallbackReason) {
+                emitV4Fallback(lifecycle);
+                emitV4Error({ ...lifecycle, errorClass: errorClass ?? fallbackReason });
+            } else {
+                emitV4Ready(lifecycle);
+            }
+        } catch (error) {
+            logger.debug?.({ error }, '[PrivateSTT] v4 flag telemetry emit failed');
+        }
     }
 
     protected async onStart(mic?: MicStream, userWords: string[] = []): Promise<void> {
@@ -276,7 +412,55 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
         if (!this.engine) {
             return { isOk: false, error: new Error('PrivateSTT not initialized.') };
         }
-        return this.engine.transcribe(audio);
+        const v4Auto = this.v4AutoFallbackEligible && this._engineType === 'transformers-js-v4';
+
+        // On the AUTO path, BOUND the v4 decode: a base_q4-on-WASM decode can HANG and never
+        // return (no error, no result), which would strand the user because the fallback only
+        // runs AFTER transcribe resolves. Race it against a timeout so a stuck decode becomes a
+        // failure we can fall back from. v2 / strict-override paths call transcribe directly.
+        const result = v4Auto
+            ? await this.transcribeBounded(this.engine, audio, V4_AUTO_DECODE_TIMEOUT_MS)
+            : await this.engine.transcribe(audio);
+
+        // A flagged v4 engine on the AUTO path "produced nothing" if it ERRORED / TIMED OUT or
+        // returned an EMPTY / whitespace transcript. base_q4 on WASM can fail SILENTLY
+        // (isOk:true, data:"") or hang, so all three must trigger fallback — otherwise the user
+        // is stranded. Genuine silence is safe: v2 also returns empty. Strict override never
+        // sets the flag, so it is unaffected.
+        const v4Empty = v4Auto && result.isOk && result.data.trim().length === 0;
+        const v4ProducedNothing = v4Auto && (!result.isOk || v4Empty);
+
+        if (result.isOk && !v4Empty) return result;
+
+        // DECODE-time fallback (AUTO / flag path only): tear down v4, init the proven v2-base
+        // engine, and RE-TRANSCRIBE the SAME audio (no data loss). One-shot: clear the flag.
+        if (v4ProducedNothing) {
+            this.v4AutoFallbackEligible = false;
+            const errorClass = result.isOk ? 'EmptyTranscript' : (result.error instanceof Error ? result.error.name : 'Error');
+            logger.warn({ sId: this.serviceId, rId: this.runId, errorClass, empty: result.isOk }, '[PrivateSTT] v4 produced no transcript; falling back to v2-base and re-transcribing');
+            try { await this.engine.terminate?.(); } catch { /* best-effort v4 teardown */ }
+            const fallback = await this.initSafeEngine();
+            if (!fallback.isOk || !this.engine) {
+                return result; // v2 also unavailable — surface v4's original result
+            }
+            this.emitV4FlagTelemetry('v4_decode_failed', undefined, errorClass);
+            return this.engine.transcribe(audio);
+        }
+        return result;
+    }
+
+    /** Race a v4 decode against a timeout so a HUNG WASM decode degrades to a failure we can fall
+     *  back from (AUTO path only). The timeout never throws; it resolves to a failure Result. */
+    private async transcribeBounded(engine: IPrivateSTTEngine, audio: Float32Array, ms: number): Promise<Result<string, Error>> {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<Result<string, Error>>((resolve) => {
+            timer = setTimeout(() => resolve({ isOk: false, error: new Error(`v4 decode exceeded ${ms}ms`) }), ms);
+        });
+        try {
+            return await Promise.race([engine.transcribe(audio), timeout]);
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
     }
 
     /**
@@ -383,7 +567,10 @@ export class PrivateSTT extends STTEngine implements IPrivateSTTEngine, ITranscr
     }
 
     private async initV4Engine(timeoutMs?: number, isMock?: boolean): Promise<Result<EngineType, Error>> {
-        const options = this.options as TranscriptionModeOptions;
+        // Thread the resolver-chosen v4 model variant (base_q4 floor / distil_q4 tier)
+        // into the engine via options. Override path (no resolver) defaults to base_q4.
+        const variant = this.runtimePath?.v4Variant ?? PRIV_STT_V4_DEFAULT_VARIANT;
+        const options = { ...(this.options as TranscriptionModeOptions), v4Variant: variant } as TranscriptionModeOptions;
         try {
             const factory = getEngine('transformers-js-v4');
             if (factory) {

--- a/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
+++ b/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
@@ -15,8 +15,10 @@ import { MicStream } from '@/services/transcription/utils/types';
 import { ENV } from '@/config/TestFlags';
 import logger from '@/lib/logger';
 import { redactTranscript } from '@/lib/logRedaction';
+import { readPrivateDecodeOptionsOverride } from '@/services/transcription/engines/whisperDecodeOptions';
 import { STTEngine } from '@/contracts/STTEngine';
-import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_V4, samplesToSeconds } from '../sttConstants';
+import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_V4, PRIV_STT_V4_VARIANTS, PRIV_STT_V4_DEFAULT_VARIANT, type PrivSttV4VariantId, samplesToSeconds } from '../sttConstants';
+import { getV4ExperimentOverrides } from '../privateV4Experiment';
 import v4WorkerUrl from './transformers-js-v4.worker.ts?worker&url';
 
 type Pipeline = Awaited<ReturnType<typeof import('@huggingface/transformers')['pipeline']>>;
@@ -81,7 +83,7 @@ function summarizeRawResult(result: unknown): UnknownRecord {
     return summary;
 }
 
-function getV4AsrOptions(audioLengthSeconds: number): Record<string, unknown> {
+function getV4AsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
     const options: Record<string, unknown> = {
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
@@ -91,6 +93,10 @@ function getV4AsrOptions(audioLengthSeconds: number): Record<string, unknown> {
     if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {
         options.language = 'en';
         options.task = 'transcribe';
+    }
+
+    if (decodeOptions) {
+        Object.assign(options, decodeOptions);
     }
 
     return options;
@@ -118,6 +124,22 @@ export class TransformersJSV4Engine extends STTEngine {
 
     protected async loadModel(isMock?: boolean): Promise<Result<void, Error>> {
         const options = (this.options || {}) as TranscriptionModeOptions;
+        // v4 model TIER (Option B): the flag-gated resolver picks the variant
+        // (base_q4 floor / distil_q4 tier) and PrivateSTT threads it via options.
+        // Default = base_q4. Both the worker init message and the in-thread pipeline
+        // load THIS variant's model/dtype instead of a hardcoded constant.
+        const variant: PrivSttV4VariantId = (this.options as { v4Variant?: PrivSttV4VariantId })?.v4Variant ?? PRIV_STT_V4_DEFAULT_VARIANT;
+        const baseVariant = PRIV_STT_V4_VARIANTS[variant];
+        // DEV/TEST-only decode root-cause overrides (device A/B + dtype). Inert in production.
+        const exp = getV4ExperimentOverrides();
+        const v4Model = {
+            MODEL_ID: baseVariant.MODEL_ID,
+            DTYPE: exp.decoderDtype
+                ? { ...baseVariant.DTYPE, decoder_model_merged: exp.decoderDtype }
+                : baseVariant.DTYPE,
+            EXPECTED_SPLIT_DOWNLOAD_MB: baseVariant.EXPECTED_SPLIT_DOWNLOAD_MB,
+        };
+        const experimentDevice = exp.device && exp.device !== 'auto' ? exp.device : undefined;
         if (this.transcriber || this.worker) {
             logger.info({ sId: this.serviceId, rId: this.runId, eId: this.instanceId }, '[TransformersJSV4] Engine already initialized, skipping.');
             options.onReady?.();
@@ -128,9 +150,10 @@ export class TransformersJSV4Engine extends STTEngine {
             sId: this.serviceId,
             rId: this.runId,
             eId: this.instanceId,
-            model: PRIV_STT_V4.MODEL_ID,
-            dtype: PRIV_STT_V4.DTYPE,
+            model: v4Model.MODEL_ID,
+            dtype: v4Model.DTYPE,
             device: PRIV_STT_V4.DEVICE ?? 'default-cpu-wasm',
+            variant,
         }, '[TransformersJSV4] Initializing engine...');
 
         if (isMock) {
@@ -140,8 +163,8 @@ export class TransformersJSV4Engine extends STTEngine {
         }
 
         try {
-            if (this.shouldUseWorker()) {
-                await this.initWorker(isMock);
+            if (this.shouldUseWorker() && !exp.noWorker) {
+                await this.initWorker(isMock, v4Model, experimentDevice);
                 options.onModelLoadProgress?.(100);
                 this.updateHeartbeat();
                 options.onReady?.();
@@ -174,16 +197,17 @@ export class TransformersJSV4Engine extends STTEngine {
 
             const loadStart = performance.now();
             const pipelineOptions: Record<string, unknown> = {
-                dtype: PRIV_STT_V4.DTYPE,
+                dtype: v4Model.DTYPE,
                 progress_callback,
             };
-            if (PRIV_STT_V4.DEVICE) {
-                pipelineOptions.device = PRIV_STT_V4.DEVICE;
+            const mainThreadDevice = experimentDevice ?? PRIV_STT_V4.DEVICE;
+            if (mainThreadDevice) {
+                pipelineOptions.device = mainThreadDevice;
             }
 
             this.transcriber = await pipeline(
                 'automatic-speech-recognition',
-                PRIV_STT_V4.MODEL_ID,
+                v4Model.MODEL_ID,
                 pipelineOptions
             );
 
@@ -207,9 +231,9 @@ export class TransformersJSV4Engine extends STTEngine {
                 rId: this.runId,
                 eId: this.instanceId,
                 event: 'model_loaded',
-                model: PRIV_STT_V4.MODEL_ID,
-                dtype: PRIV_STT_V4.DTYPE,
-                expected_download_mb: PRIV_STT_V4.EXPECTED_Q4_SPLIT_DOWNLOAD_MB,
+                model: v4Model.MODEL_ID,
+                dtype: v4Model.DTYPE,
+                expected_download_mb: v4Model.EXPECTED_SPLIT_DOWNLOAD_MB,
                 load_time_ms: Math.round(loadTime),
                 engine: 'transformersjs-v4',
             }, '[TransformersJSV4] Engine initialized successfully.');
@@ -300,7 +324,7 @@ export class TransformersJSV4Engine extends STTEngine {
             if (this.worker) {
                 const workerAudio = audio.slice(0);
                 const response = await this.sendWorkerRequest(
-                    { type: 'transcribe', audio: workerAudio },
+                    { type: 'transcribe', audio: workerAudio, decodeOptions: readPrivateDecodeOptionsOverride() },
                     [workerAudio.buffer],
                 );
                 if (response.type !== 'result') {
@@ -347,7 +371,7 @@ export class TransformersJSV4Engine extends STTEngine {
             }
 
             const audioLengthSeconds = samplesToSeconds(audio.length, PRIV_CLOUD_AUDIO.TARGET_SAMPLE_RATE_HZ);
-            const options = getV4AsrOptions(audioLengthSeconds);
+            const options = getV4AsrOptions(audioLengthSeconds, readPrivateDecodeOptionsOverride());
 
             const result = await (this.transcriber as (audio: Float32Array, options: Record<string, unknown>) => Promise<string | TranscriptionResult>)(audio, options);
 
@@ -402,7 +426,7 @@ export class TransformersJSV4Engine extends STTEngine {
             !ENV.isTest;
     }
 
-    private async initWorker(isMock?: boolean): Promise<void> {
+    private async initWorker(isMock: boolean | undefined, v4Model: { MODEL_ID: string; DTYPE: unknown }, deviceOverride?: string): Promise<void> {
         this.worker = new Worker(v4WorkerUrl, { type: 'module' });
         this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
             const response = event.data;
@@ -456,7 +480,7 @@ export class TransformersJSV4Engine extends STTEngine {
             this.pendingWorkerRequests.clear();
         };
 
-        const response = await this.sendWorkerRequest({ type: 'init', isE2E: Boolean(isMock) });
+        const response = await this.sendWorkerRequest({ type: 'init', isE2E: Boolean(isMock), model: v4Model.MODEL_ID, dtype: v4Model.DTYPE, device: deviceOverride });
         if (response.type !== 'ready') {
             throw new Error(`Unexpected TransformersJSV4 worker init response: ${response.type}`);
         }
@@ -476,7 +500,7 @@ export class TransformersJSV4Engine extends STTEngine {
     }
 
     private sendWorkerRequest(
-        request: { type: 'init'; isE2E: boolean } | { type: 'transcribe'; audio: Float32Array } | { type: 'destroy' },
+        request: { type: 'init'; isE2E: boolean; model?: string; dtype?: unknown; device?: string } | { type: 'transcribe'; audio: Float32Array; decodeOptions?: Record<string, unknown> } | { type: 'destroy' },
         transfer?: Transferable[],
     ): Promise<WorkerResponse> {
         if (!this.worker) {

--- a/frontend/src/services/transcription/engines/__tests__/PrivateSTT.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/PrivateSTT.test.ts
@@ -42,6 +42,8 @@ vi.mock('@/config/TestFlags', async (importOriginal) => {
 const mockWTEInit = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
 const mockTJInit = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
 const mockV4Init = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
+// Construction spy: proves the v4 engine object is never even instantiated on the flag-off path.
+const mockV4Construct = vi.fn();
 const mockEInit = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
 
 // A stub registered under a NON-CONFIGURED provider key, to prove PrivateSTT never
@@ -72,6 +74,10 @@ class StubTJ extends STTEngine {
 
 class StubV4 extends STTEngine {
     type = 'transformers-js-v4' as const;
+    constructor(options?: ConstructorParameters<typeof STTEngine>[0]) {
+        super(options);
+        mockV4Construct();
+    }
     checkAvailability = vi.fn().mockResolvedValue({ available: true });
     protected onInit = mockV4Init;
     onStart = vi.fn().mockResolvedValue(undefined);
@@ -124,6 +130,7 @@ describe('PrivateSTT (Routing Logic)', () => {
     let pstt: PrivateSTTType | null = null;
 
     afterEach(async () => {
+        vi.unstubAllEnvs();
         if (pstt) {
             await pstt.terminate();
             pstt = null;
@@ -132,6 +139,7 @@ describe('PrivateSTT (Routing Logic)', () => {
             const win = window as unknown as Record<string, unknown>;
             delete win.__SS_E2E__;
             window.localStorage.clear();
+            try { window.history.replaceState({}, '', '/'); } catch { /* happy-dom location reset */ }
         }
     });
 
@@ -188,6 +196,32 @@ describe('PrivateSTT (Routing Logic)', () => {
 
         expect(pstt.getEngineType()).toBe('transformers-js');
         expect(mockWTEInit).not.toHaveBeenCalled();
+    });
+
+    it('flag-off (default): auto path stays v2-base and NEVER constructs or initializes the v4 engine — even with WebGPU usable', async () => {
+        // PostHog is uninitialized in unit tests, so getV4FlagState() reads every v4 flag as OFF —
+        // exactly the production default. This nails the explicit pre-merge item:
+        // "flag off -> no v4 constructor / load / model request".
+        if (window.__SS_E2E__) {
+            window.__SS_E2E__.isActive = true;
+            window.__SS_E2E__.engineType = 'real';
+        }
+        // WebGPU IS usable — proves it is the FLAG (off), not WebGPU-absence, keeping us on v2-base.
+        Object.defineProperty(navigator, 'gpu', {
+            value: { requestAdapter: vi.fn().mockResolvedValue({ name: 'mock-adapter' }) },
+            writable: true,
+            configurable: true,
+        });
+        const { ModelManager } = await import('../../ModelManager');
+        vi.spyOn(ModelManager, 'isModelDownloaded').mockResolvedValue(false);
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js'); // v2-base default
+        expect(mockV4Construct).not.toHaveBeenCalled();        // v4 engine never constructed
+        expect(mockV4Init).not.toHaveBeenCalled();             // no v4 init / load / model request
     });
 
     it('selects TransformersJSEngine (Safe Path) when WebGPU is missing', async () => {
@@ -283,6 +317,52 @@ describe('PrivateSTT (Routing Logic)', () => {
         expect(result.error).toBe(v4Error);
         expect(mockV4Init).toHaveBeenCalledOnce();
         expect(mockTJInit).not.toHaveBeenCalled();
+    });
+
+    // ---- MERGE-SAFETY: the public ?privateEngine / localStorage override is dev/test-only ----
+    // A normal production build must NOT let a public URL or localStorage value bypass the
+    // PostHog v4 flag. Production is simulated by DEV=false + not-E2E + not-unit (__TEST__=false).
+    it('merge-safety: PRODUCTION ignores ?privateEngine=transformers-js-v4 override -> v2-base (no flag bypass)', async () => {
+        vi.stubEnv('DEV', false);
+        globalThis.__TEST__ = false;
+        if (window.__SS_E2E__) window.__SS_E2E__.isActive = false;
+        window.history.replaceState({}, '', '?privateEngine=transformers-js-v4');
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js'); // override ignored in production
+        expect(mockV4Construct).not.toHaveBeenCalled();        // v4 never constructed
+        expect(mockV4Init).not.toHaveBeenCalled();             // v4 never initialized
+    });
+
+    it('merge-safety: PRODUCTION ignores localStorage private-engine override -> v2-base (no flag bypass)', async () => {
+        vi.stubEnv('DEV', false);
+        globalThis.__TEST__ = false;
+        if (window.__SS_E2E__) window.__SS_E2E__.isActive = false;
+        window.localStorage.setItem('speaksharp.private.engine', 'transformers-js-v4');
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js');
+        expect(mockV4Construct).not.toHaveBeenCalled();
+        expect(mockV4Init).not.toHaveBeenCalled();
+    });
+
+    it('dev/test: ?privateEngine / localStorage override STILL forces v4 (override remains a dev/test affordance)', async () => {
+        // Unit context: __TEST__ = true (beforeEach) => ENV.isTest true => override allowed.
+        if (window.__SS_E2E__) { window.__SS_E2E__.isActive = true; window.__SS_E2E__.engineType = 'real'; }
+        window.localStorage.setItem('speaksharp.private.engine', 'transformers-js-v4');
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js-v4'); // honored in dev/test
+        expect(mockV4Init).toHaveBeenCalled();
     });
 
     it('contract: availability is a pure cache probe and does not instantiate registry engines', async () => {

--- a/frontend/src/services/transcription/engines/__tests__/PrivateSTT.v4DecodeFallback.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/PrivateSTT.v4DecodeFallback.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setupStrictZero } from '../../../../../../tests/setupStrictZero';
+import type { PrivateSTT as PrivateSTTType } from '../PrivateSTT';
+import { STTEngine } from '../../../../contracts/STTEngine';
+
+vi.mock('@xenova/transformers', () => ({}));
+
+// engineType 'real' => ENV.disableWasm is false, so the AUTO resolver actually runs.
+vi.mock('@/config/TestFlags', async (importOriginal) => {
+    interface SSWindow { __SS_E2E__?: { isActive?: boolean; engineType?: string } }
+    interface TestGlobal { __TEST__?: boolean }
+    const actual = await importOriginal<typeof import('@/config/TestFlags')>();
+    return {
+        ...actual,
+        ENV: {
+            ...actual.ENV,
+            get isE2E(): boolean { return !!(window as unknown as SSWindow).__SS_E2E__?.isActive; },
+            get isTest(): boolean { return this.isE2E || !!(globalThis as unknown as TestGlobal).__TEST__; },
+            get engineType(): string { return ((window as unknown as SSWindow).__SS_E2E__?.isActive && (window as unknown as SSWindow).__SS_E2E__?.engineType) || 'system'; },
+            get disableWasm(): boolean { return this.isTest && this.engineType !== 'real'; },
+        },
+    };
+});
+
+// Force the v4 flag ON so the AUTO path selects v4 (WebGPU is made usable below).
+vi.mock('../../privateV4Flags', () => ({
+    getV4FlagState: () => ({ v4Enabled: true, distilEnabled: false }),
+}));
+
+const v4Transcribe = vi.fn();
+const tjTranscribe = vi.fn();
+const mockV4Init = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
+const mockTJInit = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
+
+class StubV4 extends STTEngine {
+    type = 'transformers-js-v4' as const;
+    checkAvailability = vi.fn().mockResolvedValue({ available: true });
+    protected onInit = mockV4Init;
+    onStart = vi.fn().mockResolvedValue(undefined);
+    onStop = vi.fn().mockResolvedValue(undefined);
+    onPause = vi.fn().mockResolvedValue(undefined);
+    onResume = vi.fn().mockResolvedValue(undefined);
+    onDestroy = vi.fn().mockResolvedValue(undefined);
+    transcribe = v4Transcribe;
+}
+class StubTJ extends STTEngine {
+    type = 'transformers-js' as const;
+    checkAvailability = vi.fn().mockResolvedValue({ available: true });
+    protected onInit = mockTJInit;
+    onStart = vi.fn().mockResolvedValue(undefined);
+    onStop = vi.fn().mockResolvedValue(undefined);
+    onPause = vi.fn().mockResolvedValue(undefined);
+    onResume = vi.fn().mockResolvedValue(undefined);
+    onDestroy = vi.fn().mockResolvedValue(undefined);
+    transcribe = tjTranscribe;
+}
+
+function setGpuUsable(): void {
+    Object.defineProperty(globalThis.navigator, 'gpu', {
+        value: { requestAdapter: vi.fn().mockResolvedValue({ name: 'adapter' }) },
+        configurable: true,
+        writable: true,
+    });
+}
+
+describe('PrivateSTT v4 decode-time fallback (auto/flag path)', () => {
+    let pstt: PrivateSTTType | null = null;
+
+    beforeEach(async () => {
+        globalThis.__TEST__ = true;
+        vi.clearAllMocks();
+        mockV4Init.mockResolvedValue({ isOk: true, data: undefined });
+        mockTJInit.mockResolvedValue({ isOk: true, data: undefined });
+        await setupStrictZero();
+        const { sttRegistry } = await import('../../STTRegistry');
+        sttRegistry.register('transformers-js', (o) => new StubTJ(o));
+        sttRegistry.register('transformers-js-v4', (o) => new StubV4(o));
+        const win = window as unknown as { __SS_E2E__: { isActive: boolean; engineType: string } };
+        win.__SS_E2E__.isActive = true;
+        win.__SS_E2E__.engineType = 'real';
+        window.localStorage.clear();
+        setGpuUsable();
+    });
+
+    afterEach(async () => {
+        if (pstt) { await pstt.terminate(); pstt = null; }
+        if (typeof window !== 'undefined') {
+            delete (window as unknown as Record<string, unknown>).__SS_E2E__;
+            window.localStorage.clear();
+        }
+    });
+
+    it('v4 decode FAILURE -> falls back to v2-base and re-transcribes the SAME audio (no data loss)', async () => {
+        const audio = new Float32Array([0.1, 0.2, 0.3]);
+        v4Transcribe.mockResolvedValue({ isOk: false, error: new Error('invalid data location: undefined for input "a"') });
+        tjTranscribe.mockResolvedValue({ isOk: true, data: 'v2 base transcript' });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType(), 'auto path should select v4 with flag on + WebGPU').toBe('transformers-js-v4');
+
+        const result = await pstt.transcribe(audio);
+
+        expect(result, 'user must NOT be stranded with an empty session').toEqual({ isOk: true, data: 'v2 base transcript' });
+        expect(v4Transcribe).toHaveBeenCalledWith(audio);
+        expect(tjTranscribe).toHaveBeenCalledWith(audio); // SAME audio re-transcribed -> no data loss
+        expect(pstt.getEngineType()).toBe('transformers-js'); // swapped to v2-base
+    });
+
+    it('v4 decode SUCCESS -> no fallback (v2-base never invoked)', async () => {
+        v4Transcribe.mockResolvedValue({ isOk: true, data: 'v4 transcript' });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        const result = await pstt.transcribe(new Float32Array([0.1]));
+        expect(result).toEqual({ isOk: true, data: 'v4 transcript' });
+        expect(tjTranscribe).not.toHaveBeenCalled();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4');
+    });
+
+    it('v4 EMPTY transcript (silent WASM failure, isOk:true data:"") -> falls back to v2-base', async () => {
+        const audio = new Float32Array([0.1, 0.2, 0.3]);
+        // base_q4 on WASM can return an empty SUCCESS instead of throwing — must still fall back.
+        v4Transcribe.mockResolvedValue({ isOk: true, data: '   ' });
+        tjTranscribe.mockResolvedValue({ isOk: true, data: 'v2 recovered transcript' });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        const result = await pstt.transcribe(audio);
+        expect(result, 'empty v4 must not strand the user').toEqual({ isOk: true, data: 'v2 recovered transcript' });
+        expect(tjTranscribe).toHaveBeenCalledWith(audio); // same audio re-transcribed
+        expect(pstt.getEngineType()).toBe('transformers-js'); // swapped to v2-base
+    });
+
+    it('v4 decode HANG (never resolves) -> times out -> falls back to v2-base', async () => {
+        const audio = new Float32Array([0.1, 0.2, 0.3]);
+        // base_q4 on WASM can hang: transcribe never resolves. Without a bound the user is
+        // stranded (the fallback only runs after transcribe returns). The decode timeout fixes it.
+        v4Transcribe.mockReturnValue(new Promise<never>(() => { /* never resolves */ }));
+        tjTranscribe.mockResolvedValue({ isOk: true, data: 'v2 after timeout' });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4');
+
+        vi.useFakeTimers();
+        const p = pstt.transcribe(audio);
+        await vi.advanceTimersByTimeAsync(41_000); // past the 40s v4 decode bound
+        vi.useRealTimers();
+        const result = await p;
+
+        expect(result, 'a hung v4 decode must not strand the user').toEqual({ isOk: true, data: 'v2 after timeout' });
+        expect(tjTranscribe).toHaveBeenCalledWith(audio);
+        expect(pstt.getEngineType()).toBe('transformers-js');
+    });
+
+    it('only falls back ONCE (no loop) if v2 also fails', async () => {
+        v4Transcribe.mockResolvedValue({ isOk: false, error: new Error('invalid data location') });
+        tjTranscribe.mockResolvedValue({ isOk: false, error: new Error('v2 decode also failed') });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        const result = await pstt.transcribe(new Float32Array([0.1]));
+        expect(result.isOk).toBe(false);
+        expect(tjTranscribe).toHaveBeenCalledTimes(1); // fell back once, did not loop
+    });
+
+    it('STRICT override v4 decode failure does NOT fall back (exposes the bug for dev/test)', async () => {
+        v4Transcribe.mockResolvedValue({ isOk: false, error: new Error('invalid data location: undefined for input "a"') });
+        tjTranscribe.mockResolvedValue({ isOk: true, data: 'v2 must NOT be used on the strict override path' });
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        // forceEngine = the explicit/strict override path: it must surface the v4 error,
+        // never silently fall back, so dev/test can see the real bug.
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn(), forceEngine: 'transformers-js-v4' } as never);
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4');
+
+        const result = await pstt.transcribe(new Float32Array([0.1]));
+        expect(result.isOk).toBe(false);              // strict: surfaces the v4 decode error
+        expect(tjTranscribe).not.toHaveBeenCalled();  // v2-base NOT invoked
+        expect(pstt.getEngineType()).toBe('transformers-js-v4'); // stayed on v4, no swap
+    });
+});

--- a/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/TransformersJSV4Engine.worker.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { mockPipeline } = vi.hoisted(() => ({
+    mockPipeline: vi.fn(),
+}));
+
 vi.mock('@/config/TestFlags', () => ({
     ENV: {
         isE2E: false,
@@ -15,6 +19,15 @@ vi.mock('@/lib/logger', () => ({
         warn: vi.fn(),
         error: vi.fn(),
         debug: vi.fn(),
+    },
+}));
+
+vi.mock('@huggingface/transformers', () => ({
+    pipeline: mockPipeline,
+    env: {},
+    LogLevel: {
+        ERROR: 'error',
+        INFO: 'info',
     },
 }));
 
@@ -79,6 +92,8 @@ describe('TransformersJSV4Engine worker message contract', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
+        mockPipeline.mockReset();
+        window.localStorage.clear();
         fakeWorkerMode = 'ready';
         fakeWorkerInstances.length = 0;
         vi.stubGlobal('Worker', FakeWorker);
@@ -88,6 +103,8 @@ describe('TransformersJSV4Engine worker message contract', () => {
     });
 
     afterEach(() => {
+        delete (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+        window.localStorage.clear();
         vi.useRealTimers();
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
@@ -142,6 +159,69 @@ describe('TransformersJSV4Engine worker message contract', () => {
             expect.objectContaining({ type: 'transcribe', audio: expect.any(Float32Array) }),
             expect.any(Array),
         );
+
+        await engine.destroy();
+    });
+
+    it('contract: sends sanitized decode-option overrides from the browser proof hook', async () => {
+        fakeWorkerMode = 'transcribe-result';
+        (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = {
+            condition_on_previous_text: false,
+            compression_ratio_threshold: 2.4,
+            unsafe_option: 'ignored',
+        };
+        const { TransformersJSV4Engine } = await import('../TransformersJSV4Engine');
+        const engine = new TransformersJSV4Engine({ onReady: vi.fn(), onTranscriptUpdate: vi.fn() });
+
+        const init = await engine.init();
+        const result = await engine.transcribe(new Float32Array(16000));
+
+        expect(init.isOk).toBe(true);
+        expect(result.isOk).toBe(true);
+        expect(fakeWorkerInstances[0]?.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'transcribe',
+                decodeOptions: {
+                    condition_on_previous_text: false,
+                    compression_ratio_threshold: 2.4,
+                },
+            }),
+            expect.any(Array),
+        );
+
+        await engine.destroy();
+    });
+
+    it('contract: applies sanitized decode-option overrides in the v4 main-thread no-worker path', async () => {
+        const mainThreadTranscriber = vi.fn()
+            .mockResolvedValueOnce({ text: '' })
+            .mockResolvedValueOnce({ text: 'v4 main-thread transcript' });
+        mockPipeline.mockResolvedValueOnce(mainThreadTranscriber);
+        window.localStorage.setItem('speaksharp.v4.noWorker', '1');
+        (window as typeof window & { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = {
+            condition_on_previous_text: false,
+            no_repeat_ngram_size: 3,
+            unsafe_option: 'ignored',
+        };
+        const { TransformersJSV4Engine } = await import('../TransformersJSV4Engine');
+        const engine = new TransformersJSV4Engine({ onReady: vi.fn(), onTranscriptUpdate: vi.fn() });
+
+        const init = await engine.init();
+        const result = await engine.transcribe(new Float32Array(16000));
+
+        expect(init.isOk).toBe(true);
+        expect(result).toEqual(expect.objectContaining({
+            isOk: true,
+            data: 'v4 main-thread transcript',
+        }));
+        expect(fakeWorkerInstances).toHaveLength(0);
+        const transcribeOptions = mainThreadTranscriber.mock.calls[mainThreadTranscriber.mock.calls.length - 1]?.[1] as Record<string, unknown>;
+        expect(transcribeOptions).toEqual(expect.objectContaining({
+            condition_on_previous_text: false,
+            no_repeat_ngram_size: 3,
+            return_timestamps: true,
+        }));
+        expect(transcribeOptions).not.toHaveProperty('unsafe_option');
 
         await engine.destroy();
     });

--- a/frontend/src/services/transcription/engines/__tests__/privateV4FlagOperationalProof.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/privateV4FlagOperationalProof.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment happy-dom
+//
+// HEADLESS OPERATIONAL PostHog proof (NON-GPU claims). The GPU-dependent claim — "flag ON + real
+// WebGPU adapter -> v4 selected, WER/RTF" — is NOT here (no GPU in CI; see V4_WEBGPU_VALUE_PROOF
+// runbook). Everything below runs deterministically in headless CI against the REAL resolver +
+// the REAL posthog.capture surface.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setupStrictZero } from '../../../../../../tests/setupStrictZero';
+import type { PrivateSTT as PrivateSTTType } from '../PrivateSTT';
+import { STTEngine } from '../../../../contracts/STTEngine';
+
+// Spy the ACTUAL posthog.capture payloads PrivateSTT emits (not just the sanitizer in isolation).
+const posthogCapture = vi.fn();
+vi.mock('posthog-js', () => ({
+    default: { capture: (...a: unknown[]) => posthogCapture(...a), isFeatureEnabled: () => false },
+}));
+
+vi.mock('@xenova/transformers', () => ({}));
+
+vi.mock('@/config/TestFlags', async (importOriginal) => {
+    interface SSWindow { __SS_E2E__?: { isActive?: boolean; engineType?: string } }
+    interface TestGlobal { __TEST__?: boolean }
+    const actual = await importOriginal<typeof import('@/config/TestFlags')>();
+    return {
+        ...actual,
+        ENV: {
+            ...actual.ENV,
+            get isE2E(): boolean { return !!(window as unknown as SSWindow).__SS_E2E__?.isActive; },
+            get isTest(): boolean { return this.isE2E || !!(globalThis as unknown as TestGlobal).__TEST__; },
+            get engineType(): string { return ((window as unknown as SSWindow).__SS_E2E__?.isActive && (window as unknown as SSWindow).__SS_E2E__?.engineType) || 'system'; },
+            get disableWasm(): boolean { return this.isTest && this.engineType !== 'real'; },
+        },
+    };
+});
+
+// PostHog flag state — togglable per test (this IS the control plane under test).
+const flagState = { v4Enabled: false, distilEnabled: false };
+vi.mock('../../privateV4Flags', () => ({ getV4FlagState: () => ({ ...flagState }) }));
+
+const v4Construct = vi.fn();
+const v4Init = vi.fn();
+class StubV4 extends STTEngine {
+    type = 'transformers-js-v4' as const;
+    constructor(o?: ConstructorParameters<typeof STTEngine>[0]) { super(o); v4Construct(o); }
+    checkAvailability = vi.fn().mockResolvedValue({ available: true });
+    protected onInit = v4Init;
+    onStart = vi.fn().mockResolvedValue(undefined);
+    onStop = vi.fn().mockResolvedValue(undefined);
+    onPause = vi.fn().mockResolvedValue(undefined);
+    onResume = vi.fn().mockResolvedValue(undefined);
+    onDestroy = vi.fn().mockResolvedValue(undefined);
+    transcribe = vi.fn().mockResolvedValue({ isOk: true, data: 'v4' });
+}
+class StubTJ extends STTEngine {
+    type = 'transformers-js' as const;
+    checkAvailability = vi.fn().mockResolvedValue({ available: true });
+    protected onInit = vi.fn().mockResolvedValue({ isOk: true, data: undefined });
+    onStart = vi.fn().mockResolvedValue(undefined);
+    onStop = vi.fn().mockResolvedValue(undefined);
+    onPause = vi.fn().mockResolvedValue(undefined);
+    onResume = vi.fn().mockResolvedValue(undefined);
+    onDestroy = vi.fn().mockResolvedValue(undefined);
+    transcribe = vi.fn().mockResolvedValue({ isOk: true, data: 'v2' });
+}
+function setGpu(usable: boolean): void {
+    Object.defineProperty(globalThis.navigator, 'gpu', {
+        value: usable ? { requestAdapter: vi.fn().mockResolvedValue({ name: 'adapter' }) } : undefined,
+        configurable: true, writable: true,
+    });
+}
+const PII_KEYS = ['email', 'transcript', 'audio', 'stack', 'errorstack', 'sk_live', 'pk_live', 'whsec', 'token', 'jwt', 'password', 'secret', 'apikey', 'referencetext', 'distinctid', 'userid', 'sessiontoken'];
+
+describe('v4 PostHog flag — headless operational proof (non-GPU)', () => {
+    let pstt: PrivateSTTType | null = null;
+    beforeEach(async () => {
+        (globalThis as { __TEST__?: boolean }).__TEST__ = true;
+        vi.clearAllMocks();
+        flagState.v4Enabled = false; flagState.distilEnabled = false;
+        v4Init.mockResolvedValue({ isOk: true, data: undefined });
+        await setupStrictZero();
+        const { sttRegistry } = await import('../../STTRegistry');
+        sttRegistry.register('transformers-js', (o) => new StubTJ(o));
+        sttRegistry.register('transformers-js-v4', (o) => new StubV4(o));
+        const win = window as unknown as { __SS_E2E__: { isActive: boolean; engineType: string } };
+        win.__SS_E2E__.isActive = true; win.__SS_E2E__.engineType = 'real';
+        window.localStorage.clear();
+        window.history.replaceState({}, '', '/');
+        setGpu(false);
+    });
+    afterEach(async () => {
+        vi.unstubAllEnvs();
+        if (pstt) { await pstt.terminate(); pstt = null; }
+        if (typeof window !== 'undefined') { delete (window as unknown as Record<string, unknown>).__SS_E2E__; window.localStorage.clear(); }
+    });
+
+    // Case A — flag OFF (default) -> v2-base, no v4 construct/init (also in PrivateSTT.test.ts).
+    it('A: flag OFF -> v2-base, v4 NEVER constructed/initialized (even with WebGPU usable)', async () => {
+        flagState.v4Enabled = false; setGpu(true);
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js');
+        expect(v4Construct).not.toHaveBeenCalled();
+        expect(v4Init).not.toHaveBeenCalled();
+    });
+
+    // Case E — flag ON but NO WebGPU -> conservative v2-base (resolver never forces broken v4).
+    it('E: flag ON + NO WebGPU -> v2-base (no v4 construct); resolver does not force unsupported v4', async () => {
+        flagState.v4Enabled = true; setGpu(false);
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js');
+        expect(v4Construct).not.toHaveBeenCalled();
+    });
+
+    // Case B — PRODUCTION cannot be bypassed by ?v4ForceAuto / ?privateEngine / ?engine.
+    it('B: PRODUCTION ignores ?v4ForceAuto=1 (+ ?engine=v4 / ?privateEngine) -> v2-base, no v4 construct', async () => {
+        vi.stubEnv('DEV', false);
+        (globalThis as { __TEST__?: boolean }).__TEST__ = false;
+        if (window.__SS_E2E__) (window.__SS_E2E__ as { isActive: boolean }).isActive = false;
+        flagState.v4Enabled = false; setGpu(true);
+        window.history.replaceState({}, '', '?v4ForceAuto=1&engine=v4&privateEngine=transformers-js-v4&v4Variant=distil_q4');
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js'); // no URL bypass in production
+        expect(v4Construct).not.toHaveBeenCalled();
+    });
+
+    // Case C — PRODUCTION cannot be bypassed by localStorage experiment keys.
+    it('C: PRODUCTION ignores localStorage v4 bypass attempts -> v2-base, no v4 construct', async () => {
+        vi.stubEnv('DEV', false);
+        (globalThis as { __TEST__?: boolean }).__TEST__ = false;
+        if (window.__SS_E2E__) (window.__SS_E2E__ as { isActive: boolean }).isActive = false;
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('privateEngine', 'transformers-js-v4');
+        window.localStorage.setItem('speaksharp.private.engine', 'transformers-js-v4');
+        window.localStorage.setItem('stt_engine', 'v4');
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1'); // the REAL forceAuto key (not a phantom)
+        window.localStorage.setItem('privateModel', 'v4');
+        window.localStorage.setItem('speaksharp.v4.variant', 'distil_q4');
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js');
+        expect(v4Construct).not.toHaveBeenCalled();
+    });
+
+    // Case D — the ACTUAL posthog.capture payloads carry NO PII and record selectionSource.
+    it('D: PostHog capture payloads contain NO PII/secrets and record selectionSource', async () => {
+        flagState.v4Enabled = true; setGpu(true);
+        v4Init.mockResolvedValue({ isOk: false, error: new Error('forced v4 init failure for telemetry') }); // -> fallback -> telemetry
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(posthogCapture, 'PrivateSTT must emit a flagged v4 telemetry event').toHaveBeenCalled();
+        let attemptPayload: Record<string, unknown> | undefined;
+        // PII safety applies to EVERY captured event; selectionSource lives on the canonical attempt event.
+        for (const [event, payload] of posthogCapture.mock.calls as Array<[string, Record<string, unknown>]>) {
+            expect(String(event)).toMatch(/^private_stt_v4_/);
+            const blob = JSON.stringify(payload ?? {}).toLowerCase();
+            for (const bad of PII_KEYS) {
+                expect(blob, `posthog "${event}" payload must not contain "${bad}"`).not.toContain(bad);
+            }
+            expect(blob, 'no @-style email values').not.toMatch(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/);
+            if (event === 'private_stt_v4_attempt') attemptPayload = payload;
+        }
+        // flag-driven (not forceAuto) -> the canonical attempt event records the REAL flag source.
+        expect(attemptPayload, 'canonical private_stt_v4_attempt event with real-flag selectionSource')
+            .toMatchObject({ selectionSource: 'posthog_flag' });
+    });
+
+    // Case F1 — DEV/TEST harness: the real localStorage forceAuto key (`speaksharp.v4.forceAuto`) +
+    // usable WebGPU selects v4, and the artifact labels it selectionSource:'dev_harness' — NOT
+    // posthog_flag — even though `reason` reads `webgpu_available_v4_flag` on real WebGPU (identical
+    // for flag AND forceAuto there). Locks the Gate A (dev_harness) vs Gate B (posthog_flag) distinction.
+    it('F1: DEV/TEST forceAuto (real localStorage key) + WebGPU -> v4 selected, selectionSource=dev_harness (NOT posthog_flag)', async () => {
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1'); // dev/test-gated forceAuto shim (Gate A)
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4'); // forceAuto selects v4 in dev/test
+        const dbg = (window as unknown as { __PRIVATE_STT_RUNTIME_DEBUG__?: { selectionSource?: string; reason?: string } }).__PRIVATE_STT_RUNTIME_DEBUG__;
+        expect(dbg?.selectionSource, 'forceAuto value run must be labelled dev_harness, never posthog_flag').toBe('dev_harness');
+        expect(dbg?.reason, 'reason is the conflated signal; proves selectionSource is the honest one').toBe('webgpu_available_v4_flag');
+    });
+
+    it('F1b: DEV/TEST forceAuto + v4Variant=distil_q4 selects the distil Gate A candidate', async () => {
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
+        window.localStorage.setItem('speaksharp.v4.variant', 'distil_q4');
+
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+
+        expect(pstt.getEngineType()).toBe('transformers-js-v4');
+        expect(v4Construct).toHaveBeenCalledWith(expect.objectContaining({ v4Variant: 'distil_q4' }));
+        const dbg = (window as unknown as { __PRIVATE_STT_RUNTIME_DEBUG__?: { selectionSource?: string; v4Variant?: string } }).__PRIVATE_STT_RUNTIME_DEBUG__;
+        expect(dbg?.selectionSource).toBe('dev_harness');
+        expect(dbg?.v4Variant).toBe('distil_q4');
+    });
+
+    it('F1c: DEV/TEST forceAuto + v4Variant=base_q4 selects the base Gate A candidate (dev_harness)', async () => {
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
+        window.localStorage.setItem('speaksharp.v4.variant', 'base_q4');
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4');
+        const dbg = (window as unknown as { __PRIVATE_STT_RUNTIME_DEBUG__?: { selectionSource?: string; v4Variant?: string } }).__PRIVATE_STT_RUNTIME_DEBUG__;
+        expect(dbg?.selectionSource).toBe('dev_harness');
+        expect(dbg?.v4Variant).toBe('base_q4');
+    });
+
+    // Allowlist FAIL-CLOSED: an unknown v4Variant must never load an arbitrary model — it falls back to
+    // the base_q4 floor. Guards the security invariant that the bakeoff knob is a 2-value allowlist only.
+    it('F1d: DEV/TEST forceAuto + UNKNOWN v4Variant fails closed to base_q4 (no arbitrary model)', async () => {
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
+        window.localStorage.setItem('speaksharp.v4.variant', 'evil-org/secret-model'); // not allowlisted
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js-v4'); // forceAuto still selects v4 (base floor)
+        const dbg = (window as unknown as { __PRIVATE_STT_RUNTIME_DEBUG__?: { v4Variant?: string } }).__PRIVATE_STT_RUNTIME_DEBUG__;
+        expect(dbg?.v4Variant, 'unknown variant must fall closed to base_q4, never a custom model').toBe('base_q4');
+    });
+
+    // Case F2 — PRODUCTION/BETA: the SAME real forceAuto key is INERT. Even with WebGPU usable, a
+    // production build ignores `speaksharp.v4.forceAuto` (override gated `import.meta.env.DEV || isTest`)
+    // -> v2-base, no v4 construct, selectionSource='default' (never dev_harness). Proves the localStorage
+    // forceAuto shim can never become a production engine-selection bypass.
+    it('F2: PRODUCTION ignores the real localStorage forceAuto key -> v2-base, selectionSource=default (NOT dev_harness)', async () => {
+        vi.stubEnv('DEV', false);
+        (globalThis as { __TEST__?: boolean }).__TEST__ = false;
+        if (window.__SS_E2E__) (window.__SS_E2E__ as { isActive: boolean }).isActive = false;
+        flagState.v4Enabled = false; setGpu(true);
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1'); // real key — must be inert in production
+        window.localStorage.setItem('speaksharp.v4.variant', 'distil_q4'); // real variant key — also inert in production
+        const { PrivateSTT } = await import('../PrivateSTT');
+        pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
+        await pstt.init();
+        expect(pstt.getEngineType()).toBe('transformers-js'); // forceAuto ignored in production
+        expect(v4Construct).not.toHaveBeenCalled();
+        const dbg = (window as unknown as { __PRIVATE_STT_RUNTIME_DEBUG__?: { selectionSource?: string } }).__PRIVATE_STT_RUNTIME_DEBUG__;
+        expect(dbg?.selectionSource, 'production v2 path is selectionSource=default, never dev_harness').toBe('default');
+    });
+});

--- a/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
@@ -107,4 +107,32 @@ describe('transformers-js-v4.worker protocol contract', () => {
         });
         expect(postedMessages).not.toContainEqual(expect.objectContaining({ id: 3, type: 'ready' }));
     });
+
+    it('contract: init loads the model/dtype from the load payload (Option B variant threading)', async () => {
+        const transcriber = vi.fn(async () => ({ text: '' }));
+        const pipeline = vi.fn(async () => transcriber);
+        vi.doMock('@huggingface/transformers', () => ({
+            env: {},
+            LogLevel: { ERROR: 'error' },
+            pipeline,
+        }));
+
+        await loadWorkerModule();
+        const dtype = { encoder_model: 'fp32', decoder_model_merged: 'q4' };
+        dispatchWorkerMessage({ id: 4, type: 'init', isE2E: false, model: 'onnx-community/whisper-base.en', dtype });
+
+        await vi.waitFor(() => {
+            expect(postedMessages).toContainEqual(expect.objectContaining({
+                id: 4,
+                type: 'loaded',
+                model: 'onnx-community/whisper-base.en',
+            }));
+        });
+        // The worker must use the payload model + dtype, NOT the hardcoded tiny default.
+        expect(pipeline).toHaveBeenCalledWith(
+            'automatic-speech-recognition',
+            'onnx-community/whisper-base.en',
+            expect.objectContaining({ dtype }),
+        );
+    });
 });

--- a/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    sanitizeDecodeOptions,
+    readPrivateDecodeOptionsOverride,
+    ALLOWED_DECODE_OPTIONS,
+} from '../whisperDecodeOptions';
+
+const setHook = (value: unknown) => {
+    (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__ = value;
+};
+const clearHook = () => {
+    delete (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+};
+
+describe('whisperDecodeOptions (v4 decode-option proof hook, BL-1)', () => {
+    describe('sanitizeDecodeOptions', () => {
+        it('returns undefined for non-objects', () => {
+            expect(sanitizeDecodeOptions(undefined)).toBeUndefined();
+            expect(sanitizeDecodeOptions(null)).toBeUndefined();
+            expect(sanitizeDecodeOptions('condition_on_previous_text')).toBeUndefined();
+            expect(sanitizeDecodeOptions(5)).toBeUndefined();
+        });
+
+        it('returns undefined when no allow-listed keys are present (product defaults preserved)', () => {
+            expect(sanitizeDecodeOptions({})).toBeUndefined();
+            expect(sanitizeDecodeOptions({ not_a_real_option: true, foo: 1 })).toBeUndefined();
+        });
+
+        it('keeps allow-listed boolean / number / number[] values', () => {
+            expect(sanitizeDecodeOptions({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+                compression_ratio_threshold: 2.4,
+                temperature: [0, 0.2, 0.4],
+            })).toEqual({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+                compression_ratio_threshold: 2.4,
+                temperature: [0, 0.2, 0.4],
+            });
+        });
+
+        it('drops disallowed keys but keeps allowed ones in the same object (no arbitrary injection)', () => {
+            expect(sanitizeDecodeOptions({ no_speech_threshold: 0.6, arbitrary_injection: 'rm -rf', model: 'evil' }))
+                .toEqual({ no_speech_threshold: 0.6 });
+        });
+
+        it('drops allow-listed keys whose value type is invalid', () => {
+            expect(sanitizeDecodeOptions({ condition_on_previous_text: 'false', temperature: ['x'] }))
+                .toBeUndefined();
+        });
+
+        it('exposes exactly the documented anti-loop knob set', () => {
+            expect([...ALLOWED_DECODE_OPTIONS].sort()).toEqual([
+                'compression_ratio_threshold',
+                'condition_on_previous_text',
+                'logprob_threshold',
+                'no_repeat_ngram_size',
+                'no_speech_threshold',
+                'return_timestamps',
+                'temperature',
+            ]);
+        });
+    });
+
+    describe('readPrivateDecodeOptionsOverride', () => {
+        afterEach(clearHook);
+
+        it('returns undefined when the hook is unset (product defaults preserved)', () => {
+            clearHook();
+            expect(readPrivateDecodeOptionsOverride()).toBeUndefined();
+        });
+
+        it('returns the sanitized override when the hook is set', () => {
+            setHook({ condition_on_previous_text: false, no_repeat_ngram_size: 3, bogus: 'ignored' });
+            expect(readPrivateDecodeOptionsOverride()).toEqual({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 3,
+            });
+        });
+
+        it('returns undefined when the hook holds only disallowed keys', () => {
+            setHook({ injected: true });
+            expect(readPrivateDecodeOptionsOverride()).toBeUndefined();
+        });
+    });
+});

--- a/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
+++ b/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
@@ -4,8 +4,8 @@ import { detectWebGPUSupport } from '../utils/webgpuSupport';
 type Pipeline = Awaited<ReturnType<typeof import('@huggingface/transformers')['pipeline']>>;
 
 type WorkerRequest =
-    | { id: number; type: 'init'; isE2E: boolean }
-    | { id: number; type: 'transcribe'; audio: Float32Array }
+    | { id: number; type: 'init'; isE2E: boolean; model?: string; dtype?: unknown; device?: string }
+    | { id: number; type: 'transcribe'; audio: Float32Array; decodeOptions?: Record<string, unknown> }
     | { id: number; type: 'destroy' };
 
 type WorkerResponse =
@@ -42,7 +42,7 @@ async function getPreferredDevice(): Promise<string | undefined> {
     return (await detectWebGPUSupport()).supported ? 'webgpu' : undefined;
 }
 
-function getAsrOptions(audioLengthSeconds: number): Record<string, unknown> {
+function getAsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
     const options: Record<string, unknown> = {
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
@@ -54,10 +54,16 @@ function getAsrOptions(audioLengthSeconds: number): Record<string, unknown> {
         options.task = 'transcribe';
     }
 
+    // Proof-hook overrides (allow-listed on the main thread) win over defaults. Inert unless the
+    // browser proof sets window.__PRIVATE_STT_DECODE_OPTIONS__ — product defaults are unchanged.
+    if (decodeOptions) {
+        Object.assign(options, decodeOptions);
+    }
+
     return options;
 }
 
-async function createPipeline(progress_callback: (data: unknown) => void): Promise<{ pipe: Pipeline; device: string }> {
+async function createPipeline(progress_callback: (data: unknown) => void, modelId: string, dtype: unknown, deviceOverride?: string): Promise<{ pipe: Pipeline; device: string }> {
     const transformers = await import('@huggingface/transformers');
     const { pipeline, env, LogLevel } = transformers;
 
@@ -66,9 +72,14 @@ async function createPipeline(progress_callback: (data: unknown) => void): Promi
     env.useBrowserCache = true;
     env.logLevel = LogLevel.ERROR;
 
-    const preferredDevice = await getPreferredDevice();
+    // DEV/TEST device override (root-cause A/B): 'wasm' forces CPU/WASM, 'webgpu' forces GPU.
+    const preferredDevice = deviceOverride === 'wasm'
+        ? undefined
+        : deviceOverride === 'webgpu'
+            ? 'webgpu'
+            : await getPreferredDevice();
     const options: Record<string, unknown> = {
-        dtype: PRIV_STT_V4.DTYPE,
+        dtype,
         progress_callback,
     };
     if (preferredDevice) {
@@ -77,7 +88,7 @@ async function createPipeline(progress_callback: (data: unknown) => void): Promi
 
     try {
         return {
-            pipe: await pipeline('automatic-speech-recognition', PRIV_STT_V4.MODEL_ID, options),
+            pipe: await pipeline('automatic-speech-recognition', modelId, options),
             device: preferredDevice ?? 'wasm-default',
         };
     } catch (error) {
@@ -88,7 +99,7 @@ async function createPipeline(progress_callback: (data: unknown) => void): Promi
         const fallbackOptions = { ...options };
         delete fallbackOptions.device;
         return {
-            pipe: await pipeline('automatic-speech-recognition', PRIV_STT_V4.MODEL_ID, fallbackOptions),
+            pipe: await pipeline('automatic-speech-recognition', modelId, fallbackOptions),
             device: 'wasm-fallback',
         };
     }
@@ -108,7 +119,7 @@ async function warmUp(id: number): Promise<void> {
     post({ id, type: 'warmed', warmupMs: Math.round(performance.now() - start) });
 }
 
-async function init(id: number, isE2E: boolean): Promise<void> {
+async function init(id: number, isE2E: boolean, modelId: string, dtype: unknown, deviceOverride?: string): Promise<void> {
     if (transcriber) {
         post({ id, type: 'ready' });
         return;
@@ -129,13 +140,13 @@ async function init(id: number, isE2E: boolean): Promise<void> {
     };
 
     const loadStart = performance.now();
-    const loaded = await createPipeline(progress_callback);
+    const loaded = await createPipeline(progress_callback, modelId, dtype, deviceOverride);
     transcriber = loaded.pipe;
     post({
         id,
         type: 'loaded',
         loadTimeMs: Math.round(performance.now() - loadStart),
-        model: PRIV_STT_V4.MODEL_ID,
+        model: modelId,
         device: loaded.device,
     });
     try {
@@ -148,7 +159,7 @@ async function init(id: number, isE2E: boolean): Promise<void> {
     post({ id, type: 'ready' });
 }
 
-async function transcribe(id: number, audio: Float32Array): Promise<void> {
+async function transcribe(id: number, audio: Float32Array, decodeOptions?: Record<string, unknown>): Promise<void> {
     if (!transcriber) {
         throw new Error('TransformersJSV4 worker engine not initialized. Call init() first.');
     }
@@ -157,7 +168,7 @@ async function transcribe(id: number, audio: Float32Array): Promise<void> {
     const audioLengthSeconds = samplesToSeconds(audio.length, PRIV_CLOUD_AUDIO.TARGET_SAMPLE_RATE_HZ);
     const result = await (transcriber as (audio: Float32Array, options: Record<string, unknown>) => Promise<string | TranscriptionResult>)(
         audio,
-        getAsrOptions(audioLengthSeconds),
+        getAsrOptions(audioLengthSeconds, decodeOptions),
     );
     const transcript = typeof result === 'string'
         ? result
@@ -179,10 +190,10 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
         try {
             switch (request.type) {
                 case 'init':
-                    await init(request.id, request.isE2E);
+                    await init(request.id, request.isE2E, request.model ?? PRIV_STT_V4.MODEL_ID, request.dtype ?? PRIV_STT_V4.DTYPE, request.device);
                     break;
                 case 'transcribe':
-                    await transcribe(request.id, request.audio);
+                    await transcribe(request.id, request.audio, request.decodeOptions);
                     break;
                 case 'destroy':
                     transcriber = null;

--- a/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
+++ b/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared Whisper decode-option proof hook (BL-1 / B-prevent-2).
+ *
+ * A test/release-proof seam that lets a browser proof A/B supported Whisper generation options
+ * WITHOUT changing product defaults. It is inert unless `window.__PRIVATE_STT_DECODE_OPTIONS__` is
+ * set, and only allow-listed keys are honored. The anti-loop knobs are included so Test can measure
+ * `condition_on_previous_text=false` / `no_repeat_ngram_size` / `compression_ratio_threshold` on the
+ * real WebGPU v4 model against the repetition-loop artifact, then we set a v4 default from evidence
+ * (a separate, evidence-backed change) rather than shipping a blind default.
+ *
+ * NOTE: the v2 engine (`TransformersJSEngine.ts`) currently carries its own private copy of this
+ * logic; consolidating it onto this module is a low-risk future cleanup (left out here to avoid
+ * touching the just-proven v2 path).
+ */
+
+export type WhisperDecodeOptions = Record<string, unknown>;
+
+/**
+ * Generation options a browser proof may override. Kept deliberately small and explicit — anything
+ * not in this set is ignored, so the hook can never inject arbitrary pipeline options.
+ */
+export const ALLOWED_DECODE_OPTIONS: ReadonlySet<string> = new Set([
+    'return_timestamps',
+    'condition_on_previous_text',
+    'compression_ratio_threshold',
+    'logprob_threshold',
+    'no_speech_threshold',
+    'no_repeat_ngram_size',
+    'temperature',
+]);
+
+/**
+ * Allow-list + type-guard a raw override object. Accepts only `boolean | number | number[]` values
+ * for allow-listed keys. Returns `undefined` when nothing valid is present (so callers can treat
+ * "no override" and "empty override" identically and keep product defaults).
+ */
+export function sanitizeDecodeOptions(source: unknown): WhisperDecodeOptions | undefined {
+    if (!source || typeof source !== 'object') return undefined;
+
+    const out: WhisperDecodeOptions = {};
+    for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+        if (!ALLOWED_DECODE_OPTIONS.has(key)) continue;
+        if (typeof value === 'boolean' || typeof value === 'number') {
+            out[key] = value;
+        } else if (Array.isArray(value) && value.every((item) => typeof item === 'number')) {
+            out[key] = value;
+        }
+    }
+
+    return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Main-thread only: read the proof-hook override from `window`. Returns `undefined` in a worker or
+ * SSR context (no `window`), or when the hook is unset/empty — i.e. product defaults are preserved.
+ */
+export function readPrivateDecodeOptionsOverride(): WhisperDecodeOptions | undefined {
+    if (typeof window === 'undefined') return undefined;
+    const source = (window as unknown as { __PRIVATE_STT_DECODE_OPTIONS__?: unknown }).__PRIVATE_STT_DECODE_OPTIONS__;
+    return sanitizeDecodeOptions(source);
+}

--- a/frontend/src/services/transcription/privateV4Experiment.ts
+++ b/frontend/src/services/transcription/privateV4Experiment.ts
@@ -1,0 +1,79 @@
+/**
+ * privateV4Experiment.ts — DEV/TEST-ONLY v4 decode root-cause overrides (device A/B + dtype).
+ *
+ * Forces the runtime device / decoder dtype / no-worker so the `invalid data location`
+ * decode failure can be isolated (see product_release/V4_DECODE_ROOT_CAUSE_EXPERIMENT.md).
+ * Gated EXACTLY like the private-engine override (dev/test/E2E only) — INERT in production:
+ * a normal user can never change the v4 device/dtype via URL or localStorage.
+ *
+ * Read on the MAIN thread only (Web Workers have no localStorage); the values are threaded
+ * to the worker via the init message. Never throws.
+ *
+ * Knobs (URL param OR localStorage key):
+ *   ?v4Device=webgpu|wasm|auto        / speaksharp.v4.device
+ *   ?v4DecoderDtype=q4|q8|int8|fp32    / speaksharp.v4.decoderDtype
+ *   ?v4Variant=base_q4|distil_q4       / speaksharp.v4.variant
+ *   ?v4NoWorker=1                      / speaksharp.v4.noWorker
+ */
+import { ENV } from '@/config/TestFlags';
+
+export type V4ExperimentDevice = 'webgpu' | 'wasm' | 'auto';
+export type V4ExperimentDecoderDtype = 'q4' | 'q8' | 'int8' | 'fp32';
+export type V4ExperimentVariant = 'base_q4' | 'distil_q4';
+
+export interface V4ExperimentOverrides {
+    /** Force the runtime device, bypassing WebGPU auto-detection. */
+    device?: V4ExperimentDevice;
+    /** Override decoder_model_merged dtype (the suspected q4-on-WASM failure). */
+    decoderDtype?: V4ExperimentDecoderDtype;
+    /**
+     * DEV/TEST-HARNESS-ONLY Gate A candidate selector (the base_q4 vs distil_q4 bakeoff). Honored
+     * ONLY with forceAuto, allowlisted to EXACTLY the two known candidates (unknown values fail
+     * closed to base_q4 — never an arbitrary model/path), and inert in production. NOT a PostHog/prod
+     * selector: the real distil control plane is the `private_stt_v4_distil_enabled` flag. Do NOT
+     * widen this allowlist or accept arbitrary model IDs/dtypes/devices here.
+     */
+    variant?: V4ExperimentVariant;
+    /** Force the main-thread pipeline (no Web Worker) to isolate worker-specific issues. */
+    noWorker: boolean;
+    /** Force the AUTO resolver to ATTEMPT v4 even without WebGPU — so headless CI can prove the
+     *  AUTO-path decode fallback (v4 attempt -> decode fail -> v2-base). Dev/test/E2E only. */
+    forceAuto: boolean;
+}
+
+const DEVICES: readonly string[] = ['webgpu', 'wasm', 'auto'];
+const DTYPES: readonly string[] = ['q4', 'q8', 'int8', 'fp32'];
+const VARIANTS: readonly string[] = ['base_q4', 'distil_q4'];
+
+/** Experiment overrides are honored ONLY in dev/test/E2E. Production build => false.
+ *  (Same gate as the private-engine override — see PrivateSTT.isPrivateOverrideContextAllowed.) */
+function experimentAllowed(): boolean {
+    return import.meta.env.DEV === true || ENV.isTest;
+}
+
+export function getV4ExperimentOverrides(
+    win: Window | undefined = typeof window !== 'undefined' ? window : undefined,
+): V4ExperimentOverrides {
+    if (!win || !experimentAllowed()) return { noWorker: false, forceAuto: false };
+    const read = (queryKey: string, storageKey: string): string | undefined => {
+        try {
+            const fromQuery = new URLSearchParams(win.location.search).get(queryKey);
+            if (fromQuery) return fromQuery;
+            return win.localStorage?.getItem(storageKey) ?? undefined;
+        } catch {
+            return undefined;
+        }
+    };
+    const device = read('v4Device', 'speaksharp.v4.device');
+    const decoderDtype = read('v4DecoderDtype', 'speaksharp.v4.decoderDtype');
+    const variant = read('v4Variant', 'speaksharp.v4.variant');
+    const noWorker = read('v4NoWorker', 'speaksharp.v4.noWorker') === '1';
+    const forceAuto = read('v4ForceAuto', 'speaksharp.v4.forceAuto') === '1';
+    return {
+        device: DEVICES.includes(device ?? '') ? (device as V4ExperimentDevice) : undefined,
+        decoderDtype: DTYPES.includes(decoderDtype ?? '') ? (decoderDtype as V4ExperimentDecoderDtype) : undefined,
+        variant: VARIANTS.includes(variant ?? '') ? (variant as V4ExperimentVariant) : undefined,
+        noWorker,
+        forceAuto,
+    };
+}

--- a/frontend/src/services/transcription/privateV4Flags.ts
+++ b/frontend/src/services/transcription/privateV4Flags.ts
@@ -1,0 +1,90 @@
+/**
+ * ============================================================================
+ * PRIVATE STT v4 — FEATURE FLAGS (flag-ready, OFF by default)
+ * ============================================================================
+ *
+ * v4 is a POST-paid-soft-launch, flag-gated path. It must never alter the
+ * default Private STT behavior. With every flag off, Private STT is functionally
+ * identical to the v2-base default (`whisper-base.en` + v2-tiny fallback).
+ *
+ * Exposure hierarchy (product decision):
+ *  - PostHog runtime flags  = primary control (real kill switch + cohort targeting).
+ *  - `?privateEngine=transformers-js-v4` / localStorage = dev/test override ONLY
+ *    (handled in PrivateSTT.getPrivateEngineOverride, not here).
+ *  - Build env `VITE_PRIVATE_STT_V4_DISABLED=true` = HARD global disable that
+ *    overrides every flag (a build-time kill switch).
+ *
+ * Safety: never throws. SSR/no-window, uninitialized PostHog, or any read error
+ * all resolve to OFF — the safe default. No user-facing engine internals here.
+ */
+import posthog from 'posthog-js';
+import logger from '@/lib/logger';
+
+/** PostHog flag keys. Keep in sync with the PostHog project. */
+export const V4_FLAG_KEYS = {
+  /** Master switch: may the resolver consider v4 at all for this user? */
+  ENABLED: 'private_stt_v4_enabled',
+  /** May the WebGPU distil-q4 accuracy tier be considered (still gated on real WebGPU)? */
+  DISTIL_ENABLED: 'private_stt_v4_distil_enabled',
+  /** Restrict v4 to internal testers (cohort is enforced by PostHog targeting). */
+  INTERNAL_ONLY: 'private_stt_v4_internal_only',
+} as const;
+
+export interface V4FlagState {
+  /** Master switch — when false the resolver never selects v4. */
+  v4Enabled: boolean;
+  /** distil-q4 accuracy tier eligible (only meaningful when v4Enabled + real WebGPU). */
+  distilEnabled: boolean;
+  /** Informational: this exposure is internal-only. */
+  internalOnly: boolean;
+  /** Build-level hard kill forced everything off, regardless of PostHog. */
+  hardDisabled: boolean;
+}
+
+const ALL_OFF: V4FlagState = {
+  v4Enabled: false,
+  distilEnabled: false,
+  internalOnly: false,
+  hardDisabled: false,
+};
+
+const V4_HARD_DISABLED: boolean = (() => {
+  try {
+    return import.meta.env?.VITE_PRIVATE_STT_V4_DISABLED === 'true';
+  } catch {
+    return false;
+  }
+})();
+
+function readFlag(key: string): boolean {
+  try {
+    // posthog.isFeatureEnabled returns boolean | undefined (undefined before flags load).
+    return posthog?.isFeatureEnabled?.(key) === true;
+  } catch (error) {
+    logger.debug?.({ error, key }, '[privateV4Flags] feature-flag read failed; defaulting OFF');
+    return false;
+  }
+}
+
+/**
+ * Resolve the current v4 flag state. Any failure / no-window / hard-disable => all OFF.
+ * distilEnabled is only true when v4 is also enabled (cannot enable the accuracy
+ * tier without the master switch).
+ */
+export function getV4FlagState(): V4FlagState {
+  if (typeof window === 'undefined') return { ...ALL_OFF };
+  if (V4_HARD_DISABLED) return { ...ALL_OFF, hardDisabled: true };
+
+  const v4Enabled = readFlag(V4_FLAG_KEYS.ENABLED);
+  return {
+    v4Enabled,
+    distilEnabled: v4Enabled && readFlag(V4_FLAG_KEYS.DISTIL_ENABLED),
+    internalOnly: readFlag(V4_FLAG_KEYS.INTERNAL_ONLY),
+    hardDisabled: false,
+  };
+}
+
+/** Convenience: may Private STT consider the v4 path for this user right now? */
+export function isV4FlagEnabled(): boolean {
+  return getV4FlagState().v4Enabled;
+}

--- a/frontend/src/services/transcription/privateV4Telemetry.ts
+++ b/frontend/src/services/transcription/privateV4Telemetry.ts
@@ -1,0 +1,153 @@
+/**
+ * privateV4Telemetry.ts — Stage-B v4 rollout telemetry (lifecycle events).
+ *
+ * Centralizes the v4 PostHog event NAMES plus a STRICT non-PII property ALLOWLIST.
+ * The allowlist is the privacy guarantee: only the enumerated keys are ever sent, so
+ * no caller can leak `email`, transcript text, audio, raw stack traces, provider
+ * payloads, or Stripe secrets — even by accident. `userId` rides PostHog's
+ * `distinct_id` (set via `identify(userId)`); it is NEVER a property here.
+ *
+ * These events are emitted only when v4 is the selected engine (callers gate on the
+ * flag / resolved variant). Emission NEVER throws — telemetry must not affect the
+ * transcription path. This module has no side effects beyond an optional
+ * `posthog.capture` + a structured internal log.
+ *
+ * Stage gating: this is wired into the v4 lifecycle ONLY after v4 lands inert on
+ * main (task #84). The module itself is inert until its emitters are called.
+ */
+import posthog from 'posthog-js';
+import logger from '@/lib/logger';
+
+export const V4_TELEMETRY_EVENTS = {
+    ATTEMPT: 'private_stt_v4_attempt',
+    READY: 'private_stt_v4_ready',
+    DECODE_COMPLETE: 'private_stt_v4_decode_complete',
+    FALLBACK: 'private_stt_v4_fallback',
+    SESSION_SAVED: 'private_stt_v4_session_saved',
+    ERROR: 'private_stt_v4_error',
+} as const;
+
+export type V4TelemetryEvent = typeof V4_TELEMETRY_EVENTS[keyof typeof V4_TELEMETRY_EVENTS];
+
+/**
+ * The ONLY property keys allowed to leave the client. Every key here is non-PII
+ * engineering/outcome metadata. Anything not in this list is dropped by
+ * `sanitizeV4TelemetryProps` before it can reach PostHog or the logs.
+ */
+export const V4_TELEMETRY_ALLOWED_PROPS = [
+    'engine',
+    'variant',
+    'model',
+    'dtype',
+    'requestedDevice',
+    'resolvedDevice',
+    'webgpuAvailable',
+    'fallbackAttempted',
+    'fallbackReason',
+    'loadMs',
+    'decodeMs',
+    'rtf',
+    'recordStarted',
+    'stopSucceeded',
+    'saved',
+    'historyOpened',
+    'errorClass',
+] as const;
+
+export type V4TelemetryProp = typeof V4_TELEMETRY_ALLOWED_PROPS[number];
+export type V4TelemetryProps = Partial<Record<V4TelemetryProp, string | number | boolean | null>>;
+
+const ALLOWED = new Set<string>(V4_TELEMETRY_ALLOWED_PROPS);
+
+/**
+ * Project arbitrary input down to the allowlist. Anything not enumerated (email,
+ * transcript, audio, stack, provider payload, secrets, …) is DROPPED. `undefined`
+ * values are omitted; `null` is preserved (meaningful "absent"). Only primitives
+ * survive — objects/arrays are dropped so a nested PII blob can never ride along.
+ */
+export function sanitizeV4TelemetryProps(input?: Record<string, unknown>): V4TelemetryProps {
+    const out: V4TelemetryProps = {};
+    if (!input) return out;
+    for (const key of Object.keys(input)) {
+        if (!ALLOWED.has(key)) continue; // allowlist: silently drop everything else
+        const value = input[key];
+        if (value === undefined) continue;
+        if (
+            value === null ||
+            typeof value === 'string' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+        ) {
+            out[key as V4TelemetryProp] = value;
+        }
+        // objects/arrays/functions are intentionally dropped (potential PII containers).
+    }
+    return out;
+}
+
+/**
+ * Emit a v4 telemetry event with allowlisted props. Never throws. `userId` is NOT a
+ * property — PostHog associates the event with the identified user's `distinct_id`.
+ */
+export function emitV4Telemetry(event: V4TelemetryEvent, props?: Record<string, unknown>): void {
+    try {
+        const safe = sanitizeV4TelemetryProps(props);
+        logger.info({ ...safe, event }, '[V4_TELEMETRY]');
+        try {
+            posthog?.capture?.(event, safe);
+        } catch {
+            /* posthog optional — never let analytics break the STT path */
+        }
+    } catch {
+        /* sanitize/log must never throw into the transcription path */
+    }
+}
+
+/**
+ * Pure mapper: build the allowlisted lifecycle property bag from the v4 runtime
+ * decision + outcome. Keeps the call sites thin and testable, and routes through
+ * `sanitizeV4TelemetryProps` so only non-PII keys survive. `fallbackAttempted` is
+ * derived (true iff a fallback reason is present).
+ */
+export function buildV4LifecycleProps(input: {
+    finalEngine?: string | null;
+    variant?: string | null;
+    model?: string | null;
+    dtype?: string | null;
+    requestedDevice?: string | null;
+    resolvedDevice?: string | null;
+    webgpuAvailable?: boolean;
+    fallbackReason?: string | null;
+    loadMs?: number | null;
+    decodeMs?: number | null;
+    rtf?: number | null;
+}): V4TelemetryProps {
+    // Pass inputs through as-is: sanitize omits `undefined`, keeps `null`/values. The
+    // caller decides which fields to force-present (by passing `?? null`); fields it
+    // does not know yet (e.g. decodeMs on a ready event) are simply omitted.
+    return sanitizeV4TelemetryProps({
+        engine: input.finalEngine,
+        variant: input.variant,
+        model: input.model,
+        dtype: input.dtype,
+        requestedDevice: input.requestedDevice,
+        resolvedDevice: input.resolvedDevice,
+        webgpuAvailable: input.webgpuAvailable,
+        fallbackAttempted: input.fallbackReason != null,
+        fallbackReason: input.fallbackReason,
+        loadMs: input.loadMs,
+        decodeMs: input.decodeMs,
+        rtf: input.rtf,
+    });
+}
+
+export const emitV4Ready = (props?: Record<string, unknown>): void =>
+    emitV4Telemetry(V4_TELEMETRY_EVENTS.READY, props);
+export const emitV4DecodeComplete = (props?: Record<string, unknown>): void =>
+    emitV4Telemetry(V4_TELEMETRY_EVENTS.DECODE_COMPLETE, props);
+export const emitV4Fallback = (props?: Record<string, unknown>): void =>
+    emitV4Telemetry(V4_TELEMETRY_EVENTS.FALLBACK, props);
+export const emitV4SessionSaved = (props?: Record<string, unknown>): void =>
+    emitV4Telemetry(V4_TELEMETRY_EVENTS.SESSION_SAVED, props);
+export const emitV4Error = (props?: Record<string, unknown>): void =>
+    emitV4Telemetry(V4_TELEMETRY_EVENTS.ERROR, props);

--- a/frontend/src/services/transcription/sttConstants.ts
+++ b/frontend/src/services/transcription/sttConstants.ts
@@ -130,6 +130,51 @@ export const PRIV_STT_V4 = {
 } as const;
 
 /**
+ * v4 model TIERS for the flag-gated resolver (v4 = @huggingface/transformers).
+ * Only active when the v4 feature flag is on; flag-off behavior is unchanged.
+ *
+ *  - base_q4   = the universal FLOOR. Works on WASM (RTF ~0.72) and WebGPU
+ *                (~0.094). ~142 MB split download. Default flagged v4 engine.
+ *  - distil_q4 = the WebGPU ACCURACY tier (~21% lower WER than v2-base on hard
+ *                speech). ~251 MB and WebGPU-only — WASM RTF ~2.2 is unusable —
+ *                so it is selected ONLY when WebGPU is confirmed AND the distil
+ *                flag + user qualification are on. Never the universal default.
+ *
+ * dtype is the split scheme (fp32 encoder + q4 decoder), matching the bakeoff
+ * sizes (LibriSpeech test-other, Apple Metal). Selection is via the resolver; the
+ * engine reads the chosen variant. base_q4 is the first flagged rollout floor.
+ */
+export const PRIV_STT_V4_VARIANTS = {
+  base_q4: {
+    id: 'base_q4',
+    MODEL_ID: 'onnx-community/whisper-base.en',
+    DTYPE: { encoder_model: 'fp32', decoder_model_merged: 'q4' },
+    EXPECTED_SPLIT_DOWNLOAD_MB: 142,
+    requiresWebGPU: false,
+  },
+  distil_q4: {
+    id: 'distil_q4',
+    MODEL_ID: 'onnx-community/distil-small.en',
+    DTYPE: { encoder_model: 'fp32', decoder_model_merged: 'q4' },
+    EXPECTED_SPLIT_DOWNLOAD_MB: 251,
+    requiresWebGPU: true,
+  },
+} as const;
+
+export type PrivSttV4VariantId = keyof typeof PRIV_STT_V4_VARIANTS;
+
+/** First flagged rollout floor (reviewer: base_q4 before distil_q4). */
+export const PRIV_STT_V4_DEFAULT_VARIANT: PrivSttV4VariantId = 'base_q4';
+
+/**
+ * Single source of truth for the explicit private-engine override localStorage key.
+ * Shared by `PrivateSTT` (override read) and `sttIdentity` (debug mirror) so the two
+ * cannot drift. NOTE: the override itself is honored only in dev/test/E2E — see
+ * `PrivateSTT.getPrivateEngineOverride`. It is NOT a production user affordance.
+ */
+export const PRIVATE_ENGINE_OVERRIDE_KEY = 'speaksharp.private.engine';
+
+/**
  * Private model-eval candidates (flag-gated A/B). The CI Private v2 benchmark showed
  * ~51.7% WER vs a 6.1% ceiling, so decode/model quality — not just onset detection — is
  * the dominant gap. This lets the test agent A/B larger local models against the default

--- a/frontend/src/services/transcription/sttIdentity.ts
+++ b/frontend/src/services/transcription/sttIdentity.ts
@@ -13,7 +13,7 @@
  * `userHidden` is true for Private.
  */
 import { NOT_AVAILABLE, type Maybe } from './sttEvidence';
-import { PRIV_STT_MODELS } from './sttConstants';
+import { PRIV_STT_MODELS, PRIVATE_ENGINE_OVERRIDE_KEY } from './sttConstants';
 import {
     resolvePrivateModel,
     resolvePrivateModelSource,
@@ -193,12 +193,15 @@ interface V4RuntimeGlobal {
     onnxRuntimeVersion?: string;
 }
 
-/** Read the raw `?privateEngine=` / localStorage engine override (mirrors PrivateSTT, no import). */
+/** Read the raw `?privateEngine=` / localStorage engine override. Uses the SAME shared
+ *  `PRIVATE_ENGINE_OVERRIDE_KEY` as PrivateSTT so this debug mirror cannot drift from the
+ *  real override key. (Diagnostic display only — the badge is debug-gated; gating of the
+ *  override BEHAVIOR lives in PrivateSTT.) */
 function readEngineOverride(win: Window): string | null {
     try {
         const fromQuery = new URLSearchParams(win.location.search).get('privateEngine');
         if (fromQuery && fromQuery.length > 0) return fromQuery;
-        const stored = win.localStorage?.getItem('speaksharp_private_engine_override');
+        const stored = win.localStorage?.getItem(PRIVATE_ENGINE_OVERRIDE_KEY);
         if (stored && stored.length > 0) return stored;
     } catch {
         /* ignore */

--- a/frontend/src/services/transcription/utils/__tests__/privateRuntimePath.test.ts
+++ b/frontend/src/services/transcription/utils/__tests__/privateRuntimePath.test.ts
@@ -121,6 +121,69 @@ describe('resolvePrivateRuntimePath — policy order (CPU is the floor)', () => 
   });
 });
 
+describe('resolvePrivateRuntimePath — v4 flag-gated tiering (controlled, base/distil)', () => {
+  it('v4 omitted → never selects v4 (byte-identical v2/CPU default), even with WebGPU present', async () => {
+    setGpu(workingAdapter());
+    setIsolated(false);
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false });
+    expect(d.provider).toBe('transformers-js');
+    expect(d.v4Variant).toBeNull();
+  });
+
+  it('v4 { enabled:false } → never selects v4', async () => {
+    setGpu(workingAdapter());
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: false, distilEnabled: false } });
+    expect(d.provider).toBe('transformers-js');
+    expect(d.v4Variant).toBeNull();
+  });
+
+  it('v4 enabled + WebGPU, no distil flag → base_q4 floor', async () => {
+    setGpu(workingAdapter());
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: true, distilEnabled: false } });
+    expect(d.provider).toBe('transformers-js-v4');
+    expect(d.v4Variant).toBe('base_q4');
+    expect(d.runtime).toBe('webgpu');
+    expect(d.reason).toBe('webgpu_available_v4_flag');
+    expect(d.fallbackAvailable).toBe(true);
+  });
+
+  it('v4 enabled + distil flag + WebGPU → distil_q4 accuracy tier', async () => {
+    setGpu(workingAdapter());
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: true, distilEnabled: true } });
+    expect(d.provider).toBe('transformers-js-v4');
+    expect(d.v4Variant).toBe('distil_q4');
+  });
+
+  it('v4 enabled + NO WebGPU → v2-base (conservative; no v4 on WASM)', async () => {
+    setGpu(undefined);
+    setIsolated(false);
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: true, distilEnabled: true } });
+    expect(d.provider).toBe('transformers-js');
+    expect(d.v4Variant).toBeNull();
+  });
+
+  it('v4 enabled + forceAuto + NO WebGPU → v4 base_q4 on WASM (dev/test headless-CI fallback proof)', async () => {
+    setGpu(undefined);
+    setIsolated(false);
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: true, distilEnabled: false, forceAuto: true } });
+    expect(d.provider).toBe('transformers-js-v4');     // AUTO path attempts v4 without WebGPU
+    expect(d.v4Variant).toBe('base_q4');
+    expect(d.runtime).toBe('wasm-singlethread');
+    expect(d.reason).toBe('v4_forced_auto');
+    expect(d.webgpuAvailable).toBe(false);
+    expect(d.acceleration).toBe('cpu');
+    expect(d.fallbackAvailable).toBe(true);            // still falls back to v2-base on failure
+  });
+
+  it('v4 enabled + WebGPU detection throws → v2-base floor (never strands)', async () => {
+    setGpu({ requestAdapter: vi.fn().mockRejectedValue(new Error('boom')) });
+    setIsolated(false);
+    const d = await resolvePrivateRuntimePath({ webgpuPromotionAllowed: false, turboModelCached: false, v4: { enabled: true, distilEnabled: false } });
+    expect(d.provider).toBe('transformers-js');
+    expect(d.v4Variant).toBeNull();
+  });
+});
+
 describe('describePrivateRuntimePath — honest UX copy', () => {
   const cases: Array<[PrivateRuntimeDecision['runtime'], RegExp]> = [
     ['webgpu', /GPU acceleration/i],

--- a/frontend/src/services/transcription/utils/privateRuntimePath.ts
+++ b/frontend/src/services/transcription/utils/privateRuntimePath.ts
@@ -11,6 +11,12 @@
  *   3. CPU single-thread otherwise — the GUARANTEED local floor.
  *   4. Cloud             NEVER automatic. `cloudFallbackAttempted` is always false.
  *
+ * v4 (post-paid-soft-launch, flag-gated) layers ON TOP via the optional `v4`
+ * input. When `v4` is omitted or disabled the resolver behaves byte-identically
+ * to the v2-base default — v4 is NEVER selected. When enabled, v4 is selected
+ * ONLY on confirmed WebGPU (conservative first rollout: no-WebGPU stays v2-base),
+ * and always keeps v2-base as the init/load fallback.
+ *
  * The resolver returns a flat, fully-populated decision object so selection, UX
  * copy, diagnostics/telemetry, and tests all derive from one source of truth.
  * It does not instantiate engines or download anything — it only describes the
@@ -24,11 +30,14 @@ import {
   getHardwareThreads,
   isCrossOriginIsolated,
 } from './wasmThreads';
+import type { PrivSttV4VariantId } from '../sttConstants';
 
 export type PrivateRuntimeKind = 'webgpu' | 'wasm-multithread' | 'wasm-singlethread';
 
 export type PrivateRuntimeReason =
   | 'webgpu_available_and_model_cached'
+  | 'webgpu_available_v4_flag'
+  | 'v4_forced_auto'
   | 'no_webgpu_cross_origin_isolated'
   | 'no_webgpu_or_isolation';
 
@@ -42,8 +51,17 @@ export interface PrivateRuntimeDecision {
   /** Concrete engine the facade will initialize. (The GPU tier is parked; the WebGPU
    *  successor engine is transformers-js-v4 — whisper-turbo was retired.) */
   provider: 'transformers-js-v4' | 'transformers-js';
+  /** When provider is v4, which model TIER was chosen; null on the v2/CPU path. */
+  v4Variant: PrivSttV4VariantId | null;
   /** Acceleration class. */
   acceleration: 'gpu' | 'cpu';
+  /**
+   * Runtime ELIGIBILITY reason — why this runtime path was available/chosen. This is NOT the
+   * selection source: do not infer `selectionSource` from it (on real WebGPU this reads
+   * `webgpu_available_v4_flag` for BOTH a real-flag selection AND a dev/test forceAuto run).
+   * Examples: WebGPU available + v4 flag, no WebGPU, cross-origin isolation. See `selectionSource`
+   * for WHO selected the engine.
+   */
   reason: PrivateRuntimeReason;
   /** Whether a usable WebGPU adapter was detected (probed only when promotion is allowed). */
   webgpuAvailable: boolean;
@@ -57,6 +75,19 @@ export interface PrivateRuntimeDecision {
   fallbackAvailable: boolean;
   /** Privacy invariant: cloud is never an automatic fallback. Always false. */
   cloudFallbackAttempted: false;
+  /**
+   * WHO/WHAT selected the engine — an ORTHOGONAL dimension to `reason` (which explains runtime
+   * ELIGIBILITY, not who selected). Explicit data, NEVER inferred from `reason`:
+   *   - 'posthog_flag' : the real PostHog flag drove a v4 selection (Gate B / production v4).
+   *   - 'dev_harness'  : only the dev/test `forceAuto` shim drove it (Gate A value run; never production).
+   *   - 'default'      : the v2-base default path (flag off, flag on but no WebGPU, or promotion not allowed).
+   * NOTE: on real WebGPU `reason` reads `webgpu_available_v4_flag` for BOTH the flag AND forceAuto
+   * (because `webgpuAvailable===true`), so THIS field — not `reason` — is the honest selection signal.
+   * Gate A (forceAuto) ⇒ 'dev_harness'; Gate B (real flag) ⇒ 'posthog_flag'; v2 ⇒ 'default'.
+   * Decode-time FALLBACK is a separate outcome (orthogonal again): it's recorded via the telemetry
+   * `fallbackReason`/`finalProvider` so we keep WHO originally selected v4, not collapse it to 'fallback'.
+   */
+  selectionSource: 'posthog_flag' | 'dev_harness' | 'default';
 }
 
 export interface ResolvePrivateRuntimePathOptions {
@@ -73,6 +104,22 @@ export interface ResolvePrivateRuntimePathOptions {
    * the decision regardless of the outcome.
    */
   turboModelCached: boolean;
+  /**
+   * v4 flag-gated tiering. When omitted or { enabled:false } the resolver behaves
+   * identically to the v2-base default — v4 is NEVER selected, so flag-off is
+   * byte-identical. When enabled, v4 is selected ONLY on confirmed WebGPU
+   * (no-WebGPU stays the v2-base CPU floor). `distilEnabled` selects the WebGPU
+   * ACCURACY tier (distil_q4) on top of WebGPU; otherwise base_q4 is the WebGPU
+   * floor. Exposure stays controlled by the flags; both tiers are implemented.
+   */
+  v4?: {
+    enabled: boolean;
+    distilEnabled: boolean;
+    /** DEV/TEST-only: attempt v4 even WITHOUT WebGPU (headless-CI AUTO fallback proof). */
+    forceAuto?: boolean;
+    /** Honest selection provenance the caller computed (real PostHog flag vs dev/test forceAuto shim). */
+    selectionSource?: 'posthog_flag' | 'dev_harness';
+  };
 }
 
 function cpuDecision(crossOriginIsolated: boolean, webgpuAvailable: boolean, turboCached: boolean): PrivateRuntimeDecision {
@@ -81,6 +128,7 @@ function cpuDecision(crossOriginIsolated: boolean, webgpuAvailable: boolean, tur
   return {
     runtime: multithread ? 'wasm-multithread' : 'wasm-singlethread',
     provider: 'transformers-js',
+    v4Variant: null,
     acceleration: 'cpu',
     reason: multithread ? 'no_webgpu_cross_origin_isolated' : 'no_webgpu_or_isolation',
     webgpuAvailable,
@@ -89,6 +137,7 @@ function cpuDecision(crossOriginIsolated: boolean, webgpuAvailable: boolean, tur
     wasmThreadCount: multithread ? threads : 1,
     fallbackAvailable: false, // CPU is the floor — nothing safer to fall back to.
     cloudFallbackAttempted: false,
+    selectionSource: 'default', // v2-base default path (flag off / no WebGPU / promotion not allowed).
   };
 }
 
@@ -99,6 +148,46 @@ export async function resolvePrivateRuntimePath(
   options: ResolvePrivateRuntimePathOptions,
 ): Promise<PrivateRuntimeDecision> {
   const isolated = isCrossOriginIsolated();
+
+  // v4 flag-gated path (post-paid-soft-launch). CONSERVATIVE: v4 is selected ONLY
+  // on confirmed WebGPU; no-WebGPU stays the v2-base CPU floor. Omitted/disabled
+  // `v4` never enters here, so flag-off behavior is byte-identical to the default.
+  if (options.v4?.enabled) {
+    let webgpuAvailable = false;
+    try {
+      webgpuAvailable = (await detectWebGPUSupport()).supported;
+    } catch {
+      webgpuAvailable = false;
+    }
+
+    // v4 is selected on confirmed WebGPU (the conservative rollout). The DEV/TEST-only
+    // `forceAuto` knob ALSO selects v4 without WebGPU so headless CI can exercise the
+    // AUTO-path decode fallback (v4 attempt -> decode fail -> v2-base). forceAuto is gated
+    // in PrivateSTT (dev/test/E2E only) and is never set in production.
+    if (webgpuAvailable || options.v4.forceAuto) {
+      // Both v4 tiers load via the worker model-param. distil_q4 is the WebGPU ACCURACY tier
+      // and requires its own explicit flag ON TOP of WebGPU; otherwise base_q4 is the floor.
+      const v4Variant: PrivSttV4VariantId = options.v4.distilEnabled ? 'distil_q4' : 'base_q4';
+      return {
+        runtime: webgpuAvailable ? 'webgpu' : 'wasm-singlethread',
+        provider: 'transformers-js-v4',
+        v4Variant,
+        acceleration: webgpuAvailable ? 'gpu' : 'cpu',
+        reason: webgpuAvailable ? 'webgpu_available_v4_flag' : 'v4_forced_auto',
+        // Honest provenance — independent of `reason` (which conflates flag vs forceAuto on real WebGPU).
+        selectionSource: options.v4.selectionSource ?? (options.v4.forceAuto ? 'dev_harness' : 'posthog_flag'),
+        webgpuAvailable,
+        turboCached: options.turboModelCached,
+        crossOriginIsolated: isolated,
+        wasmThreadCount: webgpuAvailable ? 0 : 1,
+        fallbackAvailable: true, // v4 can safely fall back to the v2-base CPU floor.
+        cloudFallbackAttempted: false,
+      };
+    }
+
+    // Flag on but no WebGPU (and not forced) → conservative rollout stays on the v2-base floor.
+    return cpuDecision(isolated, false, options.turboModelCached);
+  }
 
   // Tier 1: WebGPU acceleration — only considered when explicitly allowed.
   if (options.webgpuPromotionAllowed) {
@@ -113,6 +202,7 @@ export async function resolvePrivateRuntimePath(
       return {
         runtime: 'webgpu',
         provider: 'transformers-js-v4',
+        v4Variant: null,
         acceleration: 'gpu',
         reason: 'webgpu_available_and_model_cached',
         webgpuAvailable: true,
@@ -121,6 +211,7 @@ export async function resolvePrivateRuntimePath(
         wasmThreadCount: 0, // N/A on the GPU path.
         fallbackAvailable: true, // GPU can safely fall back to the CPU floor.
         cloudFallbackAttempted: false,
+        selectionSource: 'default', // parked legacy-turbo GPU promotion — not flag/forceAuto driven.
       };
     }
 

--- a/frontend/src/types/transcription.ts
+++ b/frontend/src/types/transcription.ts
@@ -24,6 +24,15 @@ export interface TranscriptUpdate {
         partial?: string;
         final?: string;
         speaker?: string;
+        /**
+         * When true, this `final` is a COMPLETE re-transcription that REPLACES the accumulated
+         * rolling transcript — not an incremental segment to append. Set ONLY by Private's post-Stop
+         * whole-utterance decode; rolling finals, partials, and Native/Cloud finals must leave it
+         * unset. Without it the generic prefix/suffix/append merge concatenates rolling preview +
+         * final decode (duplication / inflated WER). An empty/whitespace final never wipes existing
+         * text even when this is true. Defaults to append.
+         */
+        replacesRollingTranscript?: boolean;
     };
     chunks?: { timestamp: [number, number]; text: string }[];
 }

--- a/product_release/BACKLOG.md
+++ b/product_release/BACKLOG.md
@@ -509,3 +509,17 @@ bloat / post-beta class — **none are new beta-GO blockers.**
 - Edge-function CORS = origin allowlist (no wildcards).
 - No `@stripe/stripe-js` embedded in the shipped app (checkout = redirect).
 - 0 real code smells in `frontend/src`; rotation runbook complete (`SECRET_ROTATION_RUNBOOK.md`).
+
+## Private STT v4 — dormant infrastructure on main (convergence, not launch)
+
+The v4 (transformers-js-v4 / WebGPU) infrastructure is merged to `main` as **dormant, flag-OFF**
+code to close out the long-lived `dev/v4-integration` branch. v4 is **not launched**:
+- `privateV4Flags` resolves **OFF by default** (PostHog flag absent → off; build kill-switch available).
+- With the flag off, Private STT is byte-identical to the v2-base default (`resolvePrivateRuntimePath`
+  never selects v4); Browser/Cloud/sample/save paths are unchanged.
+- Telemetry (`privateV4Telemetry`) is non-PII (strict allowlist; no transcript/audio/email/name).
+- No user-facing v4/base_q4/distil copy.
+
+**Deferred to activation (post-release, not in this convergence):** flag-ON app-path lifecycle proof (#76),
+v4 cross-utterance/decode tuning, the v4 decode-complete telemetry hook in `PrivateWhisper`, and the
+Stage-B `SpeechRuntimeController` telemetry wiring — all to be re-derived/proved when v4 is intentionally enabled.


### PR DESCRIPTION
## Summary

Closes out the long-lived `dev/v4-integration` branch by converging its **dormant, flag-OFF** infrastructure onto `main` via a **controlled additive port** — **not** a wholesale merge. This is **codebase convergence, not a v4 launch.** v4 stays OFF by default.

## Why additive, not a branch merge
`dev/v4-integration` is 24 commits behind / 83 ahead of `main` (branched before #770/#773/#774/#775/#777/#778/#772/#779), with **54 collisions** on the just-shipped, live-proven release stack. A wholesale merge would risk regressing those fixes. Instead this PR ports only the **isolated, non-collided v4 infrastructure** on top of current `main`.

## What landed (additive only)
- **New modules:** `privateV4Flags` (**default OFF** + build kill-switch), `privateV4Telemetry` (**non-PII allowlist**), `privateV4Experiment` (ENV-only), `engines/whisperDecodeOptions` (pure).
- **v4 versions of NON-collided infra** (main never changed these since the branch point → no main fix overwritten): `PrivateSTT` (flag wiring → existing `resolvePrivateRuntimePath`), `TransformersJSV4Engine` + worker, `utils/privateRuntimePath` (flag-gated v4 tier), `sttConstants`, `sttIdentity`, `types/transcription`.

## What was deliberately kept at main's version (collided/shipped/proven)
`TranscriptionService`, `PrivateWhisper`, `LiveTranscriptPanel`, `liveTranscriptUtils`, `useSessionLifecycle`, `AnalyticsBuffer`, `SessionPage`, `subscriptionTiers`, entitlement migrations, edge fns, all collided unit tests, and all live/e2e specs.

## Excluded v4-lane churn
storage→`sessionRepository` rename, domain/service refactors, posthog A/B proof scripts, v4 memo/runbook docs.

## Flag-OFF = today's behavior (safety)
- `resolvePrivateRuntimePath` never selects v4 unless explicitly enabled → Private = v2-base default.
- No user-facing `v4`/`base_q4`/`distil` copy. Telemetry is non-PII (drops transcript/audio/email/name; `userId` only via `distinct_id`).
- No entitlement/Stripe/transcript-mutation changes. #773/#777/#778 + #770 preserved. #85 untouched.

## Deferred to activation (in `BACKLOG.md`, not this PR)
Flag-ON app-path lifecycle proof (#76), v4 decode tuning, and the v4 decode-complete (`PrivateWhisper`) + Stage-B (`SpeechRuntimeController`) telemetry hooks — re-derived/proved when v4 is intentionally enabled.

## Verification
- `tsc` clean · `eslint` clean · production build OK · no v4 wording in `components`/`pages`.
- **81** v4 unit tests pass.
- **191** shipped-path tests pass **with the v4 infra present** (PrivateWhisper 43, TranscriptionService pause/race/zombie, useSessionLifecycle 12, LiveTranscriptPanel 48, useSessionStore 18, SessionPage 7, subscriptionTiers 33, repetitionRisk 6, v4 workers) — proving shipped paths are **inert** with the flag OFF.

## For Test (dormant-v4 validation)
Prove: v4 unavailable with flag OFF · Browser/Private-v2/Cloud/sample/save/analytics unchanged · no v4 UI copy · telemetry non-PII · release proof still green. Then the deletion gate applies (see below).

## Branch cleanup (gated — do NOT delete yet)
`dev/v4-integration` and all v4 branches are deleted **only after**: this PR merged + CI green + production canary green + scoped release proof green + Test confirms dormant/flag-OFF + release-owner approves the deletion table. **Durable `archive/*-pre-main-convergence` tags will be created before any deletion.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
