### PR TITLE
ci(gate-b): cloud workflow + node trigger for v4 single-user PostHog targeting proof

### DIFF
--- a/.github/workflows/posthog-gate-b.yml
+++ b/.github/workflows/posthog-gate-b.yml
@@ -71,7 +71,11 @@ jobs:
             if (!m) { console.error("No evidence line emitted."); process.exit(1); }
             const e = JSON.parse(m[1]);
             console.log("classification:", e.classification, "| pass:", e.pass);
-            console.log("flagEvaluationAfter:", JSON.stringify(e.flagEvaluationAfter));
+            console.log("exclusivity:", JSON.stringify(e.exclusivity));
+            console.log("controlEvaluationAfter (must be v4=false):", JSON.stringify(e.controlEvaluationAfter));
+            console.log("flagGroupsAfter:", JSON.stringify(e.flagGroupsAfter));
+            console.log("cohortMemberCount:", JSON.stringify(e.cohortMemberCount));
+            console.log("flagEvaluationAfter (target, must be v4=true):", JSON.stringify(e.flagEvaluationAfter));
             console.log("mutations:", JSON.stringify(e.mutations));
             if (e.classification !== "TARGETING_VERIFIED") {
               console.error("Gate B NOT verified — classification:", e.classification);

--- a/.github/workflows/posthog-gate-b.yml
+++ b/.github/workflows/posthog-gate-b.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# PostHog Gate B — v4 SINGLE-USER targeting proof (control-plane, cloud-only).
+# =============================================================================
+# Runs on GitHub-hosted ubuntu so POSTHOG_PERSONAL_API_KEY stays a CI secret and
+# never touches a local/dev environment. Drives the sanctioned proof script:
+#   scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs
+# which, for the ONE supplied app_user_id, ensures a STATIC single-user cohort,
+# targets flag private_stt_v4_enabled (709644) at that cohort, and verifies the
+# user resolves the flag — distil stays OFF.
+#
+# SCOPE GUARD: this is a SINGLE-USER operator proof. It targets exactly the one
+# app_user_id you pass (a static cohort of one). It does NOT enable any broad
+# customer rollout. Do not raise the flag's global rollout here.
+#
+# Trigger locally with: node scripts/trigger-posthog-gate-b.mjs <app_user_id>
+# =============================================================================
+name: PostHog Gate B — v4 single-user targeting proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_user_id:
+        description: 'Supabase user.id (distinct_id) of the ONE designated test operator user to target for v4'
+        type: string
+        required: true
+      cohort_name:
+        description: 'Static single-user cohort name'
+        type: string
+        required: false
+        default: stt_ab_disposable_pro_testers
+
+permissions:
+  contents: read
+
+concurrency:
+  group: posthog-gate-b
+  cancel-in-progress: false
+
+jobs:
+  targeting-proof:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: PostHog Gate B — single-user targeting proof (NO broad rollout)
+        env:
+          STT_AB_APP_USER_ID: ${{ inputs.app_user_id }}
+          POSTHOG_STT_AB_COHORT_NAME: ${{ inputs.cohort_name }}
+          POSTHOG_PROJECT_API_KEY: ${{ vars.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_INGEST_HOST: ${{ vars.POSTHOG_INGEST_HOST }}
+          POSTHOG_API_HOST: ${{ vars.POSTHOG_API_HOST }}
+        run: |
+          set -o pipefail
+          node scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs | tee gate-b-evidence.txt
+          grep 'POSTHOG_STT_AB_AUTHENTICATED_USER_TARGETING_PROOF_EVIDENCE' gate-b-evidence.txt \
+            | sed 's/^POSTHOG_STT_AB_AUTHENTICATED_USER_TARGETING_PROOF_EVIDENCE //' > gate-b-evidence.json || true
+
+      - name: Assert TARGETING_VERIFIED
+        run: |
+          node -e '
+            const fs = require("fs");
+            const t = fs.readFileSync("gate-b-evidence.txt", "utf8");
+            const m = t.match(/POSTHOG_STT_AB_AUTHENTICATED_USER_TARGETING_PROOF_EVIDENCE (.*)/);
+            if (!m) { console.error("No evidence line emitted."); process.exit(1); }
+            const e = JSON.parse(m[1]);
+            console.log("classification:", e.classification, "| pass:", e.pass);
+            console.log("flagEvaluationAfter:", JSON.stringify(e.flagEvaluationAfter));
+            console.log("mutations:", JSON.stringify(e.mutations));
+            if (e.classification !== "TARGETING_VERIFIED") {
+              console.error("Gate B NOT verified — classification:", e.classification);
+              process.exit(1);
+            }
+            console.log("✅ Gate B targeting VERIFIED (single user).");
+          '
+
+      - name: Upload Gate B evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: posthog-gate-b-evidence
+          path: |
+            gate-b-evidence.txt
+            gate-b-evidence.json
+          if-no-files-found: warn

--- a/.github/workflows/posthog-gate-b.yml
+++ b/.github/workflows/posthog-gate-b.yml
@@ -24,10 +24,10 @@ on:
         type: string
         required: true
       cohort_name:
-        description: 'Static single-user cohort name'
+        description: 'Optional explicit static cohort name. LEAVE EMPTY (recommended) to auto-generate a UNIQUE per-run single-user cohort.'
         type: string
         required: false
-        default: stt_ab_disposable_pro_testers
+        default: ''
 
 permissions:
   contents: read
@@ -50,7 +50,7 @@ jobs:
       - name: PostHog Gate B — single-user targeting proof (NO broad rollout)
         env:
           STT_AB_APP_USER_ID: ${{ inputs.app_user_id }}
-          POSTHOG_STT_AB_COHORT_NAME: ${{ inputs.cohort_name }}
+          INPUT_COHORT_NAME: ${{ inputs.cohort_name }}
           POSTHOG_PROJECT_API_KEY: ${{ vars.POSTHOG_PROJECT_API_KEY }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
@@ -58,7 +58,15 @@ jobs:
           POSTHOG_API_HOST: ${{ vars.POSTHOG_API_HOST }}
         run: |
           set -o pipefail
-          node scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs | tee gate-b-evidence.txt
+          # UNIQUE per-run single-user cohort unless an explicit name was supplied — so the proof never
+          # reuses a shared cohort that could already hold other members.
+          COHORT_NAME="$INPUT_COHORT_NAME"
+          if [ -z "$COHORT_NAME" ]; then
+            COHORT_NAME="stt_ab_single_user_run${{ github.run_id }}_a${{ github.run_attempt }}"
+          fi
+          echo "Single-user cohort for this run: $COHORT_NAME"
+          POSTHOG_STT_AB_COHORT_NAME="$COHORT_NAME" \
+            node scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs | tee gate-b-evidence.txt
           grep 'POSTHOG_STT_AB_AUTHENTICATED_USER_TARGETING_PROOF_EVIDENCE' gate-b-evidence.txt \
             | sed 's/^POSTHOG_STT_AB_AUTHENTICATED_USER_TARGETING_PROOF_EVIDENCE //' > gate-b-evidence.json || true
 

--- a/scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs
+++ b/scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs
@@ -12,7 +12,14 @@ const projectApiKey = requireEnv('POSTHOG_PROJECT_API_KEY', ['VITE_POSTHOG_KEY']
 const apiHost = (process.env.POSTHOG_API_HOST || 'https://us.posthog.com').replace(/\/$/, '');
 const ingestHost = (process.env.POSTHOG_INGEST_HOST || process.env.VITE_POSTHOG_HOST || apiHost).replace(/\/$/, '');
 const requestedCohortId = process.env.POSTHOG_STT_AB_COHORT_ID || '';
-const cohortName = process.env.POSTHOG_STT_AB_COHORT_NAME || DEFAULT_COHORT_NAME;
+// EXCLUSIVITY: default to a UNIQUE per-run static cohort so the proof always targets a FRESH cohort
+// that contains exactly the one target user — never silently reuses a named cohort that may already
+// hold other members. (Override only via POSTHOG_STT_AB_COHORT_NAME/_ID, e.g. for cleanup.)
+const cohortName = process.env.POSTHOG_STT_AB_COHORT_NAME
+  || `stt_ab_single_user_${String(appUserId).replace(/[^a-zA-Z0-9]/g, '').slice(0, 12)}_${Date.now()}`;
+// NEGATIVE CONTROL: a synthetic distinct_id that is NOT the target. v4 MUST stay false for it,
+// both before and after the mutation — empirical proof there is no broad/global rollout.
+const controlDistinctId = `gate-b-negative-control-${Date.now()}`;
 
 const evidence = {
   gate: 'POSTHOG-STT-A/B',
@@ -40,6 +47,12 @@ const evidence = {
   mutations: [],
   flagEvaluationBefore: null,
   flagEvaluationAfter: null,
+  controlEvaluationBefore: null,
+  controlEvaluationAfter: null,
+  cohortMemberCount: null,
+  flagGroupsBefore: null,
+  flagGroupsAfter: null,
+  exclusivity: null,
   classification: null,
   pass: false,
 };
@@ -48,18 +61,36 @@ try {
   evidence.person = await findPerson();
   evidence.serverIdentity = await inspectServerIdentity(evidence.person);
   evidence.flagEvaluationBefore = await evaluateFlags(appUserId);
+  evidence.controlEvaluationBefore = await evaluateFlags(controlDistinctId);
+  const flagBefore = await fetchFlagConfig();
+  evidence.flagGroupsBefore = summarizeFlagGroups(flagBefore);
 
-  if (!evidence.serverIdentity.pass) {
+  // FAIL-CLOSED pre-check: if v4 is ALREADY on for the negative control, the flag has broad/global
+  // exposure before we touch anything → abort WITHOUT mutating (do not proceed on an unsafe baseline).
+  if (evidence.controlEvaluationBefore?.privateSttV4Enabled) {
+    evidence.classification = 'FAIL_PREEXISTING_BROAD_EXPOSURE';
+  } else if (hasBroadGroup(flagBefore)) {
+    evidence.classification = 'FAIL_PREEXISTING_BROAD_FLAG_GROUP';
+  }
+
+  if (evidence.classification) {
+    // pre-check failed — leave the flag untouched.
+  } else if (!evidence.serverIdentity.pass) {
     evidence.classification = evidence.serverIdentity.classification;
   } else {
     evidence.cohort = await ensureCohort();
     if (!evidence.classification && evidence.cohort?.id) {
       await addPersonToCohort(evidence.cohort.id, evidence.person.id);
+      evidence.cohortMemberCount = await getCohortMemberCount(evidence.cohort.id);
     }
     if (!evidence.classification) {
       evidence.flagConfig = await ensureFlagTargetsCohort(evidence.cohort?.id);
     }
+    const flagAfter = await fetchFlagConfig();
+    evidence.flagGroupsAfter = summarizeFlagGroups(flagAfter);
     evidence.flagEvaluationAfter = await evaluateFlags(appUserId);
+    evidence.controlEvaluationAfter = await evaluateFlags(controlDistinctId);
+    evidence.exclusivity = assessExclusivity(flagAfter);
     if (!evidence.classification) {
       evidence.classification = classifyFinal();
     }
@@ -431,7 +462,77 @@ function classifyFinal() {
   if (evidence.classification) return evidence.classification;
   if (!evidence.flagEvaluationAfter?.privateSttV4Enabled) return 'FAIL_FLAG_TARGETING_CONFIG';
   if (evidence.flagEvaluationAfter?.distilEnabled) return 'FAIL_FLAG_TARGETING_CONFIG';
+  // EXCLUSIVITY gates — v4 must be ON for the target AND OFF for everyone else.
+  if (!evidence.exclusivity?.controlDeniedV4After) return 'FAIL_BROAD_EXPOSURE_AFTER';
+  if (!evidence.exclusivity?.noBroadGroupsAfter) return 'FAIL_BROAD_FLAG_GROUP_AFTER';
   return 'TARGETING_VERIFIED';
+}
+
+// ---- Exclusivity helpers: prove v4 reaches ONLY the designated target (single-user safety) ----
+
+function flagGroups(flag) {
+  if (Array.isArray(flag?.raw?.filters?.groups)) return flag.raw.filters.groups;
+  if (Array.isArray(flag?.filters?.groups)) return flag.filters.groups;
+  return [];
+}
+
+// A group is "broad" if it grants exposure (rollout_percentage > 0; unset defaults to 100) but is NOT
+// scoped to a cohort/person condition — i.e. it would match users beyond our single-user cohort.
+function groupIsBroad(group) {
+  const rollout = group?.rollout_percentage;
+  const grants = rollout == null ? true : Number(rollout) > 0;
+  if (!grants) return false;
+  const props = extractProperties(group);
+  if (props.length === 0) return true; // rollout>0 with no conditions = global exposure
+  return !props.every((p) => p?.type === 'cohort' || p?.key === 'id' || p?.key === 'cohort');
+}
+
+function hasBroadGroup(flag) {
+  if (!flag?.found) return false;
+  return flagGroups(flag).some(groupIsBroad);
+}
+
+function summarizeFlagGroups(flag) {
+  if (!flag?.found) return { found: false, lookupForbidden: Boolean(flag?.lookupForbidden) };
+  const groups = flagGroups(flag);
+  return {
+    found: true,
+    active: flag.active ?? flag.raw?.active ?? null,
+    groupCount: groups.length,
+    hasBroadGroup: groups.some(groupIsBroad),
+    groups: groups.map((g) => ({
+      rolloutPercentage: g?.rollout_percentage ?? null,
+      broad: groupIsBroad(g),
+      properties: extractProperties(g).map(summarizeProperty),
+    })),
+  };
+}
+
+async function getCohortMemberCount(cohortId) {
+  const response = await apiFetch(buildUrl(`/api/projects/${encodeURIComponent(projectId)}/cohorts/${encodeURIComponent(cohortId)}/`));
+  if (!response.ok) return { ok: false, status: response.status, count: null };
+  return {
+    ok: true,
+    count: typeof response.body?.count === 'number' ? response.body.count : null,
+    isStatic: response.body?.is_static ?? null,
+    note: 'PostHog computes static-cohort count asynchronously; null/stale immediately after add is expected — exclusivity is gated on the negative control + flag-group structure, not this count.',
+  };
+}
+
+function assessExclusivity(flagAfter) {
+  const targetGetsV4 = evidence.flagEvaluationAfter?.privateSttV4Enabled === true;
+  const controlDeniedV4After = evidence.controlEvaluationAfter?.privateSttV4Enabled === false;
+  const distilOff = evidence.flagEvaluationAfter?.distilEnabled === false;
+  const noBroadGroupsAfter = flagAfter?.found ? !flagGroups(flagAfter).some(groupIsBroad) : false;
+  return {
+    targetGetsV4,
+    controlDeniedV4After,
+    controlDistinctId,
+    distilOff,
+    noBroadGroupsAfter,
+    cohortMemberCount: evidence.cohortMemberCount?.count ?? null,
+    pass: targetGetsV4 && controlDeniedV4After && distilOff && noBroadGroupsAfter,
+  };
 }
 
 function summarizePerson(person) {

--- a/scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs
+++ b/scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs
@@ -69,8 +69,10 @@ try {
   // exposure before we touch anything → abort WITHOUT mutating (do not proceed on an unsafe baseline).
   if (evidence.controlEvaluationBefore?.privateSttV4Enabled) {
     evidence.classification = 'FAIL_PREEXISTING_BROAD_EXPOSURE';
-  } else if (hasBroadGroup(flagBefore)) {
-    evidence.classification = 'FAIL_PREEXISTING_BROAD_FLAG_GROUP';
+  } else if (positiveGroups(flagBefore).length > 0) {
+    // STRICT: the flag must start at a clean 0% baseline. ANY pre-existing positive-rollout group
+    // (broad OR cohort-scoped) could already expose v4 to other users — abort WITHOUT mutating.
+    evidence.classification = 'FAIL_PREEXISTING_POSITIVE_GROUP';
   }
 
   if (evidence.classification) {
@@ -464,7 +466,8 @@ function classifyFinal() {
   if (evidence.flagEvaluationAfter?.distilEnabled) return 'FAIL_FLAG_TARGETING_CONFIG';
   // EXCLUSIVITY gates — v4 must be ON for the target AND OFF for everyone else.
   if (!evidence.exclusivity?.controlDeniedV4After) return 'FAIL_BROAD_EXPOSURE_AFTER';
-  if (!evidence.exclusivity?.noBroadGroupsAfter) return 'FAIL_BROAD_FLAG_GROUP_AFTER';
+  // WHITELIST: the only positive-rollout group must be the cohort we just created (no other cohorts).
+  if (!evidence.exclusivity?.whitelistPass) return 'FAIL_NON_WHITELISTED_POSITIVE_GROUP';
   return 'TARGETING_VERIFIED';
 }
 
@@ -490,6 +493,21 @@ function groupIsBroad(group) {
 function hasBroadGroup(flag) {
   if (!flag?.found) return false;
   return flagGroups(flag).some(groupIsBroad);
+}
+
+// Any group that GRANTS exposure (rollout_percentage > 0; unset ⇒ 100), broad or cohort-scoped.
+function positiveGroups(flag) {
+  return flagGroups(flag).filter((g) => {
+    const r = g?.rollout_percentage;
+    return r == null || Number(r) > 0;
+  });
+}
+
+// The cohort id(s) a group is scoped to (PostHog cohort condition: {key:'id', value:<id>, type:'cohort'}).
+function groupCohortIds(group) {
+  return extractProperties(group)
+    .filter((p) => p?.type === 'cohort' || p?.key === 'id' || p?.key === 'cohort')
+    .map((p) => String(p?.value));
 }
 
 function summarizeFlagGroups(flag) {
@@ -520,18 +538,33 @@ async function getCohortMemberCount(cohortId) {
 }
 
 function assessExclusivity(flagAfter) {
+  const createdCohortId = evidence.cohort?.id != null ? String(evidence.cohort.id) : null;
   const targetGetsV4 = evidence.flagEvaluationAfter?.privateSttV4Enabled === true;
   const controlDeniedV4After = evidence.controlEvaluationAfter?.privateSttV4Enabled === false;
   const distilOff = evidence.flagEvaluationAfter?.distilEnabled === false;
-  const noBroadGroupsAfter = flagAfter?.found ? !flagGroups(flagAfter).some(groupIsBroad) : false;
+  const posAfter = flagAfter?.found ? positiveGroups(flagAfter) : [];
+  const noBroadGroupsAfter = !posAfter.some(groupIsBroad);
+  const actualPositiveGroupCohortIds = [...new Set(posAfter.flatMap(groupCohortIds))];
+  // WHITELIST: every positive-rollout group must be cohort-scoped to EXACTLY the cohort we created —
+  // no broad groups, and no OTHER cohort ids (which could carry other real users).
+  const whitelistPass = Boolean(createdCohortId)
+    && posAfter.length >= 1
+    && noBroadGroupsAfter
+    && actualPositiveGroupCohortIds.length === 1
+    && actualPositiveGroupCohortIds[0] === createdCohortId;
   return {
+    createdCohortId,
+    allowedPositiveGroupCohortIds: createdCohortId ? [createdCohortId] : [],
+    actualPositiveGroupCohortIds,
+    positiveGroupCount: posAfter.length,
     targetGetsV4,
     controlDeniedV4After,
     controlDistinctId,
     distilOff,
     noBroadGroupsAfter,
+    whitelistPass,
     cohortMemberCount: evidence.cohortMemberCount?.count ?? null,
-    pass: targetGetsV4 && controlDeniedV4After && distilOff && noBroadGroupsAfter,
+    pass: targetGetsV4 && controlDeniedV4After && distilOff && whitelistPass,
   };
 }
 

--- a/scripts/trigger-posthog-gate-b.mjs
+++ b/scripts/trigger-posthog-gate-b.mjs
@@ -22,7 +22,9 @@ import { join } from 'node:path';
 
 const WORKFLOW = 'posthog-gate-b.yml';
 const appUserId = process.argv[2];
-const cohortName = process.argv[3] || 'stt_ab_disposable_pro_testers';
+// Optional. If omitted, the workflow auto-generates a UNIQUE per-run single-user cohort. Do NOT default
+// to a shared cohort name here — that would defeat the per-run exclusivity guarantee.
+const cohortName = process.argv[3] || '';
 
 if (!appUserId) {
   console.error('Usage: node scripts/trigger-posthog-gate-b.mjs <app_user_id> [cohort_name]');
@@ -47,10 +49,10 @@ try {
 
 console.log(`▶ Dispatching ${WORKFLOW} (single-user targeting proof)`);
 console.log(`    app_user_id = ${appUserId}`);
-console.log(`    cohort_name = ${cohortName}`);
-gh(['workflow', 'run', WORKFLOW, '-f', `app_user_id=${appUserId}`, '-f', `cohort_name=${cohortName}`], {
-  stdio: ['ignore', 'inherit', 'inherit'],
-});
+console.log(`    cohort_name = ${cohortName || '(auto-generated unique per-run cohort)'}`);
+const dispatchArgs = ['workflow', 'run', WORKFLOW, '-f', `app_user_id=${appUserId}`];
+if (cohortName) dispatchArgs.push('-f', `cohort_name=${cohortName}`);
+gh(dispatchArgs, { stdio: ['ignore', 'inherit', 'inherit'] });
 
 // Resolve the dispatched run id (poll briefly; dispatch is async).
 let runId = '';

--- a/scripts/trigger-posthog-gate-b.mjs
+++ b/scripts/trigger-posthog-gate-b.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Trigger the PostHog Gate B single-user targeting proof workflow on GitHub.
+ *
+ * The control-plane secret (POSTHOG_PERSONAL_API_KEY) lives only as a GitHub Actions
+ * secret, so the proof MUST run in the cloud, not locally. This script dispatches
+ * .github/workflows/posthog-gate-b.yml via the locally-authenticated `gh` CLI,
+ * watches the run, and downloads the evidence artifact.
+ *
+ * Prereqs: the workflow file must already be on the DEFAULT branch (main) for
+ * workflow_dispatch to be available, and `gh auth status` must be logged in.
+ *
+ * Usage:
+ *   node scripts/trigger-posthog-gate-b.mjs <app_user_id> [cohort_name]
+ * Example:
+ *   node scripts/trigger-posthog-gate-b.mjs 842e3ba4-45e1-4f48-ab46-61b90537c52f
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const WORKFLOW = 'posthog-gate-b.yml';
+const appUserId = process.argv[2];
+const cohortName = process.argv[3] || 'stt_ab_disposable_pro_testers';
+
+if (!appUserId) {
+  console.error('Usage: node scripts/trigger-posthog-gate-b.mjs <app_user_id> [cohort_name]');
+  process.exit(1);
+}
+if (!/^[0-9a-fA-F-]{36}$/.test(appUserId)) {
+  console.error(`Refusing to dispatch: app_user_id "${appUserId}" is not a UUID (Supabase user.id / distinct_id).`);
+  process.exit(1);
+}
+
+function gh(args, opts = {}) {
+  return execFileSync('gh', args, { encoding: 'utf8', ...opts });
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+try {
+  gh(['auth', 'status'], { stdio: ['ignore', 'ignore', 'ignore'] });
+} catch {
+  console.error('gh is not authenticated. Run `gh auth login` first.');
+  process.exit(1);
+}
+
+console.log(`▶ Dispatching ${WORKFLOW} (single-user targeting proof)`);
+console.log(`    app_user_id = ${appUserId}`);
+console.log(`    cohort_name = ${cohortName}`);
+gh(['workflow', 'run', WORKFLOW, '-f', `app_user_id=${appUserId}`, '-f', `cohort_name=${cohortName}`], {
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+
+// Resolve the dispatched run id (poll briefly; dispatch is async).
+let runId = '';
+for (let i = 0; i < 15 && !runId; i += 1) {
+  await sleep(3000);
+  try {
+    const out = gh(['run', 'list', '--workflow', WORKFLOW, '--limit', '1', '--json', 'databaseId,status,createdAt']);
+    const arr = JSON.parse(out);
+    if (arr[0]?.databaseId) runId = String(arr[0].databaseId);
+  } catch { /* keep polling */ }
+}
+if (!runId) {
+  console.error('Could not resolve the dispatched run id. Check: gh run list --workflow ' + WORKFLOW);
+  process.exit(1);
+}
+
+console.log(`▶ Watching run ${runId} (Actions → PostHog Gate B) ...`);
+let runFailed = false;
+try {
+  gh(['run', 'watch', runId, '--exit-status'], { stdio: ['ignore', 'inherit', 'inherit'] });
+} catch {
+  runFailed = true; // non-zero exit = workflow failed (e.g., NOT TARGETING_VERIFIED)
+}
+
+// Pull the evidence artifact.
+const dir = mkdtempSync(join(tmpdir(), 'gate-b-evidence-'));
+try {
+  gh(['run', 'download', runId, '-n', 'posthog-gate-b-evidence', '-D', dir], { stdio: ['ignore', 'inherit', 'inherit'] });
+  console.log(`\n▶ Evidence downloaded to: ${dir}`);
+  console.log('  - gate-b-evidence.json (machine-readable)  - gate-b-evidence.txt (full log)');
+} catch {
+  console.error('Could not download the evidence artifact (run may have failed before upload). See the run logs above.');
+}
+
+console.log(runFailed
+  ? '\n❌ Gate B run did NOT pass (likely classification != TARGETING_VERIFIED, or PostHog write scope blocked). Inspect the evidence.'
+  : '\n✅ Gate B run passed: single-user targeting VERIFIED. Next: Dev runs the no-forceAuto app-selection proof.');
+process.exit(runFailed ? 1 : 0);


### PR DESCRIPTION
## What
Runs the v4 **single-user** PostHog targeting proof in **GitHub CI**, where `POSTHOG_PERSONAL_API_KEY` lives as a secret — so the operator credential never touches a local/dev env.

**Two files:**
- `.github/workflows/posthog-gate-b.yml` — `workflow_dispatch` (inputs: `app_user_id`, `cohort_name`). Runs the sanctioned `scripts/posthog-stt-ab-authenticated-user-targeting-proof.mjs` with PostHog secrets, **asserts `TARGETING_VERIFIED`**, uploads the evidence artifact.
- `scripts/trigger-posthog-gate-b.mjs` — node trigger: dispatches the workflow via `gh`, watches the run, downloads the evidence.

## Scope guard (single-user, NO broad rollout)
The proof targets a **static cohort of exactly one** `app_user_id` and verifies that user resolves `private_stt_v4_enabled` (709644); **distil stays OFF**. It does **not** raise the flag's global rollout. v2-base remains the default for everyone else.

## Secrets (already present in repo)
`POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_PROJECT_API_KEY`, `POSTHOG_API_HOST`, `POSTHOG_INGEST_HOST` — mirrors the env mapping already used by `observability-api-smoke.yml`. Nothing to add.

## How to run (after merge)
`workflow_dispatch` requires the workflow on `main` first. After merge:
```
node scripts/trigger-posthog-gate-b.mjs 842e3ba4-45e1-4f48-ab46-61b90537c52f
```
→ dispatches the cloud run, watches it, downloads `gate-b-evidence.json`. Then Dev runs the no-forceAuto app-selection proof. GO/NO-GO stays the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)