### PR TITLE
fix(rc-gates): expose CHECKOUT_TEST_EMAIL/PASSWORD to the paid Stripe step

### DIFF
--- a/.github/workflows/rc-gates.yml
+++ b/.github/workflows/rc-gates.yml
@@ -169,6 +169,11 @@ jobs:
           BASIC_TEST_PASSWORD: ${{ secrets.BASIC_TEST_PASSWORD }}
           PRO_TEST_EMAIL: ${{ secrets.PRO_TEST_EMAIL }}
           PRO_TEST_PASSWORD: ${{ secrets.PRO_TEST_PASSWORD }}
+          # stripe-checkout-readiness resolves CHECKOUT_TEST_EMAIL FIRST (then FREE/BASIC/PRO).
+          # Expose it so the paid checkout proof authenticates as the dedicated checkout-live-proof
+          # user (clean live-mode customer) instead of silently falling back to FREE_TEST_EMAIL.
+          CHECKOUT_TEST_EMAIL: ${{ secrets.CHECKOUT_TEST_EMAIL }}
+          CHECKOUT_TEST_PASSWORD: ${{ secrets.CHECKOUT_TEST_PASSWORD }}
           EDGE_FN_URL: ${{ vars.EDGE_FN_URL }}
           AGENT_SECRET: ${{ secrets.AGENT_SECRET }}
         run: pnpm rc:gate:3:dast:paid


### PR DESCRIPTION
## Summary
Workflow-only fix for the paid Gate 3 checkout failure. The paid Stripe step never exposed `CHECKOUT_TEST_EMAIL`/`CHECKOUT_TEST_PASSWORD`, so `stripe-checkout-readiness` (which resolves `CHECKOUT_TEST_EMAIL` first) **fell back to `FREE_TEST_EMAIL`** — a user with a stale test-mode `stripe_customer_id` — yielding `resource_missing` / `param: customer` no matter how the intended checkout-live-proof user's row was cleared.

## Change
`.github/workflows/rc-gates.yml`, paid step (`pnpm rc:gate:3:dast:paid`): expose
```
CHECKOUT_TEST_EMAIL: ${{ secrets.CHECKOUT_TEST_EMAIL }}
CHECKOUT_TEST_PASSWORD: ${{ secrets.CHECKOUT_TEST_PASSWORD }}
```
so the proof authenticates as the dedicated clean checkout-live-proof user.

## Scope
- **No test logic changed**, no checkout runtime code, no docs.
- YAML validated (js-yaml).

## Context (this run, 27823541127, paid_launch=true on c6958db7)
- ✅ Webhook readiness now passes (signed event `200 received:true`; `digest_match=true`) — the `STRIPE_LIVE_WEBHOOK_SECRET` wiring works.
- ❌ Only failure: checkout readiness `resource_missing/param:customer` — root cause = this env-wiring bug (wrong test user), not a DB-row clearing problem.

After merge: re-run `gh workflow run rc-gates.yml --ref main -f gate=all -f paid_launch=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
