### PR TITLE
fix(billing): burn free Private 5-min sample on paid->free downgrade

### DIFF
--- a/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
+++ b/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
@@ -1,0 +1,137 @@
+-- Burn the one-time free Private STT 5-minute sample on any paid->free downgrade.
+--
+-- Requirement (release-owner, 2026-06-19): a refunded / canceled / past-due user who is
+-- downgraded to Free must NOT regain the one-time 5-minute Private sampler.
+--
+-- Prior behavior: downgrade set subscription_status='free' (and cleared stripe_subscription_id
+-- on customer.subscription.deleted) but left the private_sample_* columns untouched. Since
+-- check_usage_limit treats the sample as available while (private_sample_completed_at IS NULL
+-- AND private_sample_seconds_used < private_sample_limit_seconds), an ex-paid user who never
+-- consumed the sample (seconds_used=0) would regain it after downgrade.
+--
+-- This re-creates the 6-arg process_stripe_webhook_event so the downgrade branch ALSO marks the
+-- sample fully consumed/closed. activate_basic / upgrade_to_pro / none branches are unchanged.
+-- NOTE (open question for review): non-deleted downgrades (customer.subscription.updated with
+-- canceled/unpaid/past_due) still retain stripe_subscription_id here, matching prior behavior —
+-- so hasPaidProEntitlement (which keys off stripe_subscription_id/subscription_id) could keep
+-- Cloud available for a "free" row until a delete event clears it. If downgrades should fully
+-- revoke paid features in BOTH branches, also null stripe_subscription_id in the ELSE branch.
+
+CREATE OR REPLACE FUNCTION public.process_stripe_webhook_event(
+    p_event_id text,
+    p_event_type text,
+    p_action text,
+    p_user_id uuid DEFAULT NULL,
+    p_subscription_id text DEFAULT NULL,
+    p_stripe_customer_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_success boolean := false;
+    v_skipped boolean := false;
+    v_error text := NULL;
+    v_warning text := NULL;
+    v_rows int := 0;
+    v_customer_id text := NULLIF(BTRIM(COALESCE(p_stripe_customer_id, '')), '');
+BEGIN
+    BEGIN
+        INSERT INTO public.processed_webhook_events (event_id, event_type, processed_at)
+        VALUES (p_event_id, p_event_type, NOW());
+    EXCEPTION WHEN unique_violation THEN
+        RETURN jsonb_build_object('success', true, 'skipped', true);
+    END;
+
+    BEGIN
+        IF p_action = 'activate_basic' THEN
+            IF p_user_id IS NULL THEN
+                RAISE EXCEPTION 'Missing user_id for paid Basic activation';
+            END IF;
+
+            UPDATE public.user_profiles
+            SET subscription_status = 'basic',
+                stripe_subscription_id = p_subscription_id,
+                stripe_customer_id = COALESCE(v_customer_id, stripe_customer_id),
+                updated_at = now()
+            WHERE id = p_user_id;
+
+            GET DIAGNOSTICS v_rows = ROW_COUNT;
+            IF v_rows <> 1 THEN
+                RAISE EXCEPTION 'Stripe Basic activation affected % profiles for user_id %', v_rows, p_user_id;
+            END IF;
+
+        ELSIF p_action = 'upgrade_to_pro' THEN
+            IF p_user_id IS NULL THEN
+                RAISE EXCEPTION 'Missing user_id for Pro upgrade';
+            END IF;
+
+            UPDATE public.user_profiles
+            SET subscription_status = 'pro',
+                stripe_subscription_id = p_subscription_id,
+                stripe_customer_id = COALESCE(v_customer_id, stripe_customer_id),
+                updated_at = now()
+            WHERE id = p_user_id;
+
+            GET DIAGNOSTICS v_rows = ROW_COUNT;
+            IF v_rows <> 1 THEN
+                RAISE EXCEPTION 'Stripe Pro upgrade affected % profiles for user_id %', v_rows, p_user_id;
+            END IF;
+
+        ELSIF p_action IN ('downgrade_to_free', 'downgrade_to_basic') THEN
+            IF p_subscription_id IS NULL THEN
+                RAISE EXCEPTION 'Missing subscription_id for downgrade';
+            END IF;
+
+            -- Burn the one-time free Private sample on paid->free downgrade so a refunded/
+            -- canceled/past-due user cannot regain the 5-minute Private sampler.
+            IF p_event_type = 'customer.subscription.deleted' THEN
+                UPDATE public.user_profiles
+                SET subscription_status = 'free',
+                    stripe_subscription_id = NULL,
+                    private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
+                    private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
+                    updated_at = now()
+                WHERE stripe_subscription_id = p_subscription_id;
+            ELSE
+                UPDATE public.user_profiles
+                SET subscription_status = 'free',
+                    private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
+                    private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
+                    updated_at = now()
+                WHERE stripe_subscription_id = p_subscription_id;
+            END IF;
+
+            GET DIAGNOSTICS v_rows = ROW_COUNT;
+            IF v_rows > 1 THEN
+                RAISE EXCEPTION 'Stripe downgrade affected % profiles for subscription_id %', v_rows, p_subscription_id;
+            ELSIF v_rows = 0 THEN
+                v_warning := format('Stripe downgrade matched no profiles for subscription_id %s', p_subscription_id);
+            END IF;
+
+        ELSIF p_action = 'none' THEN
+            NULL;
+        ELSE
+            RAISE EXCEPTION 'Unknown action: %', p_action;
+        END IF;
+
+        v_success := true;
+    EXCEPTION WHEN OTHERS THEN
+        DELETE FROM public.processed_webhook_events WHERE event_id = p_event_id;
+        v_success := false;
+        v_error := SQLERRM;
+    END;
+
+    RETURN jsonb_build_object(
+        'success', v_success,
+        'skipped', v_skipped,
+        'error', v_error,
+        'warning', v_warning
+    );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.process_stripe_webhook_event(text, text, text, uuid, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.process_stripe_webhook_event(text, text, text, uuid, text, text) TO service_role;

--- a/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
+++ b/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
@@ -11,11 +11,13 @@
 --
 -- This re-creates the 6-arg process_stripe_webhook_event so the downgrade branch ALSO marks the
 -- sample fully consumed/closed. activate_basic / upgrade_to_pro / none branches are unchanged.
--- NOTE (open question for review): non-deleted downgrades (customer.subscription.updated with
--- canceled/unpaid/past_due) still retain stripe_subscription_id here, matching prior behavior —
--- so hasPaidProEntitlement (which keys off stripe_subscription_id/subscription_id) could keep
--- Cloud available for a "free" row until a delete event clears it. If downgrades should fully
--- revoke paid features in BOTH branches, also null stripe_subscription_id in the ELSE branch.
+--
+-- Billing invariant (release-owner, 2026-06-19): a downgraded user retains NO paid subscription
+-- identifier. stripe_subscription_id is cleared on BOTH customer.subscription.deleted AND
+-- customer.subscription.updated (canceled/unpaid/past_due) downgrades, so paid features (incl.
+-- Cloud, whose entitlement keys off stripe_subscription_id/subscription_id) cannot linger on a
+-- 'free' row. stripe_customer_id is intentionally PRESERVED (identity for billing portal /
+-- history / re-upgrade).
 
 CREATE OR REPLACE FUNCTION public.process_stripe_webhook_event(
     p_event_id text,
@@ -85,24 +87,16 @@ BEGIN
                 RAISE EXCEPTION 'Missing subscription_id for downgrade';
             END IF;
 
-            -- Burn the one-time free Private sample on paid->free downgrade so a refunded/
-            -- canceled/past-due user cannot regain the 5-minute Private sampler.
-            IF p_event_type = 'customer.subscription.deleted' THEN
-                UPDATE public.user_profiles
-                SET subscription_status = 'free',
-                    stripe_subscription_id = NULL,
-                    private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
-                    private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
-                    updated_at = now()
-                WHERE stripe_subscription_id = p_subscription_id;
-            ELSE
-                UPDATE public.user_profiles
-                SET subscription_status = 'free',
-                    private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
-                    private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
-                    updated_at = now()
-                WHERE stripe_subscription_id = p_subscription_id;
-            END IF;
+            -- Paid->free downgrade (refund/cancel/past-due): clear the paid subscription id on
+            -- EVERY downgrade path (deleted AND updated), set Free, and burn the one-time 5-minute
+            -- Private sample so a downgraded user cannot regain it. Preserve stripe_customer_id.
+            UPDATE public.user_profiles
+            SET subscription_status = 'free',
+                stripe_subscription_id = NULL,
+                private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
+                private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
+                updated_at = now()
+            WHERE stripe_subscription_id = p_subscription_id;
 
             GET DIAGNOSTICS v_rows = ROW_COUNT;
             IF v_rows > 1 THEN

--- a/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
+++ b/backend/supabase/migrations/20260619170000_burn_private_sample_on_downgrade.sql
@@ -13,11 +13,11 @@
 -- sample fully consumed/closed. activate_basic / upgrade_to_pro / none branches are unchanged.
 --
 -- Billing invariant (release-owner, 2026-06-19): a downgraded user retains NO paid subscription
--- identifier. stripe_subscription_id is cleared on BOTH customer.subscription.deleted AND
--- customer.subscription.updated (canceled/unpaid/past_due) downgrades, so paid features (incl.
--- Cloud, whose entitlement keys off stripe_subscription_id/subscription_id) cannot linger on a
--- 'free' row. stripe_customer_id is intentionally PRESERVED (identity for billing portal /
--- history / re-upgrade).
+-- identifier. BOTH stripe_subscription_id AND subscription_id are cleared on every downgrade path
+-- (customer.subscription.deleted AND customer.subscription.updated canceled/unpaid/past_due), so
+-- paid features (incl. Cloud, whose entitlement keys off stripe_subscription_id OR subscription_id)
+-- cannot linger on a 'free' row. stripe_customer_id is intentionally PRESERVED (identity for
+-- billing portal / history / re-upgrade).
 
 CREATE OR REPLACE FUNCTION public.process_stripe_webhook_event(
     p_event_id text,
@@ -90,9 +90,14 @@ BEGIN
             -- Paid->free downgrade (refund/cancel/past-due): clear the paid subscription id on
             -- EVERY downgrade path (deleted AND updated), set Free, and burn the one-time 5-minute
             -- Private sample so a downgraded user cannot regain it. Preserve stripe_customer_id.
+            -- BOTH paid-id columns are cleared: entitlement (frontend hasPaidProEntitlement and the
+            -- server handle_new_user guard) treats stripe_subscription_id OR subscription_id as a
+            -- paid signal, so a lingering subscription_id would defeat the "real-paid" guard if any
+            -- writer later re-flags status='pro' without payment.
             UPDATE public.user_profiles
             SET subscription_status = 'free',
                 stripe_subscription_id = NULL,
+                subscription_id = NULL,
                 private_sample_seconds_used = COALESCE(private_sample_limit_seconds, 300),
                 private_sample_completed_at = COALESCE(private_sample_completed_at, now()),
                 updated_at = now()


### PR DESCRIPTION
## Summary
Refund/cancel/past-due downgrade must drop the user to Free, **retain no paid subscription identifier**, and **not re-grant** the one-time 5-minute Private STT sampler (release-owner requirement, 2026-06-19). Billing/entitlement-critical — **review before merge.**

## Billing invariant enforced
On **every** downgrade path (`customer.subscription.deleted`, `customer.subscription.updated` canceled/unpaid/past_due, and `invoice.payment_failed` ≥3 attempts — all map to `downgrade_to_free`):
```sql
subscription_status = 'free'
stripe_subscription_id = NULL          -- canonical Stripe paid id
subscription_id = NULL                 -- legacy paid id; entitlement reads EITHER column (Option A, release-owner approved)
private_sample_seconds_used = coalesce(private_sample_limit_seconds, 300)   -- burn the sample
private_sample_completed_at = coalesce(private_sample_completed_at, now())
-- stripe_customer_id PRESERVED (billing portal / history / re-upgrade)
```
(IF/ELSE collapsed into one `UPDATE` — both branches identical.) `activate_basic` / `upgrade_to_pro` / `none` unchanged; idempotency + grants preserved. No edge-function change. Match key stays narrow — `WHERE stripe_subscription_id = p_subscription_id` (webhook upgrades always write `stripe_subscription_id`; widening to `OR subscription_id` rejected to avoid legacy/synthetic-id collisions).

## Root cause
The downgrade left `private_sample_*` untouched, and non-deleted downgrades retained `stripe_subscription_id`. Critically, **both** paid-id columns gate entitlement: frontend `hasPaidProEntitlement` ([subscriptionTiers.ts:53](frontend/src/constants/subscriptionTiers.ts:53)) and the server `handle_new_user` guard ([private_sample_entitlement.sql:99](backend/supabase/migrations/20260610143000_private_sample_entitlement.sql:99)) treat `stripe_subscription_id` **OR** `subscription_id` as paid. Since `check_usage_limit` grants the sample while `completed_at IS NULL AND seconds_used < limit`, a downgraded user could regain the sampler; and a lingering `subscription_id` defeats the "real-paid" guard if any divergent writer later re-flags `status='pro'`. Fix clears **both** ids + burns the sample.

## Acceptance proof (no pgTAP harness → live closeout)
Deploy, then **cancel** the proof subscription; the single-line profile query should show:
```
subscription_status=free, stripe_subscription_id=NULL, subscription_id=NULL,
stripe_customer_id=cus_… (preserved),
private_sample_seconds_used=300, private_sample_completed_at=<ts>  → sample_available=false
```

## Sequencing (important)
Merge → deploy migration → re-run `gate=all + paid_launch=true` on the new SHA → confirm 1 active sub in Stripe → **cancel** → **refund** → re-run the profile query to verify the contract. (Cancelling *before* deploy runs the old code; the proof account would then need a one-time manual burn.)

## Follow-ups (not in this PR)
- **Entitlement canonicalization:** stop reading `subscription_id` as a paid signal; make production Pro = `status='pro' AND stripe_subscription_id IS NOT NULL`; deprecate the legacy column (separate PR — does not gate downgrade safety once both ids are cleared here).
- **#832** finishes the CI test/live secret split (mode-scoped `STRIPE_TEST_*` / `STRIPE_LIVE_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
