### PR TITLE
fix(auth): reset completion (recovery-session race) + sign-in-link & reset email validation

### DIFF
--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -197,6 +197,17 @@ export function AuthProvider({ children, initialSession = null }: AuthProviderPr
             logger.info({ userId: newSession?.user?.id }, '[AuthProvider] User metadata updated');
             assignSession(newSession);
             break;
+          case 'PASSWORD_RECOVERY':
+            // The user arrived via a password-reset email link. With `detectSessionInUrl: true`
+            // the client consumes the recovery token from the URL and fires this event during app
+            // boot — BEFORE the lazy-loaded /auth/reset page mounts — and then clears the hash. So
+            // record a durable, single-use marker that ResetPasswordPage can read to authorize the
+            // set-new-password form even after the token is gone and the event has already fired.
+            // A normal signed-in user never triggers PASSWORD_RECOVERY, so this stays reset-only.
+            try { sessionStorage.setItem('ss_password_recovery', '1'); } catch { /* sessionStorage may be unavailable */ }
+            assignSession(newSession);
+            setLoading(false);
+            break;
           case 'SIGNED_IN':
             logger.info({ userId: newSession?.user?.id }, '[AuthProvider] User signed in');
             assignSession(newSession);

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -219,7 +219,7 @@ export default function AuthPage() {
                           className="px-0 font-normal text-xs text-muted-foreground hover:text-primary h-auto"
                           data-testid="forgot-password-button"
                         >
-                          Forgot password?
+                          Forgot Password? Reset
                         </Button>
                       )}
                     </div>

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -53,13 +53,22 @@ export default function ResetPasswordPage() {
       /[?&#]token_hash=/.test(search) || /[?&]token_hash=/.test(hash) ||
       /[?&]code=/.test(search); // a code only reaches /auth/reset via the reset redirect
 
+    // With `detectSessionInUrl: true` the Supabase client consumes the recovery token from the URL
+    // and fires PASSWORD_RECOVERY during app boot — before this lazy page mounts — then clears the
+    // hash. The global AuthProvider listener records this durable, reset-only marker so we can still
+    // authorize the form after the token is gone and the event already fired. A plain signed-in user
+    // never sets this marker, so a normal session still cannot reach the form (P2 preserved).
+    let hasRecoveryMarker = false;
+    try { hasRecoveryMarker = sessionStorage.getItem('ss_password_recovery') === '1'; } catch { /* sessionStorage may be unavailable */ }
+
     // Late PASSWORD_RECOVERY (async token exchange) can still authorize.
     const { data: sub } = supabase.auth.onAuthStateChange((event: string) => {
       if (active && event === 'PASSWORD_RECOVERY') setPhase('ready');
     });
 
-    // No recovery token in the URL ⇒ not a recovery context ⇒ invalid (a plain session is not enough).
-    setPhase(prev => (prev === 'success' ? prev : (hasRecoveryToken ? 'ready' : 'invalid')));
+    // Authorized only by a genuine recovery flow: a token in the URL, the durable marker, or a live
+    // PASSWORD_RECOVERY event. No recovery evidence ⇒ invalid (a plain session is not enough).
+    setPhase(prev => (prev === 'success' ? prev : ((hasRecoveryToken || hasRecoveryMarker) ? 'ready' : 'invalid')));
 
     return () => { active = false; sub?.subscription?.unsubscribe?.(); };
   }, []);
@@ -89,6 +98,9 @@ export default function ResetPasswordPage() {
         setPhase('invalid');
         return;
       }
