### PR TITLE
chore: close 3 non-blocking CAT-scan P3 findings (dead constant, default-dashboard parity, test naming)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -264,8 +264,10 @@ const ANALYTICS_TOOL_GROUPS: AnalyticsToolGroup[] = [
         label: 'Sound Confident',
         purpose: 'Shows whether your pace, pauses, fillers, and delivery habits make you easy to follow.',
         outcome: 'Use it when you want your next session to sound steadier, calmer, and more confident.',
+        // Default focus: stat cards AND analysis-slide order are kept identical to the prior default
+        // (legacy 'delivery_control') so existing users' default dashboard is unchanged by the rename.
         statCardIds: ['speaking_pace', 'filler_words_per_min', 'clarity_score', 'total_practice_time'],
-        analysisSlideIds: ['pace_trend', 'clarity_trend', 'filler_words', 'weekly_activity'],
+        analysisSlideIds: ['pace_trend', 'filler_words', 'clarity_trend', 'weekly_activity'],
     },
     {
         id: 'track_progress',

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -17,13 +17,10 @@ export const FILLER_WORD_KEYS = {
   SORT_OF: 'Sort Of',
 } as const;
 
-// Session time limits (in seconds)
-export const SESSION_LIMITS = {
-  ANONYMOUS: 120,        // 2 minutes for anonymous users
-  FREE: 1800,             // 30 minutes for free tier
-  BASIC: 1800,            // Reserved for future paid Basic tier
-  PRO: null,             // unlimited for pro users
-} as const;
+// NOTE: session/usage limits are NOT defined here. The authoritative source is the DB
+// `tier_configs` reconciled with `constants/subscriptionTiers.ts` (Pro = 7200s/day, NOT
+// unlimited). A former `SESSION_LIMITS` constant here was dead code carrying a stale
+// "unlimited for pro users" claim; it was removed to avoid drift from the real limits.
 
 // Pause detection configuration
 export const PAUSE_DETECTION = {

--- a/frontend/src/services/transcription/engines/__tests__/privateV4FlagOperationalProof.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/privateV4FlagOperationalProof.test.ts
@@ -177,10 +177,11 @@ describe('v4 PostHog flag — headless operational proof (non-GPU)', () => {
     // Case F1 — DEV/TEST harness: the real localStorage forceAuto key (`speaksharp.v4.forceAuto`) +
     // usable WebGPU selects v4, and the artifact labels it selectionSource:'dev_harness' — NOT
     // posthog_flag — even though `reason` reads `webgpu_available_v4_flag` on real WebGPU (identical
-    // for flag AND forceAuto there). Locks the Gate A (dev_harness) vs Gate B (posthog_flag) distinction.
+    // for flag AND forceAuto there). Locks the dev_harness (forceAuto) vs posthog_flag (real flag)
+    // selectionSource distinction.
     it('F1: DEV/TEST forceAuto (real localStorage key) + WebGPU -> v4 selected, selectionSource=dev_harness (NOT posthog_flag)', async () => {
         flagState.v4Enabled = false; setGpu(true);
-        window.localStorage.setItem('speaksharp.v4.forceAuto', '1'); // dev/test-gated forceAuto shim (Gate A)
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1'); // dev/test-gated forceAuto shim (dev_harness selection)
         const { PrivateSTT } = await import('../PrivateSTT');
         pstt = new PrivateSTT({ onTranscriptUpdate: vi.fn(), onReady: vi.fn() });
         await pstt.init();
@@ -190,7 +191,7 @@ describe('v4 PostHog flag — headless operational proof (non-GPU)', () => {
         expect(dbg?.reason, 'reason is the conflated signal; proves selectionSource is the honest one').toBe('webgpu_available_v4_flag');
     });
 
-    it('F1b: DEV/TEST forceAuto + v4Variant=distil_q4 selects the distil Gate A candidate', async () => {
+    it('F1b: DEV/TEST forceAuto + v4Variant=distil_q4 selects the distil candidate via the dev/test forceAuto path', async () => {
         flagState.v4Enabled = false; setGpu(true);
         window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
         window.localStorage.setItem('speaksharp.v4.variant', 'distil_q4');
@@ -206,7 +207,7 @@ describe('v4 PostHog flag — headless operational proof (non-GPU)', () => {
         expect(dbg?.v4Variant).toBe('distil_q4');
     });
 
-    it('F1c: DEV/TEST forceAuto + v4Variant=base_q4 selects the base Gate A candidate (dev_harness)', async () => {
+    it('F1c: DEV/TEST forceAuto + v4Variant=base_q4 selects the base candidate via the dev/test forceAuto path (dev_harness)', async () => {
         flagState.v4Enabled = false; setGpu(true);
         window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
         window.localStorage.setItem('speaksharp.v4.variant', 'base_q4');

--- a/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
@@ -108,7 +108,7 @@ describe('transformers-js-v4.worker protocol contract', () => {
         expect(postedMessages).not.toContainEqual(expect.objectContaining({ id: 3, type: 'ready' }));
     });
 
-    it('contract: init loads the model/dtype from the load payload (Option B variant threading)', async () => {
+    it('contract: init loads the model/dtype from the load payload (model/dtype variant threading)', async () => {
         const transcriber = vi.fn(async () => ({ text: '' }));
         const pipeline = vi.fn(async () => transcriber);
         vi.doMock('@huggingface/transformers', () => ({


### PR DESCRIPTION
Release-owner-authorized cleanup of the three **P3** items from the today-change CAT scan. No behavior change; no P0/P1 touched. 4 files, +13/−13.

## P3.1 — remove dead `SESSION_LIMITS` constant (`config.ts`)
Never imported anywhere (repo-wide grep = definition only) and carried a stale `PRO: null // unlimited for pro users` comment that contradicts the reconciled **2h/day** Pro cap. Replaced with a pointer note to the authoritative source (DB `tier_configs` + `constants/subscriptionTiers.ts`).

## P3.2 — restore default-dashboard parity (`AnalyticsDashboard.tsx`)
Restores the legacy `delivery_control` analysis-slide **order** on the default focus `sound_confident` → `[pace_trend, filler_words, clarity_trend, weekly_activity]`. Stat cards already matched; this makes the default dashboard byte-identical to the pre-taxonomy default (honors the "default dashboard must not change" intent). **Same slides, order only — no new/removed charts, no class/metric change.**

## P3.3 — behavior-descriptive test naming (2 v4 test files)
Renames "Gate A/B" / "Option B" → real selectionSource terms in **descriptions/comments only** (no assertions touched):
- `Gate A` → dev_harness (forceAuto) path
- `Gate B` → posthog_flag
- "Option B variant threading" → "model/dtype variant threading"

> Note: the same shorthand also appears in v4 **source** comments (`privateV4Experiment.ts`, `privateRuntimePath.ts`, `PrivateSTT.ts`, `TransformersJSV4Engine.ts`). Those are intentionally **left untouched** to avoid modifying v4 source outside a concrete regression — can be done separately if full consistency is wanted.

## Verification
- `tsc` clean, `eslint` clean, production build OK
- Affected suites **59/59** (AnalyticsDashboard, privateV4FlagOperationalProof, transformers-js-v4.worker.protocol, PrivateSTT)
- No analytics layout/class/metric-calculation change; no STT/v4 behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)