### PR TITLE
fix(stt): restore whole-utterance REPLACE so v4 saved transcript stops duplicating (#87/#88 regression)

### DIFF
--- a/frontend/src/services/SpeechRuntimeController.ts
+++ b/frontend/src/services/SpeechRuntimeController.ts
@@ -1233,6 +1233,25 @@ export class SpeechRuntimeController {
                 return;
             }
 
+            // AUTHORITATIVE whole-utterance re-transcription (Private post-Stop): REPLACE the rolling
+            // transcript + chunks instead of running the prefix/append heuristics below. Without this
+            // the clean final decode is appended onto the garbled streaming preview (it is not a forward
+            // prefix) → duplicated/inflated saved transcript. Regression guard for #87/#88. A blank final
+            // is already rejected above, so this never wipes text to empty.
+            if (data.transcript.replacesRollingTranscript) {
+                store.updateTranscript(finalTranscript, data.transcript.partial || '');
+                store.setChunks([{ transcript: finalTranscript, timestamp: Date.now(), isFinal: true }]);
+                this.syncTranscriptLifecycleFromStore();
+                pushNativeStoreTrace('store_replace_rolling_with_whole_utterance', { finalTranscript });
+                pushTranscriptLifecycleTrace('store:update', {
+                    type: 'final_replace_whole_utterance',
+                    committedLength: useSessionStore.getState().transcript.transcript.length,
+                    partialLength: useSessionStore.getState().transcript.partial.length,
+                    preview: finalTranscript.slice(0, 80),
+                });
+                return;
+            }
+
             const lastChunk = store.chunks[store.chunks.length - 1];
             if (lastChunk?.isFinal && normalizeTranscriptPrefix(lastChunk.transcript) === finalNormalized) {
                 pushNativeStoreTrace('store_skip_duplicate_last_chunk', {

--- a/frontend/src/services/__tests__/SpeechRuntimeController.test.ts
+++ b/frontend/src/services/__tests__/SpeechRuntimeController.test.ts
@@ -317,6 +317,42 @@ describe('SpeechRuntimeController FSM Expansion (Steps 1-4)', () => {
         );
     });
 
+    it('REGRESSION (#87/#88): an authoritative whole-utterance final REPLACES the rolling transcript, not appends', () => {
+        const push = (controller as unknown as {
+            pushTranscriptToStore: (data: { transcript: { final: string; replacesRollingTranscript?: boolean } }) => void
+        }).pushTranscriptToStore.bind(controller);
+
+        // Garbled streaming/provisional preview accumulates (the v4 rolling text).
+        push({ transcript: { final: 'well the swan dive was far short of pre the box was thrown beside the door' } });
+        // The clean post-Stop whole-utterance decode is NOT a forward prefix of the garbled preview, so the
+        // generic prefix/append merge would CONCATENATE the two (duplication / inflated WER). The replace
+        // flag must wipe the rolling text and leave only the authoritative final.
+        push({ transcript: { final: 'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.', replacesRollingTranscript: true } });
+
+        expect(useSessionStore.getState().transcript.transcript).toBe(
+            'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.'
+        );
+        // chunks are reset to the single authoritative final — no garbled rolling chunk survives to be
+        // re-joined by the save-candidate selection.
+        expect(useSessionStore.getState().chunks).toEqual([
+            expect.objectContaining({
+                transcript: 'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.',
+                isFinal: true,
+            }),
+        ]);
+    });
+
+    it('REGRESSION: a blank authoritative final never wipes existing committed text', () => {
+        const push = (controller as unknown as {
+            pushTranscriptToStore: (data: { transcript: { final: string; replacesRollingTranscript?: boolean } }) => void
+        }).pushTranscriptToStore.bind(controller);
+
+        push({ transcript: { final: 'real committed words here' } });
+        push({ transcript: { final: '   ', replacesRollingTranscript: true } });
+
+        expect(useSessionStore.getState().transcript.transcript).toBe('Real committed words here.');
+    });
+
     it('adds conservative commas and first-person capitalization without rewriting words', () => {
         const push = (controller as unknown as {
             pushTranscriptToStore: (data: { transcript: { final: string } }) => void

--- a/frontend/src/services/transcription/TranscriptionService.ts
+++ b/frontend/src/services/transcription/TranscriptionService.ts
@@ -1678,10 +1678,16 @@ export default class TranscriptionService {
     }
 
     if (transcript.final) {
-      this.currentTranscript = mergeFinalTranscriptUpdate(this.currentTranscript, transcript.final);
+      // replacesRollingTranscript: an AUTHORITATIVE whole-utterance re-transcription (Private
+      // post-Stop decode) REPLACES the rolling transcript outright. Otherwise the clean final
+      // decode is append-merged onto the garbled streaming preview (it is not a forward prefix),
+      // doubling the saved transcript via service_result. A blank final never wipes existing text.
+      this.currentTranscript = transcript.replacesRollingTranscript && transcript.final.trim()
+        ? transcript.final
+        : mergeFinalTranscriptUpdate(this.currentTranscript, transcript.final);
       this.partialTranscript = '';
       this.options.onTranscriptUpdate?.({
-        transcript: { final: this.currentTranscript }
+        transcript: { final: this.currentTranscript, replacesRollingTranscript: transcript.replacesRollingTranscript }
       });
     }
 

--- a/frontend/src/services/transcription/__tests__/TranscriptionService.test.ts
+++ b/frontend/src/services/transcription/__tests__/TranscriptionService.test.ts
@@ -333,6 +333,56 @@ describe('TranscriptionService', () => {
         });
     });
 
+    it('REGRESSION (#87/#88): an authoritative whole-utterance final REPLACES accumulated rolling finals (no duplication)', async () => {
+        const { sttRegistry } = await import('../STTRegistry');
+
+        class MockEngine extends STTEngine {
+            public override readonly type = 'transformers-js' as EngineType;
+            public async checkAvailability() { return { isAvailable: true }; }
+            protected async onInit() { return Result.ok(undefined); }
+            protected async onStart() {}
+            protected async onStop() {}
+            protected async onPause() {}
+            protected async onResume() {}
+            protected async onDestroy() {}
+            async transcribe() { return Result.ok('test'); }
+            public override getEngineType() { return 'transformers-js' as EngineType; }
+
+            public triggerTranscript(data: { transcript: { final?: string; partial?: string; replacesRollingTranscript?: boolean } }) {
+                (this.options as TranscriptionModeOptions)?.onTranscriptUpdate?.(data);
+            }
+        }
+
+        const mockEngine = new MockEngine({} as unknown as TranscriptionModeOptions);
+        sttRegistry.registerStatic('mock', mockEngine);
+
+        await service.startTranscription();
+
+        // Garbled streaming/provisional finals accumulate (the v4 rolling preview).
+        mockEngine.triggerTranscript({ transcript: { final: 'well the swan dive was far short of pre the box was thrown beside the door' } });
+        // Clean post-Stop whole-utterance decode: NOT a forward prefix of the garbled preview, so the
+        // generic merge would APPEND it → doubled service_result / selectedForSave (the 142-vs-87 bug).
+        // The replace flag must make it the authoritative full transcript.
+        mockEngine.triggerTranscript({
+            transcript: {
+                final: 'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.',
+                replacesRollingTranscript: true,
+            },
+        });
+
+        // service_result (what stop() returns and selectedForSave reads) is the clean final ONLY.
+        expect(mockOnTranscriptUpdate).toHaveBeenLastCalledWith({
+            transcript: {
+                final: 'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.',
+                replacesRollingTranscript: true,
+            },
+        });
+        const internal = service as unknown as { currentTranscript: string };
+        expect(internal.currentTranscript).toBe(
+            'Well, the swan dive was far short of perfect, the box was thrown beside the parked truck.'
+        );
+    });
+
     it('REGRESSION: splits combined Web Speech final+interim into final commit then visible partial', async () => {
         const { sttRegistry } = await import('../STTRegistry');
 

--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -2224,7 +2224,12 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
       decodeMs,
     });
 
-    this.onTranscriptUpdate?.({ transcript: { final: transcript } });
+    // AUTHORITATIVE whole-utterance re-transcription: this single final REPLACES the rolling
+    // streaming preview, it is NOT an incremental segment to append. Without replacesRollingTranscript
+    // the downstream merges (TranscriptionService.mergeFinalTranscriptUpdate +
+    // SpeechRuntimeController.pushTranscriptToStore) concatenate the garbled streaming pass with this
+    // clean final decode → duplicated/inflated saved transcript (regression guard for #87/#88).
+    this.onTranscriptUpdate?.({ transcript: { final: transcript, replacesRollingTranscript: true } });
   }
 
   private retainAudioForRetry(audio: Float32Array): void {

--- a/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
+++ b/frontend/src/services/transcription/modes/__tests__/PrivateWhisper.test.ts
@@ -608,7 +608,7 @@ describe('PrivateWhisper (Facade Wrapper)', () => {
         expect(mocks.transcribe).toHaveBeenCalledTimes(2);
         expect((mocks.transcribe.mock.calls[1][0] as Float32Array).length).toBe(longLiveChunk.length);
         expect(mockCallbacks.onTranscriptUpdate).toHaveBeenLastCalledWith({
-            transcript: { final: 'private local full final transcript' },
+            transcript: { final: 'private local full final transcript', replacesRollingTranscript: true },
         });
 
         vi.useRealTimers();
@@ -762,8 +762,10 @@ describe('PrivateWhisper (Facade Wrapper)', () => {
 
         expect(engine.wholeUtteranceTranscript).toBe('The puppy, like, chewed up the new shoes.');
         expect(await engine.getTranscript()).toBe('The puppy, like, chewed up the new shoes.');
+        // The whole-utterance stop decode is AUTHORITATIVE: it must carry replacesRollingTranscript
+        // so downstream merges REPLACE (not append onto) the garbled streaming preview (#87/#88 guard).
         expect(mockCallbacks.onTranscriptUpdate).toHaveBeenLastCalledWith({
-            transcript: { final: 'The puppy, like, chewed up the new shoes.' },
+            transcript: { final: 'The puppy, like, chewed up the new shoes.', replacesRollingTranscript: true },
         });
     });
 
@@ -1081,7 +1083,7 @@ describe('PrivateWhisper (Facade Wrapper)', () => {
             expect.objectContaining({ type: 'info', message: 'Processing speech locally…' }),
         );
         expect(mockCallbacks.onTranscriptUpdate).toHaveBeenLastCalledWith({
-            transcript: { final: 'first stable words continue with tail' },
+            transcript: { final: 'first stable words continue with tail', replacesRollingTranscript: true },
         });
     });
 

--- a/frontend/src/services/transcription/modes/types.ts
+++ b/frontend/src/services/transcription/modes/types.ts
@@ -17,6 +17,14 @@ export interface Transcript {
   partial?: string;
   final?: string;
   speaker?: string;
+  /**
+   * When true, this `final` is an AUTHORITATIVE whole-utterance re-transcription that REPLACES the
+   * accumulated rolling transcript rather than being appended. Set ONLY by Private's post-Stop
+   * whole-utterance decode; without it the downstream merges concatenate the garbled streaming
+   * preview with the clean final decode (duplication / inflated WER). Mirrors
+   * {@link TranscriptUpdate}. A blank/whitespace final never wipes existing text. Defaults to append.
+   */
+  replacesRollingTranscript?: boolean;
 }
 
 // TranscriptionError definition removed (Moved to consolidated errors.ts)


### PR DESCRIPTION
## Root cause (proven, not inferred)

Test's 2026-06-15 GPU run saved a v4 transcript of **142 words vs the 87-word reference** (WER 51.72%). I traced it end to end:

- The `replacesRollingTranscript` signal — designed in #87/#88 so Private's post-Stop **whole-utterance** decode *replaces* the rolling streaming preview instead of being appended to it — was **declared in the type but its producer + both consumers had been deleted**. Only the type's tombstone comment survived. That is the "regression of #87/#88."
- Without it, the clean whole-utterance final (which is **not** a forward prefix of the garbled streaming preview) fell through every merge's prefix check into the **append** branch:
  - `TranscriptionService.mergeFinalTranscriptUpdate` → `currentTranscript = garbled + clean`; `stop()` prefers the longer string → returns **142 words** as `result.transcript` → `service_result` → `selectedForSave`. **This is the saved number Test measured** (confirmed via `saveCandidateReason: "service_result"` in the evidence).
  - `SpeechRuntimeController.pushTranscriptToStore` → same append into the store transcript.
- The **model was never at fault**: the clean half of the 142-word string ≈ the Dev Node v4-base ceiling (98.85%) almost verbatim.

## Fix — re-wire the existing flag end to end

| Site | Change |
|---|---|
| `PrivateWhisper.commitWholeUtteranceTranscript` | emit `{ final, replacesRollingTranscript: true }` |
| `TranscriptionService.processTranscript` | when set + non-empty, **replace** `currentTranscript` (not merge) and forward the flag |
| `SpeechRuntimeController.pushTranscriptToStore` | when set + non-empty, **replace** the store transcript + reset chunks to the single authoritative final |
| `modes/types.ts` `Transcript` | add `replacesRollingTranscript?` (mirrors `TranscriptUpdate`) |

Guards: a blank/whitespace final never wipes existing text; **Native/Cloud finals leave the flag unset → append/accumulate behavior unchanged**.

## Regression tests
- **PrivateWhisper**: whole-utterance stop emit carries `replacesRollingTranscript` (producer).
- **TranscriptionService**: garbled rolling finals + authoritative final → `currentTranscript` is the clean final only (no duplication); Native accumulate preserved.
- **SpeechRuntimeController**: authoritative final replaces store transcript + resets chunks; blank final never wipes; Native append preserved.

## Scope
Fixes the **duplication**. The separate **onset truncation** (first ~2 sentences missing from the browser decode — present in *both* passes, so it's audio-capture, not merge) is tracked in `BACKLOG.md` and NOT addressed here. After this fix the v4 saved transcript should jump from ~51% toward the clean-pass accuracy, still capped by onset until that's fixed separately.

## Verify
`tsc` clean · `eslint` clean · **627/627** transcription + controller + stores tests pass (incl. the new regression specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
