### PR TITLE
test: accept Private sample state in production canary

### DIFF
--- a/tests/canary/smoke.canary.spec.ts
+++ b/tests/canary/smoke.canary.spec.ts
@@ -79,12 +79,24 @@ test.describe('Production Smoke Canary @canary', () => {
         // Verify that the profile loaded correctly and reflects the subscription status
         // This implicitly validates the 'user_profiles' table schema
         await expect(page.getByTestId(TEST_IDS.SESSION_START_STOP_BUTTON)).toBeVisible({ timeout: 15000 });
-        const upgradeButton = page.getByRole('button', { name: /upgrade to pro/i });
-        const proBadge = page.getByTestId(TEST_IDS.PRO_BADGE);
-        // We don't enforce WHICH one is visible (depends on the canary user state), but ONE must be.
-        // This confirms the frontend correctly mapped the database columns.
-        const isProfileValid = (await upgradeButton.isVisible()) || (await proBadge.isVisible());
-        expect(isProfileValid, 'Schema Valid: Profile must reflect a known tier (Free/Pro)').toBe(true);
+        const validReleaseTierAffordances = [
+            page.getByRole('button', { name: /upgrade to pro/i }),
+            page.getByTestId(TEST_IDS.PRO_BADGE),
+            page.getByTestId(TEST_IDS.PRIVATE_SAMPLE_SETUP_BUTTON),
+            page.getByText(/Private sample: up to 5 minutes/i),
+        ];
+        // We don't enforce WHICH release-valid access state is visible. Free users may
+        // see an upgrade prompt or a Private-sample affordance; Pro users see the Pro badge.
+        // This validates profile/usage hydration through behavior, without requiring
+        // production UI to preserve one exact tier phrase.
+        const releaseTierAffordanceVisible = await Promise.all(
+            validReleaseTierAffordances.map(async (locator) => {
+                if ((await locator.count()) === 0) return false;
+                return locator.first().isVisible();
+            })
+        );
+        const isProfileValid = releaseTierAffordanceVisible.some(Boolean);
+        expect(isProfileValid, 'Schema Valid: Profile must reflect a known release tier/access state').toBe(true);
 
         // 3. Configure for Native STT (Free/Low Risk)
         debugLog('[CANARY] Configuring Native STT mode...');

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -103,6 +103,7 @@ export const TEST_IDS = {
   TRANSCRIPT_CONTAINER: 'transcript-container',
   TRANSCRIPT_DISPLAY: 'transcript-display',
   MODEL_LOADING_INDICATOR: 'model-loading-indicator',
+  PRIVATE_SAMPLE_SETUP_BUTTON: 'first-run-setup-private',
 
   // Metrics
   CLARITY_SCORE_VALUE: 'clarity-score-value',


### PR DESCRIPTION
## Summary
- Updates the production canary's profile/tier sanity check to validate release-valid access behavior instead of requiring only the old Upgrade-to-Pro button or Pro badge.
- Accepts the current valid Free/sample state via the Private sample CTA/status, while still accepting Free upgrade or Pro badge states.
- Adds the Private sample CTA test id to the test constants.

## Scope
- Test-only change.
- No production code changes.
- No UI/layout/copy/entitlement changes.

## Verification
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `git diff --check` ✅
- `pnpm test:deploy:prod` runs locally but skips because local `CANARY_PASSWORD` is not configured; GitHub scheduled/manual canary should exercise it with provisioned credentials.

## Context
Scheduled canary `27493468185` failed at `tests/canary/smoke.canary.spec.ts:87` because the assertion only accepted Upgrade-to-Pro or Pro badge. The artifact showed an authenticated `/session` with Mic ready, Browser mode, and Private sample CTA, which is a valid release state after the sample-entitlement changes. This adapts the test to production behavior rather than changing production code to fit the test.