### PR TITLE
fix(harness): Gate 2 audio route + de-gate harness-limited browser WER + silence guard

### DIFF
--- a/scripts/manual-stt-corpus-proof.mjs
+++ b/scripts/manual-stt-corpus-proof.mjs
@@ -1428,6 +1428,11 @@ async function runFixture(page, mode, fixture) {
     }
   }
   if (INJECT_MIC_AUDIO && mode !== 'native') {
+    // ⚠️ NON-AUTHORITATIVE / DEPRECATED for proof. The Web-Audio getUserMedia override is
+    // NONDETERMINISTIC in automated Chrome (observed: digital silence in some runs, partial audio in
+    // others) and is NOT a trusted Gate-2 proof path. Use STT_USE_FAKE_AUDIO_CAPTURE (Chrome
+    // --use-file-for-fake-audio-capture) for authoritative proof. Retained only for ad-hoc diagnostics.
+    console.warn('⚠️  STT_INJECT_MIC_AUDIO is NON-AUTHORITATIVE for proof (nondeterministic in automated Chrome: silence/partial). Use STT_USE_FAKE_AUDIO_CAPTURE for trusted Gate-2 results.');
     await installInjectedMicAudio(page, fixture.audioPath);
   }
   if (mode === 'private' && PRIVATE_MODEL) {

--- a/scripts/manual-stt-corpus-proof.mjs
+++ b/scripts/manual-stt-corpus-proof.mjs
@@ -83,6 +83,16 @@ const FAKE_AUDIO_FILE = process.env.STT_FAKE_AUDIO_FILE || '';
 const RESOLVED_FAKE_AUDIO_FILE = FAKE_AUDIO_FILE ? path.resolve(FAKE_AUDIO_FILE) : '';
 const INJECT_MIC_AUDIO = process.env.STT_INJECT_MIC_AUDIO === 'true';
 const INJECT_MIC_AUDIO_LOOP = process.env.STT_INJECT_MIC_AUDIO_LOOP === 'true';
+
+// Per-fixture audio-frame accumulator, populated from the app's [PRIVATE_TRACE] audio_frame_in console
+// events. Lets the proof distinguish a SILENT HARNESS (engine fed digital silence, frameRms=0 — e.g. an
+// unreliable Web-Audio getUserMedia override) from a genuine app/STT failure. Reset per runFixture.
+const audioFrameStats = { count: 0, maxRms: 0, speechFrames: 0 };
+function resetAudioFrameStats() {
+  audioFrameStats.count = 0;
+  audioFrameStats.maxRms = 0;
+  audioFrameStats.speechFrames = 0;
+}
 const DISABLE_WEBGPU = process.env.STT_DISABLE_WEBGPU === 'true';
 const INCLUDE_AUDIO_DATA_URL = process.env.STT_INCLUDE_AUDIO_DATA_URL === 'true';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '';
@@ -1367,6 +1377,7 @@ async function fetchLatestSavedSessions(page, expectedTranscript = '') {
 }
 
 async function runFixture(page, mode, fixture) {
+  resetAudioFrameStats();
   const sessionUrl = new URL('/session', BASE_URL);
   if (mode === 'private' && PRIVATE_ENGINE) {
     sessionUrl.searchParams.set('privateEngine', PRIVATE_ENGINE);
@@ -1696,6 +1707,16 @@ async function runFixture(page, mode, fixture) {
     speechExpected: fixture.type !== 'silence',
     stopFinalizationMs: result.stopFinalizationMs ?? undefined,
   });
+  // SILENCE GUARD: if the engine received audio frames but ALL were digital silence (frameRms=0, zero
+  // speech frames), the HARNESS failed to deliver audio — NOT the app/STT. Mark INVALID_SETUP so a silent
+  // harness can never masquerade as a transcription failure. (Real audio ⇒ maxRms > 0.)
+  result.audioFrameStats = { ...audioFrameStats };
+  if (mode !== 'silence' && fixture.type !== 'silence'
+      && audioFrameStats.count > 0 && audioFrameStats.maxRms === 0 && audioFrameStats.speechFrames === 0) {
+    result.invalidForWer = true;
+    result.invalidReason = 'harness_silent_audio';
+    result.invalidDetails = `Engine received ${audioFrameStats.count} audio frames but ALL had frameRms=0 (digital silence) — the harness did not deliver audio to the mic pipeline (e.g. a Web-Audio getUserMedia override produced a silent stream). Use STT_USE_FAKE_AUDIO_CAPTURE (Chrome --use-file-for-fake-audio-capture). SETUP error, NOT an STT/app defect.`;
+  }
   result.meetsWerThreshold = MAX_WER == null ? null : result.wer <= MAX_WER;
   result.verdict = result.invalidForWer
     ? result.invalidReason
@@ -1879,6 +1900,14 @@ try {
       evidence.consoleEvents.push({ type: message.type(), text });
       // Un-blind (diagnostic observability only): forward relevant browser console to the run log.
       console.log(`[BROWSER:${message.type()}] ${text}`);
+      if (text.includes('audio_frame_in')) {
+        const rms = text.match(/frameRms:\s*([0-9.]+)/);
+        if (rms) {
+          audioFrameStats.count += 1;
+          audioFrameStats.maxRms = Math.max(audioFrameStats.maxRms, parseFloat(rms[1]) || 0);
+          if (/isSpeechFrame:\s*true/.test(text)) audioFrameStats.speechFrames += 1;
+        }
+      }
     }
   });
   page.on('pageerror', (error) => {

--- a/scripts/run-v4-gates.sh
+++ b/scripts/run-v4-gates.sh
@@ -133,7 +133,8 @@ echo ""; echo "════ GATE 2: v4 app-path proof (real WebGPU, headed) ═�
 G2_OUT="$EVIDENCE_DIR/v4-gate2-real-gpu-$TS.json"
 STT_AUTH=existing STT_MODES=private STT_FIXTURES=h1_6 \
 STT_PRIVATE_ENGINE=transformers-js-v4 STT_V4_VARIANT=base_q4 STT_V4_DEVICE=webgpu \
-STT_INJECT_MIC_AUDIO=true STT_POST_PLAYBACK_WAIT_MS=15000 STT_FIRST_TEXT_TIMEOUT_MS=45000 \
+STT_USE_FAKE_AUDIO_CAPTURE=true STT_FAKE_AUDIO_FILE="$REPO/tests/fixtures/stt-isomorphic/audio/h1_6.wav" \
+STT_POST_PLAYBACK_WAIT_MS=15000 STT_FIRST_TEXT_TIMEOUT_MS=45000 \
 HEADLESS=false STT_CORPUS_OUT="$G2_OUT" BASE_URL="$BASE_URL" \
   node scripts/manual-stt-corpus-proof.mjs || echo "⚠ Gate 2 proof returned non-zero (inspect above)"
 

--- a/tests/live/benchmark-cpu.live.spec.ts
+++ b/tests/live/benchmark-cpu.live.spec.ts
@@ -115,7 +115,14 @@ test('measure TransformersJS (CPU)', async ({ page }) => {
     console.log(`\n📊 Private (CPU) Ceiling: WER ${(wer * 100).toFixed(2)}% → Accuracy ${accuracyPct}%`);
     console.log(`📝 TRANSCRIPT(${wordCount}w/${referenceWordCount}): ${transcriptText}`);
 
-    assertNoRegression('Private', wer, 'TransformersJS', 'cpu');
+    // ADVISORY ONLY (owner-approved Option-1 disposition): browser app-path WER is HARNESS-LIMITED
+    // evidence, NOT a release gate — Chrome fake-audio is timing-nondeterministic + onset-truncated.
+    // Log regressions, never throw. The deterministic Node clean-decode ceiling is the real gate.
+    try {
+        assertNoRegression('Private', wer, 'TransformersJS', 'cpu');
+    } catch (e) {
+        console.warn(`⚠️  [browser WER · harness-limited · advisory, not a gate] ${(e as Error).message}`);
+    }
 
     const benchmarks = readBenchmarks();
     benchmarks.engines.Private.cpu.expectedAccuracy = accuracyPct;

--- a/tests/live/benchmark-cpu.live.spec.ts
+++ b/tests/live/benchmark-cpu.live.spec.ts
@@ -125,7 +125,13 @@ test('measure TransformersJS (CPU)', async ({ page }) => {
     }
 
     const benchmarks = readBenchmarks();
-    benchmarks.engines.Private.cpu.expectedAccuracy = accuracyPct;
+    // RAISE-ONLY: browser numbers are harness-limited + nondeterministic (±~10pp). Record EVERY run in
+    // history below, but never let a single unlucky run LOWER the committed reference floor (this preserves
+    // the prior "floor only improves" intent that the now-advisory regression throw used to enforce).
+    const priorCpuAccuracy = benchmarks.engines.Private.cpu.expectedAccuracy;
+    if (priorCpuAccuracy == null || accuracyPct > priorCpuAccuracy) {
+        benchmarks.engines.Private.cpu.expectedAccuracy = accuracyPct;
+    }
     benchmarks.engines.Private.cpu.history.push({
         timestamp: new Date().toISOString(),
         model: 'TransformersJS whisper-small (ONNX CPU)',

--- a/tests/live/benchmark-v4.live.spec.ts
+++ b/tests/live/benchmark-v4.live.spec.ts
@@ -155,13 +155,20 @@ test('measure Transformers.js v4 worker', async ({ page }) => {
     // Per-variant|device floor = the source of truth for the v2-vs-v4 A/B. Each run records (and may
     // only improve) its own config's floor; the latest measurement becomes the floor going forward.
     benchmarks.engines.Private.v4.floors = benchmarks.engines.Private.v4.floors ?? {};
-    benchmarks.engines.Private.v4.floors[benchmarkConfig] = {
-        expectedAccuracy: accuracyPct,
-        model: V4_VARIANT_MODEL_ID[V4_VARIANT],
-    };
-    // Keep the legacy engine-level expectedAccuracy in sync for the rollout default so the frontend
-    // STTAccuracyVsBenchmark component (reads expectedAccuracy) reflects the shipping floor.
-    if (V4_VARIANT === 'base_q4' && V4_DEVICE === 'wasm') {
+    // RAISE-ONLY: browser app-path WER is harness-limited + nondeterministic. Record every run in history
+    // below, but never let a single unlucky run LOWER the committed reference floor (preserves the prior
+    // "floor only improves" intent now that the regression check is advisory rather than throwing).
+    const priorFloorAccuracy = benchmarks.engines.Private.v4.floors[benchmarkConfig]?.expectedAccuracy;
+    if (priorFloorAccuracy == null || accuracyPct > priorFloorAccuracy) {
+        benchmarks.engines.Private.v4.floors[benchmarkConfig] = {
+            expectedAccuracy: accuracyPct,
+            model: V4_VARIANT_MODEL_ID[V4_VARIANT],
+        };
+    }
+    // Keep the legacy engine-level expectedAccuracy in sync for the rollout default (raise-only too) so the
+    // frontend STTAccuracyVsBenchmark component (reads expectedAccuracy) reflects the best shipping floor.
+    if (V4_VARIANT === 'base_q4' && V4_DEVICE === 'wasm'
+        && (benchmarks.engines.Private.v4.expectedAccuracy == null || accuracyPct > benchmarks.engines.Private.v4.expectedAccuracy)) {
         benchmarks.engines.Private.v4.expectedAccuracy = accuracyPct;
     }
     benchmarks.engines.Private.v4.history.push({

--- a/tests/live/benchmark-v4.live.spec.ts
+++ b/tests/live/benchmark-v4.live.spec.ts
@@ -141,7 +141,15 @@ test('measure Transformers.js v4 worker', async ({ page }) => {
     const benchmarkConfig = `${V4_VARIANT}|${V4_DEVICE}`;
     // Regression is checked against THIS config's own floor (base_q4|wasm, base_q4|webgpu,
     // distil_q4|webgpu); a null/absent floor means this run establishes it.
-    assertNoRegression('Private', wer, 'TransformersJS v4 worker', 'v4', benchmarkConfig);
+    // ADVISORY ONLY (owner-approved Option-1 disposition): browser app-path WER is HARNESS-LIMITED
+    // evidence, NOT a release gate — Chrome fake-audio is timing-nondeterministic (±~10pp) and
+    // onset-truncated, so a hard regression throw produces false failures. Log it, never throw.
+    // The deterministic Node clean-decode ceiling (~99%) remains the model-quality gate.
+    try {
+        assertNoRegression('Private', wer, 'TransformersJS v4 worker', 'v4', benchmarkConfig);
+    } catch (e) {
+        console.warn(`⚠️  [browser WER · harness-limited · advisory, not a gate] ${(e as Error).message}`);
+    }
 
     const benchmarks = readBenchmarks();
     // Per-variant|device floor = the source of truth for the v2-vs-v4 A/B. Each run records (and may


### PR DESCRIPTION
## Harness-correctness fixes for the v4 Gate 2/3 runner (independent-review ready)

Root-cause fixes for the failures surfaced when running `scripts/run-v4-gates.sh` on a real GPU. **No product/app code changes — test harness only.** The v4/v2 STT engines are not modified and are confirmed healthy (real coherent transcripts in every run).

### Reviewer checklist (all satisfied)
- [x] **No product/app code changed** — diff is 4 harness files (`scripts/*` + 2 live specs), 0 lines under `frontend/src`.
- [x] **Gate 2 uses the Chrome fake-audio route** (`STT_USE_FAKE_AUDIO_CAPTURE` + `h1_6.wav`).
- [x] **Node deterministic quality gate remains HARD-gated** — `assertNoRegression` helper is unchanged; only the two *browser* call-sites are made advisory.
- [x] **Browser WER is advisory only** (per owner-approved Option-1 disposition: harness-limited evidence, not a gate).
- [x] **Benchmark floors only improve** — floor write is raise-only; the verify-run drift (cpu 85→71) was reverted.
- [x] **Inject route explicitly marked NON-AUTHORITATIVE / deprecated for proof — NOT fixed** (code-level `console.warn` + comment at the call-site, plus PR text below).

### Commits
| SHA | Fix |
|---|---|
| `abb1fe47` | Gate 2 → Chrome `--use-file-for-fake-audio-capture` route (not the silent Web-Audio `getUserMedia` override) |
| `f67b00f6` | De-gate harness-limited browser WER (advisory, not throwing) + silent-audio guard |
| `8399bb97` | Floor write is RAISE-ONLY (advisory de-gate must not let an unlucky run lower the floor) |
| `<this>`   | Mark `STT_INJECT_MIC_AUDIO` non-authoritative/deprecated for proof (warn + comment) |

### Gate 2 Chrome-route proof (real GPU, reproduced 2×)
```
pass: true
verdict: journey-completed
wer: 0          accuracyPct: 100
audioFrameStats: { count: 21806, maxRms: 0.332945, speechFrames: 936 }   ← real audio (maxRms > 0)
journeyPass: true   sessionPersisted: true   detailVisible: true
transcript: "They, like, told wild tales to frighten him."
```

### Gate 3 browser-WER advisory proof (real GPU)
```
📊 Private (CPU) Ceiling: WER 28.74% → Accuracy 71.26%
⚠️  [browser WER · harness-limited · advisory, not a gate] ... WER REGRESSION DETECTED
  1 passed          EXIT 0          (advisory warning, no hard fail)
```
Same for `base_q4|webgpu` (1 passed, exit 0, advisory). `tsc` clean; both TS specs eslint-clean; `node --check` on the script clean.

### Inject route is NON-AUTHORITATIVE (not fixed)
The `STT_INJECT_MIC_AUDIO` Web-Audio `getUserMedia` override is **nondeterministic** in automated Chrome — digital silence (`frameRms:0`) in earlier runs, partial audio (`"Him."`) in the verify run. This PR does **not** repair it; it routes Gate 2 to the trusted Chrome flag and marks the inject path non-authoritative in code. (Repairing the Web-Audio override is out of scope and vendor-discouraged for automated Chrome.)

### Honest disclosures
- **Silence guard: implemented, NOT observed firing.** In the verify run the inject route delivered *partial* audio (`maxRms 0.33`), so the guard correctly did not fire (there was audio). It is verified by inspection + non-false-fire behavior only; no true all-silent run was captured to observe it fire.
- **Browser WER stays harness-limited** by design; model quality gates on the Node ceiling (~99%), real-world on the PostHog A/B.
- **`scripts/manual-stt-corpus-proof.mjs` has pre-existing eslint `no-undef` noise** — the eslint config covers `scripts/**/*.js`, not `.mjs`; this file was never in the lint set. Not introduced here; should be a separate scope fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
