### PR TITLE
fix(ci): cap execSync maxBuffer in impact-detection helpers (avoid ENOBUFS)

### DIFF
--- a/scripts/detect-impact-automation.mjs
+++ b/scripts/detect-impact-automation.mjs
@@ -7,6 +7,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 
+// The depcruise dependency-graph JSON (and large `git diff` outputs) exceed Node's default 1 MB
+// execSync buffer, which throws ENOBUFS. Cap generously so local/CI runs don't crash on big repos.
+const EXEC_MAX_BUFFER = 64 * 1024 * 1024; // 64 MB
+
 /**
  * Automates test impact detection using dependency-cruiser.
  * Replaces manual test-impact-map.json.
@@ -18,9 +22,9 @@ async function run() {
 
         try {
             if (process.env.GITHUB_BASE_REF) {
-                changedFiles = execSync(`git diff --name-only origin/${baseBranch}...HEAD`, { cwd: rootDir }).toString().split('\n');
+                changedFiles = execSync(`git diff --name-only origin/${baseBranch}...HEAD`, { cwd: rootDir, maxBuffer: EXEC_MAX_BUFFER }).toString().split('\n');
             } else {
-                changedFiles = execSync(`git diff --name-only HEAD~1`, { cwd: rootDir }).toString().split('\n');
+                changedFiles = execSync(`git diff --name-only HEAD~1`, { cwd: rootDir, maxBuffer: EXEC_MAX_BUFFER }).toString().split('\n');
             }
         } catch (e) {
             console.log("ALL");
@@ -38,7 +42,7 @@ async function run() {
 
         // Generate full dependency graph as JSON
         // Using --includeOnly to focus on src and tests
-        const cruiseOutput = execSync('npx depcruise frontend/src --config .dependency-cruiser.cjs --output-type json', { cwd: rootDir }).toString();
+        const cruiseOutput = execSync('npx depcruise frontend/src --config .dependency-cruiser.cjs --output-type json', { cwd: rootDir, maxBuffer: EXEC_MAX_BUFFER }).toString();
         const graph = JSON.parse(cruiseOutput);
 
         const modules = graph.modules;

--- a/scripts/detect-impacted-tests.mjs
+++ b/scripts/detect-impacted-tests.mjs
@@ -3,14 +3,17 @@ import fs from 'fs';
 
 const IMPACT_MAP_PATH = 'test-impact-map.json';
 
+// Large `git diff` outputs can exceed Node's default 1 MB execSync buffer → ENOBUFS. Cap generously.
+const EXEC_MAX_BUFFER = 64 * 1024 * 1024; // 64 MB
+
 function getChangedFiles() {
   try {
-    return execSync('git diff --name-only origin/main...HEAD', { encoding: 'utf8' })
+    return execSync('git diff --name-only origin/main...HEAD', { encoding: 'utf8', maxBuffer: EXEC_MAX_BUFFER })
       .split('\n')
       .filter(Boolean);
   } catch {
     // Fallback if origin/main is missing
-    return execSync('git diff --name-only HEAD~1', { encoding: 'utf8' })
+    return execSync('git diff --name-only HEAD~1', { encoding: 'utf8', maxBuffer: EXEC_MAX_BUFFER })
       .split('\n')
       .filter(Boolean);
   }


### PR DESCRIPTION
## Summary
The local impact-detection helpers shell out with `execSync` and capture the output, but Node's default `execSync` buffer is **1 MB**. The dependency-graph JSON from `npx depcruise frontend/src …` (and large `git diff` outputs) exceed that, so a local `pnpm rc:gates` run crashes with **`ENOBUFS`** during impact detection. This is a local-tooling crash, not a gate/product failure — CI gates pass on `main`.

## Fix
Add an explicit, generous `maxBuffer` (64 MB) to the `execSync` calls in:
- `scripts/detect-impact-automation.mjs` (the `depcruise` JSON call + the two `git diff` calls)
- `scripts/detect-impacted-tests.mjs` (the two `git diff` calls)

No behavior change beyond not crashing on large output.

## Verification
- `node --check` passes on both scripts.
- Low-risk: only enlarges a child-process output buffer in dev/CI helper scripts; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
