### PR TITLE
fix(v4): discard invalid base_q4|webgpu floor (51.72% free-account run)

### DIFF
--- a/tests/STT_BENCHMARKS.json
+++ b/tests/STT_BENCHMARKS.json
@@ -93,7 +93,7 @@
             "model": "onnx-community/whisper-base.en"
           },
           "base_q4|webgpu": {
-            "expectedAccuracy": 51.72,
+            "expectedAccuracy": null,
             "model": "onnx-community/whisper-base.en"
           },
           "distil_q4|webgpu": {
@@ -111,16 +111,6 @@
             "ceiling_accuracy_pct": 87.96,
             "environment": "local-chromium-worker",
             "note": "Initial v4 worker mini-corpus: h1_1 11.11% WER, h1_2 25.00% WER, h1_3 0.00% WER. Weekly automation must replace this with full harvard-list-1 evidence."
-          },
-          {
-            "timestamp": "2026-06-15T20:32:08.172Z",
-            "model": "TransformersJS v4 onnx-community/whisper-base.en",
-            "variant": "base_q4",
-            "device": "webgpu",
-            "corpus": "harvard-list-1",
-            "ceiling_wer": 0.4828,
-            "ceiling_accuracy_pct": 51.72,
-            "environment": "chromium-playwright-v4-worker-webgpu"
           }
         ]
       }


### PR DESCRIPTION
The 51.72% base_q4|webgpu floor accidentally reached main via the #808 squash (the test agent's floor commit was in the branch base). It is NOT a valid v4 measurement — that run signed in as a **free** account, so Private/v4 was gated off and it fell to native. Resets the floor to `null` and removes the bad history entry, restoring 'no v4 number on record until a verified Pro + transformers-js-v4 + webgpu run.'

🤖 Generated with [Claude Code](https://claude.com/claude-code)