### PR TITLE
ci(gate3): diagnostic single-spec input for RC gates (NOT a Gate 3 shortcut)

### DIFF
--- a/.github/workflows/rc-gates.yml
+++ b/.github/workflows/rc-gates.yml
@@ -166,9 +166,9 @@ jobs:
           echo "spec=$DIAGNOSTIC_DAST_SPEC grep=${DIAGNOSTIC_DAST_GREP:-<none>}"
           node scripts/rc-dast-live-preflight.mjs
           if [ -n "$DIAGNOSTIC_DAST_GREP" ]; then
-            cross-env VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --grep "$DIAGNOSTIC_DAST_GREP" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
+            VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --grep "$DIAGNOSTIC_DAST_GREP" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
           else
-            cross-env VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
+            VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
           fi
       - name: Diagnostic single-spec notice (NOT a Gate 3 pass)
         if: ${{ always() && github.event.inputs.diagnostic_dast_spec != '' }}

--- a/.github/workflows/rc-gates.yml
+++ b/.github/workflows/rc-gates.yml
@@ -23,6 +23,14 @@ on:
           - gate-3-dast
           - gate-4-sca
           - gate-5-ux
+      diagnostic_dast_spec:
+        description: 'DIAGNOSTIC ONLY — run a single live-DAST spec file for root-cause classification (e.g. tests/live/stt-switching-contract.live.spec.ts). EMPTY = full Gate 3 unchanged. A diagnostic run is NOT a Gate 3 pass.'
+        required: false
+        default: ''
+      diagnostic_dast_grep:
+        description: 'DIAGNOSTIC ONLY — restrict the single spec to tests matching this title (used with diagnostic_dast_spec).'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -76,6 +84,7 @@ jobs:
         with:
           install-playwright: 'true'
       - name: Run DAST Local Gate
+        if: ${{ github.event.inputs.diagnostic_dast_spec == '' }}
         env:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           VITE_SUPABASE_URL: ${{ vars.SUPABASE_URL }}
@@ -92,12 +101,14 @@ jobs:
           AGENT_SECRET: ${{ secrets.AGENT_SECRET }}
         run: pnpm rc:dast:local
       - name: Verify Stripe Webhook Secret Digest
+        if: ${{ github.event.inputs.diagnostic_dast_spec == '' }}
         env:
           SECRET_DIGEST_LABEL: STRIPE_WEBHOOK_SECRET
           SECRET_VALUE: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           EXPECTED_SHA256: ${{ github.event.inputs.stripe_webhook_secret_sha256 }}
         run: node scripts/verify-secret-digest.mjs
       - name: Verify live test-user profile rows
+        if: ${{ github.event.inputs.diagnostic_dast_spec == '' }}
         env:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -105,6 +116,7 @@ jobs:
           PRO_TEST_EMAIL: ${{ secrets.PRO_TEST_EMAIL }}
         run: pnpm verify:test-users
       - name: Run DAST Live Gate
+        if: ${{ github.event.inputs.diagnostic_dast_spec == '' }}
         env:
           BASE_URL: ${{ github.event.inputs.base_url }}
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
@@ -125,6 +137,50 @@ jobs:
           EDGE_FN_URL: ${{ vars.EDGE_FN_URL }}
           AGENT_SECRET: ${{ secrets.AGENT_SECRET }}
         run: pnpm rc:dast:live