+      // Recovery complete — consume the durable marker so a later /auth/reset visit in this tab
+      // (now a normal signed-in session) is no longer treated as a recovery context.
+      try { sessionStorage.removeItem('ss_password_recovery'); } catch { /* sessionStorage may be unavailable */ }
       setPhase('success');
     } catch (err) {
       logger.warn({ err }, '[ResetPassword] update failed');

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -62,6 +62,10 @@ export default function SignInPage() {
     const [isSendingReset, setIsSendingReset] = useState(false);
 
     const handleForgotPassword = async () => {
+        // Clear any prior error/success message FIRST so an early-return validation error never
+        // leaves a stale success message (e.g. from a previous reset/sign-in-link) on screen.
+        setError(null);
+        setMessage(null);
         const normalizedEmail = email.trim();
         if (!normalizedEmail) {
             setError('Please enter your email address first');
@@ -74,8 +78,6 @@ export default function SignInPage() {
             return;
         }
         setIsSendingReset(true);
-        setError(null);
-        setMessage(null);
         try {
             const supabase = getSupabaseClient();
             // Anti-enumeration: fire the provider reset (only emails a registered, verified address)
@@ -115,6 +117,10 @@ export default function SignInPage() {
     };
 
     const handleMagicLink = async () => {
+        // Clear any prior error/success message FIRST so an early-return validation error never
+        // leaves a stale success message (e.g. from a previous reset/sign-in-link) on screen.
+        setError(null);
+        setMessage(null);
         const normalizedEmail = email.trim();
         if (!normalizedEmail) {
             setError('Please enter your email address first');
@@ -125,8 +131,6 @@ export default function SignInPage() {
             return;
         }
         setIsSendingMagicLink(true);
-        setError(null);
-        setMessage(null);
         try {
             const supabase = getSupabaseClient();
             const { error: otpError } = await supabase.auth.signInWithOtp({

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -62,8 +62,15 @@ export default function SignInPage() {
     const [isSendingReset, setIsSendingReset] = useState(false);
 
     const handleForgotPassword = async () => {
-        if (!email) {
+        const normalizedEmail = email.trim();
+        if (!normalizedEmail) {
             setError('Please enter your email address first');
+            return;
+        }
+        // Mirror the magic-link path: block obviously malformed input client-side (format ≠ existence,
+        // so this does not enable enumeration) instead of letting it round-trip to the provider.
+        if (!isEmailFormatValid(normalizedEmail)) {
+            setError('Email not valid');
             return;
         }
         setIsSendingReset(true);
@@ -74,7 +81,7 @@ export default function SignInPage() {
             // Anti-enumeration: fire the provider reset (only emails a registered, verified address)
             // and ALWAYS show the same neutral response. The link lands on /auth/reset. No email or
             // token is logged.
-            await supabase.auth.resetPasswordForEmail(email, {
+            await supabase.auth.resetPasswordForEmail(normalizedEmail, {
                 redirectTo: `${window.location.origin}/auth/reset`,
             });
         } catch (err: unknown) {

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -30,6 +30,9 @@ const getSafeMagicLinkError = (err: unknown): string => {
     const rawMessage = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
     const message = rawMessage.toLowerCase();
 
+    if (message.includes('invalid email') || (message.includes('email') && message.includes('valid'))) {
+        return 'Email not valid';
+    }
     if (err instanceof TypeError && message.includes('failed to fetch')) {
         return 'Unable to send a sign-in link. Check your connection and try again.';
     }
@@ -39,6 +42,8 @@ const getSafeMagicLinkError = (err: unknown): string => {
 
     return 'Sign-in link could not be sent. Please try again.';
 };
+
+const isEmailFormatValid = (value: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
 
 // Sign In page – supports both password and magic link
 export default function SignInPage() {
@@ -103,8 +108,13 @@ export default function SignInPage() {
     };
 
     const handleMagicLink = async () => {
-        if (!email) {
+        const normalizedEmail = email.trim();
+        if (!normalizedEmail) {
             setError('Please enter your email address first');
+            return;
+        }
+        if (!isEmailFormatValid(normalizedEmail)) {
+            setError('Email not valid');
             return;
         }
         setIsSendingMagicLink(true);
@@ -113,7 +123,7 @@ export default function SignInPage() {
         try {
             const supabase = getSupabaseClient();
             const { error: otpError } = await supabase.auth.signInWithOtp({
-                email,
+                email: normalizedEmail,
                 options: {
                     emailRedirectTo: `${window.location.origin}${postAuthPath}`
                 }
@@ -175,7 +185,7 @@ export default function SignInPage() {
                                         className="px-0 font-normal text-xs text-muted-foreground hover:text-primary h-auto"
                                         data-testid="forgot-password-button"
                                     >
-                                        {isSendingReset ? 'Sending...' : 'Forgot password?'}
+                                        {isSendingReset ? 'Sending...' : 'Forgot Password? Reset'}
                                     </Button>
                                 </div>
                                 <Input

--- a/frontend/src/pages/__tests__/ResetPasswordPage.component.test.tsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.component.test.tsx
@@ -19,6 +19,7 @@ describe('ResetPasswordPage (basic password-reset completion)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         clearHash();
+        try { sessionStorage.clear(); } catch { /* ignore */ }
         authCb = null;
         mockUpdateUser.mockResolvedValue({ error: null });
         // Default: a session EXISTS — used to prove it is NOT sufficient authority without a recovery flow.
@@ -36,7 +37,7 @@ describe('ResetPasswordPage (basic password-reset completion)', () => {
         } as unknown as ReturnType<typeof supabaseClient.getSupabaseClient>);
     });
 
-    afterEach(() => clearHash());
+    afterEach(() => { clearHash(); try { sessionStorage.clear(); } catch { /* ignore */ } });
 
     it('shows the set-new-password form (no username field) when arriving via a recovery link', async () => {
         setRecoveryHash();
@@ -52,6 +53,16 @@ describe('ResetPasswordPage (basic password-reset completion)', () => {
         await screen.findByTestId('reset-password-invalid');
         await act(async () => { authCb?.('PASSWORD_RECOVERY', { user: { id: 'uuid-123' } }); });
         expect(await screen.findByTestId('set-new-password-form')).toBeInTheDocument();
+    });
+
+    it('authorizes the form via the durable recovery marker after the URL token was consumed at boot', async () => {
+        // Real prod shape: detectSessionInUrl consumed the hash (URL is now bare `/auth/reset#`) and
+        // the PASSWORD_RECOVERY event fired during app boot before this page mounted. The global
+        // AuthProvider listener recorded the marker; the page must still authorize the form.
+        sessionStorage.setItem('ss_password_recovery', '1');
+        render(<ResetPasswordPage />); // no recovery hash, no live event
+        expect(await screen.findByTestId('set-new-password-form')).toBeInTheDocument();
+        expect(screen.queryByTestId('reset-password-invalid')).not.toBeInTheDocument();
     });
 
     it('SECURITY: a normal signed-in session is NOT reset authority without a recovery flow', async () => {

--- a/frontend/src/pages/__tests__/SignInPage.component.test.tsx
+++ b/frontend/src/pages/__tests__/SignInPage.component.test.tsx
@@ -285,5 +285,30 @@ describe('SignInPage', () => {
                 });
             });
         });
+
+        it('shows Email not valid for malformed sign-in-link email without calling Supabase', async () => {
+            const user = userEvent.setup();
+
+            renderSignInPage();
+
+            await user.type(screen.getByLabelText(/email/i), 'a');
+            await user.click(screen.getByTestId('magic-link-button'));
+
+            expect(mockSignInWithOtp).not.toHaveBeenCalled();
+            expect(await screen.findByTestId('auth-error-message')).toHaveTextContent('Email not valid');
+        });
+
+        it('maps provider invalid-email responses to Email not valid for sign-in links', async () => {
+            const user = userEvent.setup();
+            mockSignInWithOtp.mockResolvedValue({ error: new Error('Invalid email') });
+
+            renderSignInPage();
+
+            await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+            await user.click(screen.getByTestId('magic-link-button'));
+
+            await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledTimes(1));
+            expect(await screen.findByTestId('auth-error-message')).toHaveTextContent('Email not valid');
+        });
     });
 });

--- a/frontend/src/pages/__tests__/SignInPage.forgotPassword.component.test.tsx
+++ b/frontend/src/pages/__tests__/SignInPage.forgotPassword.component.test.tsx
@@ -71,4 +71,25 @@ describe('SignInPage — forgot password from the primary sign-in page (P1, anti
         expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
         expect(await screen.findByTestId('auth-error-message')).toHaveTextContent(/enter your email/i);
     });
+
+    it('clears a prior success message when a follow-up malformed email validation fails (no stale success)', async () => {
+        const user = userEvent.setup();
+        mockResetPasswordForEmail.mockResolvedValue({ error: null });
+        render(<SignInPage />);
+
+        // First: a successful reset shows the neutral success message.
+        await user.type(screen.getByTestId('email-input'), 'real@example.com');
+        await user.click(screen.getByTestId('forgot-password-button'));
+        expect(await screen.findByTestId('auth-message')).toHaveTextContent(NEUTRAL);
+
+        // Then: edit to a malformed email and retry — the early-return error must REPLACE the stale
+        // success message, not sit beside it.
+        await user.clear(screen.getByTestId('email-input'));
+        await user.type(screen.getByTestId('email-input'), 'not-an-email');
+        await user.click(screen.getByTestId('forgot-password-button'));
+
+        expect(await screen.findByTestId('auth-error-message')).toHaveTextContent(/email not valid/i);
+        expect(screen.queryByTestId('auth-message')).not.toBeInTheDocument();
+        expect(mockResetPasswordForEmail).toHaveBeenCalledTimes(1); // not called again for malformed input
+    });
 });


### PR DESCRIPTION
Auth-flow fixes for the initial release. Builds on the original sign-in-link validation work; adds the reset-completion fix surfaced by live production testing.

## 1. Reset completion was broken end-to-end (P1)
Clicking the emailed reset link landed on `…/auth/reset#` and showed **"invalid or expired"** even though the token was valid.

**Root cause:** with `detectSessionInUrl: true`, the Supabase client consumes the recovery token from the URL hash and fires `PASSWORD_RECOVERY` during app boot — *before* the lazy `/auth/reset` page mounts — then clears the hash (leaving the bare `#`). `ResetPasswordPage` read the already-emptied hash, missed the already-fired event, and fell through to "invalid."

**Fix:** the always-on `AuthProvider` auth listener now handles `PASSWORD_RECOVERY` and records a durable, single-use `sessionStorage` marker (`ss_password_recovery`). `ResetPasswordPage` authorizes the form on **any** recovery evidence — URL token, the marker, or a live `PASSWORD_RECOVERY` event — and consumes the marker on successful update.

**Security preserved (P2):** a plain signed-in user never triggers `PASSWORD_RECOVERY`, so a normal session still cannot reach the form. `updateUser({password})` remains the real authority.

## 2. Reset-path email validation gap
The forgot-password handler lacked the format check the magic-link path already had, so malformed input round-tripped to the provider. Added the same `isEmailFormatValid` guard (format ≠ existence → no enumeration) + trims the email.

## 3. (original) Sign-in-link validation + label
Magic-link email-format validation (`Email not valid`) and the "Forgot Password? Reset" label.

## Verification
- ResetPasswordPage **9/9** (incl. new "durable marker authorizes after URL token consumed at boot")
- AuthProvider **15/15** (new `PASSWORD_RECOVERY` case), SignInPage **18/18**, SignInPage forgot **4/4**, AuthPage forgot **4/4**
- tsc + eslint + build OK

## ⚠️ Required Supabase config for the reset/magic-link to work in production (Ops — not in this PR)
- **Site URL** → `https://speaksharp-public.vercel.app` (currently `http://localhost:3000` → causes the magic-link `localhost:3000` redirect)
- **Redirect URLs** → add `https://speaksharp-public.vercel.app/**` (covers `/session` for magic-link; `/auth/reset` already added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)