### PR TITLE
feat(stt): conservative anti-loop decode defaults for v4 (F2)

### DIFF
--- a/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
+++ b/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
@@ -15,7 +15,7 @@ import { MicStream } from '@/services/transcription/utils/types';
 import { ENV } from '@/config/TestFlags';
 import logger from '@/lib/logger';
 import { redactTranscript } from '@/lib/logRedaction';
-import { readPrivateDecodeOptionsOverride } from '@/services/transcription/engines/whisperDecodeOptions';
+import { readPrivateDecodeOptionsOverride, V4_ANTI_LOOP_DECODE_DEFAULTS } from '@/services/transcription/engines/whisperDecodeOptions';
 import { STTEngine } from '@/contracts/STTEngine';
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_V4, PRIV_STT_V4_VARIANTS, PRIV_STT_V4_DEFAULT_VARIANT, type PrivSttV4VariantId, samplesToSeconds } from '../sttConstants';
 import { getV4ExperimentOverrides } from '../privateV4Experiment';
@@ -88,6 +88,8 @@ function getV4AsrOptions(audioLengthSeconds: number, decodeOptions?: Record<stri
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
         return_timestamps: true,
+        // Conservative anti-loop generation defaults (F2). Overridable by the proof hook below.
+        ...V4_ANTI_LOOP_DECODE_DEFAULTS,
     };
 
     if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {

--- a/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/transformers-js-v4.worker.protocol.test.ts
@@ -135,4 +135,43 @@ describe('transformers-js-v4.worker protocol contract', () => {
             expect.objectContaining({ dtype }),
         );
     });
+
+    it('contract: transcribe applies the conservative anti-loop decode defaults (F2)', async () => {
+        const transcriber = vi.fn(async () => ({ text: 'hello world' }));
+        const pipeline = vi.fn(async () => transcriber);
+        vi.doMock('@huggingface/transformers', () => ({ env: {}, LogLevel: { ERROR: 'error' }, pipeline }));
+
+        await loadWorkerModule();
+        dispatchWorkerMessage({ id: 5, type: 'init', isE2E: false, model: 'onnx-community/whisper-base.en', dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' } });
+        await vi.waitFor(() => expect(postedMessages).toContainEqual(expect.objectContaining({ id: 5, type: 'ready' })));
+
+        dispatchWorkerMessage({ id: 6, type: 'transcribe', audio: new Float32Array(16000) });
+        await vi.waitFor(() => expect(postedMessages).toContainEqual(expect.objectContaining({ id: 6, type: 'result' })));
+
+        // The real transcribe call (not the warm-up) carries the anti-loop defaults.
+        expect(transcriber).toHaveBeenCalledWith(
+            expect.any(Float32Array),
+            expect.objectContaining({ no_repeat_ngram_size: 6, condition_on_previous_text: false }),
+        );
+    });
+
+    it('contract: a proof-hook decode override wins over the anti-loop defaults', async () => {
+        const transcriber = vi.fn(async () => ({ text: 'hello' }));
+        const pipeline = vi.fn(async () => transcriber);
+        vi.doMock('@huggingface/transformers', () => ({ env: {}, LogLevel: { ERROR: 'error' }, pipeline }));
+
+        await loadWorkerModule();
+        dispatchWorkerMessage({ id: 7, type: 'init', isE2E: false, model: 'onnx-community/whisper-base.en', dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' } });
+        await vi.waitFor(() => expect(postedMessages).toContainEqual(expect.objectContaining({ id: 7, type: 'ready' })));
+
+        // Proof hook sets no_repeat_ngram_size=3; the worker receives it via the message's decodeOptions.
+        dispatchWorkerMessage({ id: 8, type: 'transcribe', audio: new Float32Array(16000), decodeOptions: { no_repeat_ngram_size: 3 } });
+        await vi.waitFor(() => expect(postedMessages).toContainEqual(expect.objectContaining({ id: 8, type: 'result' })));
+
+        expect(transcriber).toHaveBeenCalledWith(
+            expect.any(Float32Array),
+            // override wins for the overridden key; the other default is preserved
+            expect.objectContaining({ no_repeat_ngram_size: 3, condition_on_previous_text: false }),
+        );
+    });
 });

--- a/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
+++ b/frontend/src/services/transcription/engines/__tests__/whisperDecodeOptions.test.ts
@@ -4,6 +4,7 @@ import {
     sanitizeDecodeOptions,
     readPrivateDecodeOptionsOverride,
     ALLOWED_DECODE_OPTIONS,
+    V4_ANTI_LOOP_DECODE_DEFAULTS,
 } from '../whisperDecodeOptions';
 
 const setHook = (value: unknown) => {
@@ -61,6 +62,21 @@ describe('whisperDecodeOptions (v4 decode-option proof hook, BL-1)', () => {
                 'return_timestamps',
                 'temperature',
             ]);
+        });
+    });
+
+    describe('V4_ANTI_LOOP_DECODE_DEFAULTS (F2 conservative v4 defaults)', () => {
+        it('sets the documented conservative anti-loop values', () => {
+            expect(V4_ANTI_LOOP_DECODE_DEFAULTS).toEqual({
+                condition_on_previous_text: false,
+                no_repeat_ngram_size: 6,
+            });
+        });
+
+        it('uses only allow-listed knobs (so the proof hook can override each one)', () => {
+            for (const key of Object.keys(V4_ANTI_LOOP_DECODE_DEFAULTS)) {
+                expect(ALLOWED_DECODE_OPTIONS.has(key)).toBe(true);
+            }
         });
     });
 

