### PR TITLE
fix(v4): honest model label + variant-correct language check

### DIFF
--- a/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
+++ b/frontend/src/services/transcription/engines/TransformersJSV4Engine.ts
@@ -83,7 +83,7 @@ function summarizeRawResult(result: unknown): UnknownRecord {
     return summary;
 }
 
-function getV4AsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
+function getV4AsrOptions(modelId: string, audioLengthSeconds: number, decodeOptions?: Record<string, unknown>): Record<string, unknown> {
     const options: Record<string, unknown> = {
         chunk_length_s: PRIV_STT.WHISPER_WINDOW_SECONDS,
         stride_length_s: audioLengthSeconds < PRIV_STT.WHISPER_WINDOW_SECONDS ? 0 : PRIV_STT.WHISPER_STRIDE_SECONDS,
@@ -92,7 +92,9 @@ function getV4AsrOptions(audioLengthSeconds: number, decodeOptions?: Record<stri
         ...V4_ANTI_LOOP_DECODE_DEFAULTS,
     };
 
-    if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {
+    // Decide language off the model ACTUALLY loaded (base_q4→whisper-base.en, distil_q4→distil-small.en),
+    // not the legacy PRIV_STT_V4.MODEL_ID constant. `.en` models are English-only and must NOT set language.
+    if (!modelId.endsWith('.en')) {
         options.language = 'en';
         options.task = 'transcribe';
     }
@@ -111,6 +113,9 @@ export class TransformersJSV4Engine extends STTEngine {
     private workerRequestId: number = 0;
     private pendingWorkerRequests = new Map<number, PendingWorkerRequest>();
     private lastModelProgress: number = -1;
+    // The v4 model id this engine actually loaded (base_q4→whisper-base.en, distil_q4→distil-small.en).
+    // Source of truth for the ASR language decision — never the dead PRIV_STT_V4.MODEL_ID constant.
+    private v4ModelId: string = PRIV_STT_V4_VARIANTS[PRIV_STT_V4_DEFAULT_VARIANT].MODEL_ID;
 
     constructor(options?: TranscriptionModeOptions) {
         super(options);
@@ -141,6 +146,7 @@ export class TransformersJSV4Engine extends STTEngine {
                 : baseVariant.DTYPE,
             EXPECTED_SPLIT_DOWNLOAD_MB: baseVariant.EXPECTED_SPLIT_DOWNLOAD_MB,
         };
+        this.v4ModelId = v4Model.MODEL_ID;
         const experimentDevice = exp.device && exp.device !== 'auto' ? exp.device : undefined;
         if (this.transcriber || this.worker) {
             logger.info({ sId: this.serviceId, rId: this.runId, eId: this.instanceId }, '[TransformersJSV4] Engine already initialized, skipping.');
@@ -373,7 +379,7 @@ export class TransformersJSV4Engine extends STTEngine {
             }
 
             const audioLengthSeconds = samplesToSeconds(audio.length, PRIV_CLOUD_AUDIO.TARGET_SAMPLE_RATE_HZ);
-            const options = getV4AsrOptions(audioLengthSeconds, readPrivateDecodeOptionsOverride());
+            const options = getV4AsrOptions(this.v4ModelId, audioLengthSeconds, readPrivateDecodeOptionsOverride());
 
             const result = await (this.transcriber as (audio: Float32Array, options: Record<string, unknown>) => Promise<string | TranscriptionResult>)(audio, options);
 

--- a/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
+++ b/frontend/src/services/transcription/engines/transformers-js-v4.worker.ts
@@ -24,6 +24,8 @@ interface TranscriptionResult {
 }
 
 let transcriber: Pipeline | null = null;
+// The model id actually loaded by init() — drives the ASR language decision (set below).
+let loadedModelId: string | null = null;
 
 function post(response: WorkerResponse): void {
     self.postMessage(response);
@@ -52,7 +54,9 @@ function getAsrOptions(audioLengthSeconds: number, decodeOptions?: Record<string
         ...V4_ANTI_LOOP_DECODE_DEFAULTS,
     };
 
-    if (!PRIV_STT_V4.MODEL_ID.endsWith('.en')) {
+    // Decide language off the model ACTUALLY loaded (base_q4→whisper-base.en, distil_q4→distil-small.en),
+    // not the legacy PRIV_STT_V4.MODEL_ID constant. `.en` models are English-only and must NOT set language.
+    if (loadedModelId != null && !loadedModelId.endsWith('.en')) {
         options.language = 'en';
         options.task = 'transcribe';
     }
@@ -145,6 +149,7 @@ async function init(id: number, isE2E: boolean, modelId: string, dtype: unknown,
     const loadStart = performance.now();
     const loaded = await createPipeline(progress_callback, modelId, dtype, deviceOverride);
     transcriber = loaded.pipe;
+    loadedModelId = modelId;
     post({
         id,
         type: 'loaded',

--- a/scripts/manual-stt-corpus-proof.mjs
+++ b/scripts/manual-stt-corpus-proof.mjs
@@ -1715,7 +1715,10 @@ const evidence = {
   privateEngine: PRIVATE_ENGINE || 'default',
   privateMicConstraints: PRIVATE_MIC_CONSTRAINTS || 'default-product',
   privateVad: PRIVATE_VAD || 'default-rms',
-  privateModel: PRIVATE_MODEL || 'default-whisper-tiny.en',
+  // Configured Private model OVERRIDE (STT_PRIVATE_MODEL). When unset, the engine picks the model at
+  // runtime (v2 default, or the v4 variant base_q4/distil_q4) — see `privateRuntimePath` for what
+  // ACTUALLY loaded. Do NOT default this to a model name; that mislabels v4 runs as tiny.en.
+  privateModel: PRIVATE_MODEL || 'default',
   privateResampler: PRIVATE_RESAMPLER || 'default-box',
   nativeConfig: {
     continuous: NATIVE_CONTINUOUS || 'default',


### PR DESCRIPTION
## Summary
Two small correctness/clarity fixes around v4 model identity. **No behavior change today** (both current v4 variants are English `.en` models), and **not a load-path fix** — the static trace confirmed `base_q4`→`whisper-base.en` and `distil_q4`→`distil-small.en` already load correctly. These remove a misleading label and a latent trap that caused real confusion (a harness placeholder made WebGPU runs *look* like they loaded `tiny.en`).

## Changes
- **`TransformersJSV4Engine.ts` / `transformers-js-v4.worker.ts`** — the ASR language decision (`language='en'` for multilingual models) now reads the **model actually loaded** (threaded via `this.v4ModelId` / the worker's `loadedModelId`) instead of the legacy `PRIV_STT_V4.MODEL_ID` constant. Behavior is identical for the current `.en` variants; this is correct for any future non-`.en` (multilingual) variant.
- **`scripts/manual-stt-corpus-proof.mjs`** — the `privateModel` evidence field no longer defaults to `'default-whisper-tiny.en'` when `STT_PRIVATE_MODEL` is unset (it now reports `'default'`). That default string mislabeled v4 runs as tiny; the model that actually loaded is in `privateRuntimePath`.

## Not changed (intentionally)
- `PRIV_STT_V4.MODEL_ID` is left as-is — it's referenced by `releaseSpineGuards.test.ts` and is now only an unreachable defensive worker fallback. Retiring it is a separate, higher-risk change.

## Verification
- `pnpm typecheck` clean · eslint clean on changed files · `vitest` transcription suites **513/513 pass** (incl. v4 engine/worker/fallback). Coverage-threshold warnings only appear when running the subset locally; full CI shards meet thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
