### PR TITLE
fix(auth): magic-link sign-in must not auto-create accounts (shouldCreateUser:false + anti-enumeration)

### DIFF
--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -26,23 +26,6 @@ const getSafeSignInError = (err: unknown): string => {
     return 'Sign-in could not be completed. Please try again.';
 };
 
-const getSafeMagicLinkError = (err: unknown): string => {
-    const rawMessage = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
-    const message = rawMessage.toLowerCase();
-
-    if (message.includes('invalid email') || (message.includes('email') && message.includes('valid'))) {
-        return 'Email not valid';
-    }
-    if (err instanceof TypeError && message.includes('failed to fetch')) {
-        return 'Unable to send a sign-in link. Check your connection and try again.';
-    }
-    if (message.includes('rate') || message.includes('too many')) {
-        return 'Too many sign-in link requests. Please wait a moment and try again.';
-    }
-
-    return 'Sign-in link could not be sent. Please try again.';
-};
-
 const isEmailFormatValid = (value: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
 
 // Sign In page – supports both password and magic link
@@ -133,18 +116,24 @@ export default function SignInPage() {
         setIsSendingMagicLink(true);
         try {
             const supabase = getSupabaseClient();
-            const { error: otpError } = await supabase.auth.signInWithOtp({
+            // Anti-circumvention: `shouldCreateUser: false` issues a sign-in link ONLY to an
+            // already-registered user. Without it, Supabase defaults to creating an account for an
+            // unknown email — letting a new user / attacker use the magic link to auto-provision an
+            // account and bypass the signup flow. Anti-enumeration: suppress the provider outcome and
+            // ALWAYS show the same neutral message (an unknown email now errors with "Signups not
+            // allowed for otp"; surfacing that would reveal whether the account exists) — mirrors the
+            // password-reset path above.
+            await supabase.auth.signInWithOtp({
                 email: normalizedEmail,
                 options: {
-                    emailRedirectTo: `${window.location.origin}${postAuthPath}`
-                }
+                    shouldCreateUser: false,
+                    emailRedirectTo: `${window.location.origin}${postAuthPath}`,
+                },
             });
-            if (otpError) throw otpError;
-            setMessage('Magic link sent! Check your email for a login link.');
         } catch (err: unknown) {
-            logger.error({ err }, '[SignInPage] handleMagicLink failed');
-            setError(getSafeMagicLinkError(err));
+            logger.warn({ name: (err as { name?: string })?.name }, '[SignInPage] magic-link request error (suppressed from UI)');
         } finally {
+            setMessage("If an account exists for this email, we'll send a sign-in link.");
             setIsSendingMagicLink(false);
         }
     };

--- a/frontend/src/pages/__tests__/SignInPage.component.test.tsx
+++ b/frontend/src/pages/__tests__/SignInPage.component.test.tsx
@@ -280,6 +280,7 @@ describe('SignInPage', () => {
                 expect(mockSignInWithOtp).toHaveBeenCalledWith({
                     email: 'test@example.com',
                     options: {
+                        shouldCreateUser: false,
                         emailRedirectTo: `${window.location.origin}/session`,
                     },
                 });
@@ -298,17 +299,31 @@ describe('SignInPage', () => {
             expect(await screen.findByTestId('auth-error-message')).toHaveTextContent('Email not valid');
         });
 
-        it('maps provider invalid-email responses to Email not valid for sign-in links', async () => {
+        it('requests sign-in links with shouldCreateUser:false and never enumerates unknown emails', async () => {
             const user = userEvent.setup();
-            mockSignInWithOtp.mockResolvedValue({ error: new Error('Invalid email') });
+            // Under shouldCreateUser:false an unknown email is rejected by the provider
+            // ("Signups not allowed for otp"). The UI must SUPPRESS that and show the same neutral
+            // message it shows for a known email, so a caller cannot tell whether the account exists
+            // — and no account is auto-created to bypass signup.
+            mockSignInWithOtp.mockResolvedValue({ error: new Error('Signups not allowed for otp') });
 
             renderSignInPage();
 
-            await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+            await user.type(screen.getByLabelText(/email/i), 'stranger@example.com');
             await user.click(screen.getByTestId('magic-link-button'));
 
-            await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledTimes(1));
-            expect(await screen.findByTestId('auth-error-message')).toHaveTextContent('Email not valid');
+            await waitFor(() => {
+                expect(mockSignInWithOtp).toHaveBeenCalledWith({
+                    email: 'stranger@example.com',
+                    options: {
+                        shouldCreateUser: false,
+                        emailRedirectTo: `${window.location.origin}/session`,
+                    },
+                });
+            });
+            // Neutral success message, NOT an error → no account-existence leak.
+            expect(await screen.findByTestId('auth-message')).toHaveTextContent(/if an account exists for this email/i);
+            expect(screen.queryByTestId('auth-error-message')).not.toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
## Summary
Magic-link sign-in (`signInWithOtp` in `frontend/src/pages/SignInPage.tsx`) omitted `shouldCreateUser`, so Supabase's default (`true`) silently **created an account + session for an unknown email** — letting a new user / attacker bypass the signup flow via the magic-link request. Flagged by the release-owner.

## Fix
- `shouldCreateUser: false` — a sign-in link is only issued to an **existing** user; unknown emails can no longer auto-provision an account.
- Suppress the provider outcome and **always show the same neutral message** (anti-enumeration), mirroring the password-reset path — so blocking creation doesn't leak whether an account exists.
- Remove the now-dead `getSafeMagicLinkError` helper.

Password **reset** was already safe (`resetPasswordForEmail` never creates users); magic-link was the only `signInWithOtp` call site.

## Verification
- `SignInPage` suites **23/23**, incl. a new test asserting `shouldCreateUser:false` **and** the neutral no-enumeration response for an unknown email.
- `typecheck` clean, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