--- a/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
+++ b/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
@@ -1,5 +1,6 @@
 import { PRIV_CLOUD_AUDIO, PRIV_STT, PRIV_STT_V4, samplesToSeconds } from '../sttConstants';
 import { detectWebGPUSupport } from '../utils/webgpuSupport';
+import { V4_ANTI_LOOP_DECODE_DEFAULTS } from './whisperDecodeOptions';
 
 type Pipeline = Awaited<ReturnType<typeof import('@huggingface/transformers')['pipeline']>>;
 
@@ -47,6 +48,8 @@ function getAsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
         return_timestamps: true,
+        // Conservative anti-loop generation defaults (F2). Overridable by the proof hook below.
+        ...V4_ANTI_LOOP_DECODE_DEFAULTS,
     };
 
     if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {

--- a/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
+++ b/frontend/src/services/transcription/engines/whisperDecodeOptions.ts
@@ -30,6 +30,24 @@ export const ALLOWED_DECODE_OPTIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Conservative anti-loop generation DEFAULTS for the v4 engine (F2). Applied as defaults in the v4
+ * ASR options; the proof hook (`__PRIVATE_STT_DECODE_OPTIONS__`) still overrides them, so Test can
+ * A/B alternative values on real WebGPU. Targets the observed v4 rolling-hypothesis repetition loop:
+ *   - `condition_on_previous_text: false` — stop each decode window conditioning on the prior
+ *     (possibly looped) text; this is the direct driver of the rolling-hypothesis loop.
+ *   - `no_repeat_ngram_size: 6` — hard backstop against long verbatim n-gram loops; 6 is large
+ *     enough never to clip natural short repeats ("no no no"), small enough to break the artifact's
+ *     multi-word loop.
+ * Both are safe-if-ignored generation params, and v4 ships flag-OFF, so there is ZERO production
+ * impact until the A/B flips on. Conservative + reversible — Test's WebGPU decode-knob proof should
+ * confirm/tune these (and evaluate `compression_ratio_threshold`) with on-device WER/loop evidence.
+ */
+export const V4_ANTI_LOOP_DECODE_DEFAULTS: Readonly<WhisperDecodeOptions> = {
+    condition_on_previous_text: false,
+    no_repeat_ngram_size: 6,
+};
+
+/**
  * Allow-list + type-guard a raw override object. Accepts only `boolean | number | number[]` values
  * for allow-listed keys. Returns `undefined` when nothing valid is present (so callers can treat
  * "no override" and "empty override" identically and keep product defaults).


### PR DESCRIPTION
## What
Bakes conservative anti-loop generation **defaults** into the v4 decode path (audit finding **F2**). Previously the anti-loop knobs existed only behind the inert proof hook, so v4 generation was needlessly loop-prone.

`V4_ANTI_LOOP_DECODE_DEFAULTS = { condition_on_previous_text: false, no_repeat_ngram_size: 6 }`, merged as defaults into **both** ASR option builders — the worker (production path) and the main-thread engine (parity). The proof hook (`__PRIVATE_STT_DECODE_OPTIONS__`) still **overrides** them.

## Why
- `condition_on_previous_text: false` → directly targets the observed v4 rolling-hypothesis repetition loop.
- `no_repeat_ngram_size: 6` → hard backstop against long verbatim loops; large enough never to clip natural short repeats.
- Without this, a v2-vs-v4 A/B would be **biased against v4** (loops inflate WER); loops were only mitigated post-hoc at the display/commit layer.

## Safety
**Zero production impact today** — v4 ships flag-OFF, so these defaults are dormant until the PostHog A/B turns v4 on (at which point v4 is measured *with* the fix). Conservative + reversible. Both are safe-if-ignored generation params.

## Follow-up (Test, real WebGPU)
The decode-knob proof should confirm/tune these values and evaluate `compression_ratio_threshold` on-device — then we set evidence-backed finals.

## Verification
- tsc + eslint + production build OK
- v4 suites **39/39** (incl. new "transcribe applies anti-loop defaults" + "proof-hook override wins")
- STT smoke **64/64** (PrivateSTT selection + LiveTranscriptPanel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)