+      - name: Run DAST Live Gate (DIAGNOSTIC single spec — NOT a Gate 3 pass)
+        if: ${{ github.event.inputs.diagnostic_dast_spec != '' }}
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          VITE_SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          VITE_USE_LIVE_DB: 'true'
+          VITE_SKIP_MSW: 'true'
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY || secrets.STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          FREE_TEST_EMAIL: ${{ secrets.FREE_TEST_EMAIL || secrets.BASIC_TEST_EMAIL }}
+          FREE_TEST_PASSWORD: ${{ secrets.FREE_TEST_PASSWORD || secrets.BASIC_TEST_PASSWORD }}
+          BASIC_TEST_EMAIL: ${{ secrets.BASIC_TEST_EMAIL }}
+          BASIC_TEST_PASSWORD: ${{ secrets.BASIC_TEST_PASSWORD }}
+          PRO_TEST_EMAIL: ${{ secrets.PRO_TEST_EMAIL }}
+          PRO_TEST_PASSWORD: ${{ secrets.PRO_TEST_PASSWORD }}
+          EDGE_FN_URL: ${{ vars.EDGE_FN_URL }}
+          AGENT_SECRET: ${{ secrets.AGENT_SECRET }}
+          DIAGNOSTIC_DAST_SPEC: ${{ github.event.inputs.diagnostic_dast_spec }}
+          DIAGNOSTIC_DAST_GREP: ${{ github.event.inputs.diagnostic_dast_grep }}
+        run: |
+          echo "DIAGNOSTIC_SINGLE_SPEC=true"
+          echo "::warning::DIAGNOSTIC single-spec run — NOT a full Gate 3 pass. Release gate stays FAIL until a full Gate 3 run (no diagnostic input) passes."
+          echo "spec=$DIAGNOSTIC_DAST_SPEC grep=${DIAGNOSTIC_DAST_GREP:-<none>}"
+          node scripts/rc-dast-live-preflight.mjs
+          if [ -n "$DIAGNOSTIC_DAST_GREP" ]; then
+            cross-env VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --grep "$DIAGNOSTIC_DAST_GREP" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
+          else
+            cross-env VITE_USE_LIVE_DB=true pnpm exec playwright test "$DIAGNOSTIC_DAST_SPEC" --config=playwright.deployed-live.config.ts --project=deployed-live-chromium --reporter=line
+          fi
+      - name: Diagnostic single-spec notice (NOT a Gate 3 pass)
+        if: ${{ always() && github.event.inputs.diagnostic_dast_spec != '' }}
+        run: |
+          {
+            echo "### ⚠️ DIAGNOSTIC single-spec run — NOT a full Gate 3 pass"
+            echo ""
+            echo "- spec: \`${{ github.event.inputs.diagnostic_dast_spec }}\`"
+            echo "- grep: \`${{ github.event.inputs.diagnostic_dast_grep }}\`"
+            echo ""
+            echo "Root-cause classification only. The release gate stays **FAIL** until a FULL Gate 3 (no diagnostic input) passes."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Gate 3 DAST artifacts (trace/screenshot/video/report)
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds a **diagnosis-only** single-spec path to `rc-gates.yml` so we can classify the Pro idle-switching root cause (surfaced in run 27688174214, hardened in #821) **without** running or marking green a full Gate 3.

## Inputs (workflow_dispatch only)
- `diagnostic_dast_spec` — default `''`. Empty ⇒ **full Gate 3 unchanged**. Set ⇒ run only that live spec.
- `diagnostic_dast_grep` — default `''`. Restrict to a test title (e.g. `Pro idle switching`).

## Guarantees
- The 4 normal live-DAST steps run **only when `diagnostic_dast_spec == ''`** — default Gate 3 is byte-for-byte unchanged.
- The diagnostic step prints `DIAGNOSTIC_SINGLE_SPEC=true`, emits a `::warning::`, and writes a step-summary: **"NOT a full Gate 3 pass — release gate stays FAIL until a full Gate 3 passes."**
- It **cannot** be used to mark Gate 3 green; only a full Gate 3 run (no diagnostic input) is the release pass.
- Trace/screenshot/video/report upload always (from #821), so the diagnostic produces inspectable artifacts.

## Intended use (next step, separate dispatch)
```
gh workflow run rc-gates.yml --ref main -f gate=gate-3-dast \
  -f diagnostic_dast_spec=tests/live/stt-switching-contract.live.spec.ts \
  -f diagnostic_dast_grep="Pro idle switching"
```
This produces the #821 classification (`OPTION_NEVER_VISIBLE_OR_ENABLED` / `CLICK_ACTIONABILITY_FAILED` / `APP_NO_DATA_STATE_TRANSITION`) + trace, to assign the real Private-selection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
