### PR TITLE
ci(canary): reuse one stable canary account (stop auth.users bloat)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,8 +29,11 @@ jobs:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           CANARY_PASSWORD: ${{ secrets.CANARY_PASSWORD }}
-          # Unique email to avoid collision
-          CANARY_EMAIL: canary-${{ github.run_id }}@speaksharp.app
+          # Stable email so provision-canary.mjs reuses ONE account every run (its idempotent
+          # create-or-sync pattern) instead of minting a new canary-* user each run and bloating
+          # auth.users. The job concurrency guard above (one run per ref, cancel-in-progress) already
+          # prevents overlapping runs, so a fixed email is safe.
+          CANARY_EMAIL: canary@speaksharp.app
         run: node scripts/provision-canary.mjs
 
       - name: Run Smoke Test
@@ -38,7 +41,7 @@ jobs:
           VITE_TEST_MODE: "true"
           VITE_USE_LIVE_DB: "true"
           CANARY_PASSWORD: ${{ secrets.CANARY_PASSWORD }}
-          CANARY_EMAIL: canary-${{ github.run_id }}@speaksharp.app
+          CANARY_EMAIL: canary@speaksharp.app
           BASE_URL: https://speaksharp-public.vercel.app/
         run: pnpm test:deploy:prod
 


### PR DESCRIPTION
## Summary
The daily Production Canary workflow set `CANARY_EMAIL: canary-${{ github.run_id }}@speaksharp.app` — a **unique email per run**. `scripts/provision-canary.mjs` is already idempotent (create → on-conflict reuse + password/tier sync), but a fresh email every run meant it created a brand-new `canary-*@speaksharp.app` auth user **daily and never deleted it**. ~222 stale canary accounts had accumulated in prod (the bulk of an inactive-user cleanup).

## Fix
Use a **stable `canary@speaksharp.app`** for both the provision step and the smoke-test step, so the script reuses one account every run instead of minting a new one.

The "unique email to avoid collision" rationale is no longer needed: the job already has a concurrency guard (`group: canary-${{ github.ref }}`, `cancel-in-progress: true`) that prevents overlapping runs, and the provision script handles "already registered" idempotently.

## Effect
- One stable canary account, reused daily → **no more `auth.users` bloat**.
- No behavior change to the smoke test itself (same account, freshly synced password + `pro` tier each run).
- The ~222 already-accumulated stale canary/test accounts are being cleaned up separately by the release-owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
