### PR TITLE
fix(auth): validate signup email before Supabase

### DIFF
--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -29,6 +29,8 @@ const mapError = (message: string) => {
   return friendlyErrors[message] || 'An unexpected error occurred.';
 };
 
+const isEmailFormatValid = (value: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+
 export default function AuthPage() {
   const { session, loading, setSession } = useAuthProvider();
   const location = useLocation();
@@ -58,9 +60,16 @@ export default function AuthPage() {
 
     try {
       const supabase = getSupabaseClient();
+      const normalizedEmail = email.trim();
       if (!supabase) {
         logger.error('[AuthPage CRITICAL] Supabase client is null/undefined!');
         throw new Error("Supabase client not available");
+      }
+
+      if (view === 'sign_up' && !isEmailFormatValid(normalizedEmail)) {
+        setInlineError('Email not valid');
+        setIsSubmitting(false);
+        return;
       }
 
       if (password.length < 6 && view !== 'forgot_password') {
@@ -83,7 +92,7 @@ export default function AuthPage() {
         logger.info({ event: 'sign_up', phase: 'attempt' }, '[AuthPage] sign-up attempt');
         
         const { error: signUpError } = await supabase.auth.signUp({
-          email,
+          email: normalizedEmail,
           password
         });
 
@@ -100,7 +109,7 @@ export default function AuthPage() {
         setInlineError(null);
 
         // Post-signup sign-in to get the session (Supabase quirk)
-        const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+        const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({ email: normalizedEmail, password });
         if (signInError) {
           logger.error({ err: signInError }, '[AuthPage] Post-signup sign-in failed');
           setInlineError(mapError(signInError.message));

--- a/frontend/src/pages/__tests__/AuthPage.signup.component.test.tsx
+++ b/frontend/src/pages/__tests__/AuthPage.signup.component.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '../../../tests/support/test-utils';
+import userEvent from '@testing-library/user-event';
+import AuthPage from '../AuthPage';
+import * as AuthProvider from '@/contexts/AuthProvider';
+import * as supabaseClient from '@/lib/supabaseClient';
+
+vi.mock('@/contexts/AuthProvider');
+vi.mock('@/lib/supabaseClient');
+
+const mockUseAuthProvider = vi.mocked(AuthProvider.useAuthProvider);
+const mockGetSupabaseClient = vi.mocked(supabaseClient.getSupabaseClient);
+
+describe('AuthPage signup email validation', () => {
+    const mockSignUp = vi.fn();
+    const mockSignInWithPassword = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseAuthProvider.mockReturnValue({
+            session: null,
+            loading: false,
+            setSession: vi.fn(),
+            user: null,
+            signOut: vi.fn(),
+        } as unknown as ReturnType<typeof AuthProvider.useAuthProvider>);
+        mockGetSupabaseClient.mockReturnValue({
+            auth: {
+                signInWithPassword: mockSignInWithPassword,
+                signUp: mockSignUp,
+                resetPasswordForEmail: vi.fn(),
+            },
+        } as unknown as ReturnType<typeof supabaseClient.getSupabaseClient>);
+    });
+
+    it('blocks blank signup email before calling Supabase', async () => {
+        const user = userEvent.setup();
+        render(<AuthPage />, { route: '/auth/signup', path: '/auth/signup' });
+
+        await user.type(screen.getByTestId('password-input'), 'validpass123');
+        await user.click(screen.getByTestId('sign-up-submit'));
+
+        expect(await screen.findByTestId('signup-inline-error')).toHaveTextContent('Email not valid');
+        expect(mockSignUp).not.toHaveBeenCalled();
+        expect(mockSignInWithPassword).not.toHaveBeenCalled();
+    });
+
+    it('blocks malformed signup email before calling Supabase', async () => {
+        const user = userEvent.setup();
+        render(<AuthPage />, { route: '/auth/signup', path: '/auth/signup' });
+
+        await user.type(screen.getByTestId('email-input'), 'not-an-email');
+        await user.type(screen.getByTestId('password-input'), 'validpass123');
+        fireEvent.submit(screen.getByTestId('auth-form'));
+
+        expect(await screen.findByTestId('signup-inline-error')).toHaveTextContent('Email not valid');
+        expect(mockSignUp).not.toHaveBeenCalled();
+        expect(mockSignInWithPassword).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Block blank or malformed `/auth/signup` email input before calling Supabase.
- Show the existing auth copy `Email not valid` inline on the signup panel.
- Pass the trimmed email to Supabase only after validation succeeds.
- Add component regressions proving blank/malformed signup email never calls `signUp` or post-signup `signInWithPassword`.

## Scope
- Production behavior fix for the release-blocking blank-email signup issue.
- No layout/className changes.
- No password reset, billing, STT, transcript, analytics, or Supabase config changes.

## Verification
- `pnpm exec vitest run --config frontend/vitest.config.mjs --coverage.enabled=false frontend/src/pages/__tests__/AuthPage.signup.component.test.tsx frontend/src/pages/__tests__/AuthPage.forgotPassword.component.test.tsx frontend/src/pages/__tests__/SignInPage.component.test.tsx frontend/src/pages/__tests__/SignInPage.forgotPassword.component.test.tsx` — PASS, 29/29
- `pnpm typecheck` — PASS
- `pnpm lint` — PASS
- `git diff --check` — PASS
- `pnpm build` — PASS

## Follow-up after merge
- Rerun the production signup repro: `/auth/signup`, blank email + valid password must remain on signup and show `Email not valid`; no protected `/session` navigation.
- Rerun production canary if release policy requires current-HEAD canary after this auth fix.