### PR TITLE
test(stt): benchmark v4 on rollout models (base_q4/distil_q4) + WebGPU

### DIFF
--- a/tests/live/benchmark-v4.live.spec.ts
+++ b/tests/live/benchmark-v4.live.spec.ts
@@ -23,12 +23,27 @@ import { HARVARD_BENCHMARK_AUDIO } from './helpers/audio-fixtures';
 const HARVARD_BENCHMARK_AUDIO_MS = 34_600;
 const AUDIO_COMPLETION_MARGIN_MS = 2_000;
 
+// Parameterized so Test can benchmark the ROLLOUT v4 models (not the legacy tiny.en) on either device:
+//   V4_VARIANT=base_q4|distil_q4   (default base_q4 — the universal rollout floor)
+//   V4_DEVICE=wasm|webgpu          (default wasm; webgpu requires a REAL GPU machine, not headless CI)
+// e.g.  V4_VARIANT=distil_q4 V4_DEVICE=webgpu pnpm exec playwright test tests/live/benchmark-v4.live.spec.ts
+// NOTE: distil_q4 is the WebGPU accuracy tier — run it with V4_DEVICE=webgpu (the resolver gates distil
+// on confirmed WebGPU). The run logs the actual loaded model; confirm it matches the intended variant.
+const V4_VARIANT = (process.env.V4_VARIANT ?? 'base_q4') as 'base_q4' | 'distil_q4';
+const V4_DEVICE = (process.env.V4_DEVICE ?? 'wasm') as 'wasm' | 'webgpu';
+const V4_VARIANT_MODEL_ID: Record<string, string> = {
+    base_q4: 'onnx-community/whisper-base.en',
+    distil_q4: 'onnx-community/distil-small.en',
+};
+const GPU_ARGS = V4_DEVICE === 'webgpu'
+    ? ['--enable-features=WebGPU', '--enable-unsafe-webgpu']
+    : ['--disable-gpu', '--disable-webgpu'];
+
 test.use({
     launchOptions: {
         args: [
             ...AUDIO_ARGS,
-            '--disable-gpu',
-            '--disable-webgpu',
+            ...GPU_ARGS,
             `--use-file-for-fake-audio-capture=${HARVARD_BENCHMARK_AUDIO}`,
         ]
     }
@@ -48,13 +63,19 @@ test('measure Transformers.js v4 worker', async ({ page }) => {
         throw new Error('PRO_TEST_EMAIL and PRO_TEST_PASSWORD must be set for benchmark runs. E2E_PRO_EMAIL/E2E_PRO_PASSWORD remain supported as legacy local aliases.');
     }
 
-    await page.addInitScript(() => {
+    await page.addInitScript((cfg: { variant: string; device: string }) => {
         window.__E2E_CONTEXT__ = true;
         window.REAL_WHISPER_TEST = true;
         window.__STT_LOAD_TIMEOUT__ = 180000;
         (window as unknown as { __PRIVATE_TRANSCRIPT_TRACE__?: boolean }).__PRIVATE_TRANSCRIPT_TRACE__ = true;
+        // Select v4 + the specific rollout variant/device via the dev/test experiment overrides
+        // (honored only in DEV/test — inert in production). forceAuto + variant is how PrivateSTT
+        // picks base_q4 vs distil_q4 under identical conditions; device pins the runtime backend.
         window.localStorage.setItem('speaksharp.private.engine', 'transformers-js-v4');
-    });
+        window.localStorage.setItem('speaksharp.v4.forceAuto', '1');
+        window.localStorage.setItem('speaksharp.v4.variant', cfg.variant);
+        window.localStorage.setItem('speaksharp.v4.device', cfg.device);
+    }, { variant: V4_VARIANT, device: V4_DEVICE });
 
     await page.goto('/auth/signin');
     await page.waitForSelector(`[data-testid="auth-form"]`, { timeout: 15_000 });
@@ -113,14 +134,21 @@ test('measure Transformers.js v4 worker', async ({ page }) => {
     assertNoRegression('Private', wer, 'TransformersJS v4 worker', 'v4');
 
     const benchmarks = readBenchmarks();
-    benchmarks.engines.Private.v4.expectedAccuracy = accuracyPct;
+    // Only the rollout DEFAULT (base_q4 on wasm — the universal floor) moves the v4 ceiling that
+    // assertNoRegression enforces. distil_q4 / webgpu runs are recorded as labeled history for the
+    // A/B comparison without redefining the floor.
+    if (V4_VARIANT === 'base_q4' && V4_DEVICE === 'wasm') {
+        benchmarks.engines.Private.v4.expectedAccuracy = accuracyPct;
+    }
     benchmarks.engines.Private.v4.history.push({
         timestamp: new Date().toISOString(),
-        model: 'TransformersJS v4 onnx-community/whisper-tiny.en',
+        model: `TransformersJS v4 ${V4_VARIANT_MODEL_ID[V4_VARIANT]}`,
+        variant: V4_VARIANT,
+        device: V4_DEVICE,
         corpus: 'harvard-list-1',
         ceiling_wer: parseFloat(wer.toFixed(4)),
         ceiling_accuracy_pct: accuracyPct,
-        environment: 'chromium-playwright-v4-worker',
+        environment: `chromium-playwright-v4-worker-${V4_DEVICE}`,
     });
     writeBenchmarks(benchmarks);
 });


### PR DESCRIPTION
## Why
The v4 benchmark harness could never record a **valid** v4 number for the A/B: it hardcoded the label `whisper-tiny.en` and force-disabled the GPU (`--disable-gpu --disable-webgpu`). So `tests/STT_BENCHMARKS.json`'s lone v4 entry is a stale tiny.en/WASM placeholder (87.96%, *worse* than v2's 93.89%) on the **wrong model and device**.

## What
Parameterizes `benchmark-v4.live.spec.ts` so Test can record the **rollout** models on both devices:
- `V4_VARIANT=base_q4|distil_q4` (default `base_q4`) → selects the variant via the dev/test experiment override (`forceAuto` + `variant`), the same path PrivateSTT uses.
- `V4_DEVICE=wasm|webgpu` (default `wasm`) → pins the backend; `webgpu` **enables** the GPU flags instead of disabling them (needs a real GPU machine; distil_q4 is the WebGPU accuracy tier).
- Records the **correct** model + `variant` + `device` in each history entry (no more tiny.en mislabel).
- Only the rollout default (`base_q4` + `wasm` — the universal floor) moves `expectedAccuracy` that `assertNoRegression` enforces; other combos are labeled history.

Example: `V4_VARIANT=distil_q4 V4_DEVICE=webgpu pnpm exec playwright test tests/live/benchmark-v4.live.spec.ts`

## Scope / verification
- **Test-only**, no production code. eslint clean.
- I can't run a live Playwright + GPU spec here — **Test runs it** on a real browser (+ GPU for webgpu).

## For Test to verify on the run
1. The run log shows the loaded model = `whisper-base.en` (base_q4) / `distil-small.en` (distil_q4) — **not** tiny.en.
2. distil_q4 should be run with `V4_DEVICE=webgpu` (resolver gates distil on confirmed WebGPU).
3. After the run, the v4 history in STT_BENCHMARKS.json carries real `base_q4`/`distil_q4` × `wasm`/`webgpu` numbers — replacing the stale placeholder, and that becomes the floor.

## Sequencing
Land #789 (anti-loop decode defaults) first so v4 is measured **with** the F2 fix.

Follow-up (separate): `benchmark-webgpu.live.spec.ts` still benchmarks the retired WhisperTurbo and the `engines.Private.webgpu` slot is stale — cleanup or repurpose for v4-webgpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
