### PR TITLE
fix(auth): remove email from AuthPage structured client logs (P3 privacy)

### DIFF
--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -76,10 +76,11 @@ export default function AuthPage() {
 
       let authResult;
       if (view === 'sign_in') {
-        logger.info({ email }, '[AuthPage] Attempting sign_in');
+        // Non-PII structured log only: never log the email address.
+        logger.info({ event: 'sign_in', phase: 'attempt' }, '[AuthPage] sign-in attempt');
         authResult = await supabase.auth.signInWithPassword({ email, password });
       } else if (view === 'sign_up') {
-        logger.info({ email }, '[AuthPage] Attempting sign_up');
+        logger.info({ event: 'sign_up', phase: 'attempt' }, '[AuthPage] sign-up attempt');
         
         const { error: signUpError } = await supabase.auth.signUp({
           email,
@@ -137,7 +138,8 @@ export default function AuthPage() {
         logger.info('[AuthPage] Sign-up successful, awaiting email confirmation');
         setMessage('Success! Please check your email for a confirmation link.');
       } else {
-        logger.error({ data: authResult.data }, '[AuthPage CRITICAL] No session returned from Supabase for sign-in!');
+        // Non-PII structured log only: log the phase, not the auth payload (which can carry the user/email).
+        logger.error({ event: 'sign_in', phase: 'no_session' }, '[AuthPage CRITICAL] No session returned from Supabase for sign-in!');
         throw new Error('No session returned from Supabase for sign-in.');
       }
     } catch (err: unknown) {


### PR DESCRIPTION
## What
Removes the submitted **email address** from `AuthPage` structured client logs, replacing it with non-PII descriptors (event name + phase). Closes the P3 privacy item surfaced by the today-change CAT scan.

## Why
`AuthPage` logged `{ email }` on sign-in/sign-up attempts (pre-existing, Feb/May commits) and logged the raw `authResult.data` on the no-session error path (which can carry the user object / email). These are client-side structured logs; emitting the email there is unnecessary PII exposure.

## Changes (logging only — no behavior change)
| Before | After |
|---|---|
| `logger.info({ email }, '…Attempting sign_in')` | `logger.info({ event: 'sign_in', phase: 'attempt' }, '…sign-in attempt')` |
| `logger.info({ email }, '…Attempting sign_up')` | `logger.info({ event: 'sign_up', phase: 'attempt' }, '…sign-up attempt')` |
| `logger.error({ data: authResult.data }, '…No session returned…')` | `logger.error({ event: 'sign_in', phase: 'no_session' }, '…No session returned…')` |

## Explicitly untouched
Password-reset flow, identity model, analytics, STT, v4, Stripe, the `userId` (= `user.id`) success log, and all auth control flow. `{ err }` error-class logs are left as-is (error class is non-PII and acceptable).

## Verification
- `tsc` clean, `eslint` clean, production build OK
- Auth suites **32/32** (AuthPage forgot, ResetPasswordPage, SignInPage forgot, SignInPage)
- No test references the changed log payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)