### PR TITLE
test(e2e): wait for visible model readiness in user features

### DIFF
--- a/tests/e2e/user-features.e2e.spec.ts
+++ b/tests/e2e/user-features.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 import {
   navigateToRoute,
-  waitForTranscriptionService
+  waitForModelReady
 } from './helpers';
 
 /**
@@ -34,7 +34,7 @@ test.describe('Exhaustive User Feature Matrix', () => {
     await expect(page.getByTestId('engine-select-private')).not.toBeVisible();
 
     // Deterministic Sync: Wait for engine handshake before clicking start
-    await waitForTranscriptionService(page, 'ENGINE_READY');
+    await waitForModelReady(page);
     await startButton.click();
 
     await navigateToRoute(page, '/analytics');
@@ -68,7 +68,7 @@ test.describe('Exhaustive User Feature Matrix', () => {
     await expect(startButton).toBeVisible();
 
     // Deterministic Sync: Wait for engine handshake before clicking start
-    await waitForTranscriptionService(page, 'ENGINE_READY');
+    await waitForModelReady(page);
     await startButton.click();
 
     // 3. Navigation to Analytics & Session Selection


### PR DESCRIPTION
## Summary
- Updates `user-features.e2e` to wait on the existing visible/model readiness contract instead of the internal `ENGINE_READY` probe.
- Keeps the test aligned with user-observable Session readiness (`data-stt-ready`, `data-runtime-state`, or model-ready state) so it does not fail while the UI is already usable.

## Verification
- `pnpm build:test`
- `pnpm exec playwright test tests/e2e/user-features.e2e.spec.ts --config=playwright.config.ts --project=full-suite --reporter=line --output=/private/tmp/speaksharp-user-features-ready-wait-results` — 7/7 PASS
- `pnpm exec playwright test tests/e2e/primary-journey.e2e.spec.ts tests/e2e/user-features.e2e.spec.ts tests/e2e/error-states.e2e.spec.ts tests/e2e/analytics-suite.e2e.spec.ts --config=playwright.config.ts --project=full-suite --reporter=line --output=/private/tmp/speaksharp-user-minded-e2e-after-ready-wait` — 18/18 PASS
- `pnpm lint`