### PR TITLE
test(v4): real-GPU WebGPU floors

### DIFF
--- a/tests/STT_BENCHMARKS.json
+++ b/tests/STT_BENCHMARKS.json
@@ -39,7 +39,10 @@
         "provider": "TransformersJS",
         "_floors_note": "Legacy expectedAccuracy (93.89%) was measured on whisper-tiny.en; the SHIPPING v2 Private default is whisper-base.en (see sttProviderConfig DEFAULT). `floors` tracks the shipping model so v2 and v4 are compared on like models; expectedAccuracy:null = re-measure pending.",
         "floors": {
-          "whisper-base.en|cpu": { "expectedAccuracy": null, "model": "Xenova/whisper-base.en" }
+          "whisper-base.en|cpu": {
+            "expectedAccuracy": null,
+            "model": "Xenova/whisper-base.en"
+          }
         },
         "history": [
           {
@@ -85,9 +88,18 @@
         "provider": "TransformersJS v4",
         "_floors_note": "expectedAccuracy/history below is a STALE placeholder (whisper-tiny.en, 3 sentences, WASM) — NOT the rollout models. `floors` is the per-variant|device source of truth for the v2-vs-v4 PostHog A/B; expectedAccuracy:null = not yet measured (the first benchmark run establishes that config's floor, and each later run may only improve it). Rollout models: base_q4=whisper-base.en, distil_q4=distil-small.en.",
         "floors": {
-          "base_q4|wasm": { "expectedAccuracy": null, "model": "onnx-community/whisper-base.en" },
-          "base_q4|webgpu": { "expectedAccuracy": null, "model": "onnx-community/whisper-base.en" },
-          "distil_q4|webgpu": { "expectedAccuracy": null, "model": "onnx-community/distil-small.en" }
+          "base_q4|wasm": {
+            "expectedAccuracy": null,
+            "model": "onnx-community/whisper-base.en"
+          },
+          "base_q4|webgpu": {
+            "expectedAccuracy": 51.72,
+            "model": "onnx-community/whisper-base.en"
+          },
+          "distil_q4|webgpu": {
+            "expectedAccuracy": null,
+            "model": "onnx-community/distil-small.en"
+          }
         },
         "history": [
           {
@@ -99,6 +111,16 @@
             "ceiling_accuracy_pct": 87.96,
             "environment": "local-chromium-worker",
             "note": "Initial v4 worker mini-corpus: h1_1 11.11% WER, h1_2 25.00% WER, h1_3 0.00% WER. Weekly automation must replace this with full harvard-list-1 evidence."
+          },
+          {
+            "timestamp": "2026-06-15T20:32:08.172Z",
+            "model": "TransformersJS v4 onnx-community/whisper-base.en",
+            "variant": "base_q4",
+            "device": "webgpu",
+            "corpus": "harvard-list-1",
+            "ceiling_wer": 0.4828,
+            "ceiling_accuracy_pct": 51.72,
+            "environment": "chromium-playwright-v4-worker-webgpu"
           }
         ]
       }


### PR DESCRIPTION
Records base_q4|webgpu floor from real-GPU run: 51.72%. distil_q4|webgpu was not run (private mode unavailable for test account).