### PR TITLE
fix(ci): wire Stripe consumers to mode-scoped test/live secrets (#11)

### DIFF
--- a/.github/workflows/live-release-matrix.yml
+++ b/.github/workflows/live-release-matrix.yml
@@ -421,10 +421,10 @@ jobs:
 
       - name: Audit Stripe Price Configuration
         env:
-          # TEST price audit: test key + test pro price. No test-scoped basic price exists, so the
-          # generic (test) basic price stays — consistent with the test key.
+          # TEST price audit: test key + test pro price. Basic falls back to the generic (test)
+          # price until a STRIPE_TEST_BASIC_PRICE_ID secret is provisioned, then auto-upgrades.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
-          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
+          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_TEST_BASIC_PRICE_ID || secrets.STRIPE_BASIC_PRICE_ID }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}
           EXPECTED_STRIPE_BASIC_AMOUNT: '499'
           EXPECTED_STRIPE_PRO_AMOUNT: '999'

--- a/.github/workflows/live-release-matrix.yml
+++ b/.github/workflows/live-release-matrix.yml
@@ -389,11 +389,10 @@ jobs:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # TEST proof: COMPLETE_HOSTED_CHECKOUT is honored by the spec only in test mode. Use the
-          # explicit test-scoped key + pro price. Webhook stays generic (= the test whsec; there is
-          # no STRIPE_TEST_WEBHOOK_SECRET — the generic one is test-only by design).
+          # TEST proof: COMPLETE_HOSTED_CHECKOUT is honored by the spec only in test mode.
+          # Explicit test-scoped key + webhook + pro price.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
-          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_TEST_WEBHOOK_SECRET }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}
           STRIPE_COMPLETE_HOSTED_CHECKOUT: 'true'
         run: pnpm exec playwright test tests/live/stripe-paid-soft-launch-runtime.live.spec.ts --config=playwright.live.config.ts --project=live-stt-chromium --reporter=list
@@ -422,8 +421,8 @@ jobs:
 
       - name: Audit Stripe Price Configuration
         env:
-          # TEST price audit: test key + test pro price. Basic has no mode split (generic = test),
-          # so it stays generic and remains consistent with the test key.
+          # TEST price audit: test key + test pro price. No test-scoped basic price exists, so the
+          # generic (test) basic price stays — consistent with the test key.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
           STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}

--- a/.github/workflows/live-release-matrix.yml
+++ b/.github/workflows/live-release-matrix.yml
@@ -421,10 +421,11 @@ jobs:
 
       - name: Audit Stripe Price Configuration
         env:
-          # TEST price audit: test key + test pro price. Basic falls back to the generic (test)
-          # price until a STRIPE_TEST_BASIC_PRICE_ID secret is provisioned, then auto-upgrades.
+          # TEST price audit: Pro is required (active product). Basic is future-reserved — pass the
+          # test-scoped basic price ONLY if provisioned; when absent the audit skips Basic (reserved),
+          # not a failure. No generic fallback — generic basic is not a launch gate.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
-          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_TEST_BASIC_PRICE_ID || secrets.STRIPE_BASIC_PRICE_ID }}
+          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_TEST_BASIC_PRICE_ID }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}
           EXPECTED_STRIPE_BASIC_AMOUNT: '499'
           EXPECTED_STRIPE_PRO_AMOUNT: '999'

--- a/.github/workflows/live-release-matrix.yml
+++ b/.github/workflows/live-release-matrix.yml
@@ -290,7 +290,10 @@ jobs:
       - name: Run Stripe Webhook Readiness Proof
         env:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
-          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          # LIVE proof: the spec signs with the LIVE endpoint whsec and reads STRIPE_LIVE_WEBHOOK_SECRET
+          # (fail-fast if absent). The generic test STRIPE_WEBHOOK_SECRET it previously passed was dead
+          # (this spec never reads it). Deviates from the matrix's test-mode default by design.
+          STRIPE_LIVE_WEBHOOK_SECRET: ${{ secrets.STRIPE_LIVE_WEBHOOK_SECRET }}
         run: pnpm exec playwright test tests/live/stripe-webhook-readiness.live.spec.ts --config=playwright.live.config.ts --project=live-stt-chromium --reporter=list
 
       - name: Upload Stripe Webhook Artifacts
@@ -350,7 +353,8 @@ jobs:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          # TEST proof (PRO_TEST is a test-mode customer) → explicit test-scoped key.
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
           PRO_TEST_EMAIL: ${{ secrets.PRO_TEST_EMAIL }}
           PRO_TEST_PASSWORD: ${{ secrets.PRO_TEST_PASSWORD }}
         run: pnpm exec playwright test tests/live/stripe-billing-portal-readiness.live.spec.ts --config=playwright.live.config.ts --project=live-stt-chromium --reporter=list
@@ -385,9 +389,12 @@ jobs:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          # TEST proof: COMPLETE_HOSTED_CHECKOUT is honored by the spec only in test mode. Use the
+          # explicit test-scoped key + pro price. Webhook stays generic (= the test whsec; there is
+          # no STRIPE_TEST_WEBHOOK_SECRET — the generic one is test-only by design).
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_PRO_PRICE_ID }}
+          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}
           STRIPE_COMPLETE_HOSTED_CHECKOUT: 'true'
         run: pnpm exec playwright test tests/live/stripe-paid-soft-launch-runtime.live.spec.ts --config=playwright.live.config.ts --project=live-stt-chromium --reporter=list
 
@@ -415,9 +422,11 @@ jobs:
 
       - name: Audit Stripe Price Configuration
         env:
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          # TEST price audit: test key + test pro price. Basic has no mode split (generic = test),
+          # so it stays generic and remains consistent with the test key.
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
           STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
-          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_PRO_PRICE_ID }}
+          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_TEST_PRO_PRICE_ID }}
           EXPECTED_STRIPE_BASIC_AMOUNT: '499'
           EXPECTED_STRIPE_PRO_AMOUNT: '999'
           EXPECTED_STRIPE_BASIC_CURRENCY: usd

--- a/.github/workflows/ops-health.yml
+++ b/.github/workflows/ops-health.yml
@@ -38,10 +38,15 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ASSEMBLYAI_API_KEY: ${{ secrets.ASSEMBLYAI_API_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          # Prod monitoring → LIVE Stripe (the deployed app runs live keys). Source the
+          # live mode-scoped secrets so the live key can read the live price/webhook objects.
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_LIVE_WEBHOOK_SECRET }}
+          # NOTE: no STRIPE_LIVE_BASIC_PRICE_ID exists yet; the generic basic price is test-mode,
+          # so the basic-price check reports degraded under the live key until a live basic price
+          # secret is added (Basic tier not live-launched). Pro is split and remapped below.
           STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
-          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_PRO_PRICE_ID }}
+          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_LIVE_PRO_PRICE_ID }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SENTRY_DSN: ${{ vars.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ops-health.yml
+++ b/.github/workflows/ops-health.yml
@@ -42,10 +42,7 @@ jobs:
           # live mode-scoped secrets so the live key can read the live price/webhook objects.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_LIVE_WEBHOOK_SECRET }}
-          # NOTE: no STRIPE_LIVE_BASIC_PRICE_ID exists yet; the generic basic price is test-mode,
-          # so the basic-price check reports degraded under the live key until a live basic price
-          # secret is added (Basic tier not live-launched). Pro is split and remapped below.
-          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
+          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_LIVE_BASIC_PRICE_ID }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_LIVE_PRO_PRICE_ID }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SENTRY_DSN: ${{ vars.SENTRY_DSN }}

--- a/.github/workflows/service-level-evidence.yml
+++ b/.github/workflows/service-level-evidence.yml
@@ -87,10 +87,14 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ASSEMBLYAI_API_KEY: ${{ secrets.ASSEMBLYAI_API_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          # This step runs the same `pnpm ops:health` prod-monitoring command as ops-health.yml
+          # (BASE_URL = the deployed live app), so it mirrors that job's LIVE Stripe wiring — a
+          # test key here would snapshot the wrong (test) Stripe account. Step is continue-on-error.
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_LIVE_WEBHOOK_SECRET }}
+          # generic basic price is test-mode (no STRIPE_LIVE_BASIC_PRICE_ID yet — see ops-health.yml)
           STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
-          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_PRO_PRICE_ID }}
+          STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_LIVE_PRO_PRICE_ID }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SENTRY_DSN: ${{ vars.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/service-level-evidence.yml
+++ b/.github/workflows/service-level-evidence.yml
@@ -92,8 +92,7 @@ jobs:
           # test key here would snapshot the wrong (test) Stripe account. Step is continue-on-error.
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_LIVE_WEBHOOK_SECRET }}
-          # generic basic price is test-mode (no STRIPE_LIVE_BASIC_PRICE_ID yet — see ops-health.yml)
-          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_BASIC_PRICE_ID }}
+          STRIPE_BASIC_PRICE_ID: ${{ secrets.STRIPE_LIVE_BASIC_PRICE_ID }}
           STRIPE_PRO_PRICE_ID: ${{ secrets.STRIPE_LIVE_PRO_PRICE_ID }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SENTRY_DSN: ${{ vars.SENTRY_DSN }}

--- a/scripts/ops-health.mjs
+++ b/scripts/ops-health.mjs
@@ -82,7 +82,7 @@ await row('Stripe API', 'Can billing credentials reach Stripe and read product p
   });
   const checks = await Promise.all([
     { ok: stripe.ok, detail: `balance=${stripe.status}` },
-    stripePrice(secret, 'basic', env('STRIPE_BASIC_PRICE_ID', ['VITE_STRIPE_BASIC_PRICE_ID'])),
+    optionalStripePrice(secret, 'basic', optionalEnv('STRIPE_BASIC_PRICE_ID', ['STRIPE_LIVE_BASIC_PRICE_ID', 'VITE_STRIPE_BASIC_PRICE_ID'])),
     stripePrice(secret, 'pro', env('STRIPE_PRO_PRICE_ID', ['VITE_STRIPE_PRO_PRICE_ID', 'VITE_STRIPE_PRICE_ID'])),
   ]);
   return combined(checks, 'https://dashboard.stripe.com/');
@@ -283,6 +283,19 @@ async function stripePrice(secret, label, priceId) {
     ok: response.ok && body?.active === true,
     detail: `${label}=${response.status}${body?.active === false ? ':inactive' : ''}`,
   };
+}
+
+// Basic is a future-reserved product (not launch scope): surface its status for visibility but
+// never gate launch health on it. Absent id => reserved (pass); present-but-unreadable/inactive
+// => reserved warning (non-fatal). Pro remains a hard gate via stripePrice().
+async function optionalStripePrice(secret, label, priceId) {
+  if (!priceId) {
+    return { ok: true, detail: `${label}=reserved/not-launched` };
+  }
+  const probe = await stripePrice(secret, label, priceId);
+  return probe.ok
+    ? { ok: true, detail: probe.detail }
+    : { ok: null, skipped: true, detail: `${label}=reserved/not-launched(${probe.detail})` };
 }
 
 function secretShape(name, value, { minLength = 1 } = {}) {

--- a/scripts/stripe-price-audit.mjs
+++ b/scripts/stripe-price-audit.mjs
@@ -1,6 +1,10 @@
-const requiredPlans = [
+// Pro is the active launch product (always required). Basic is future-reserved (may never
+// launch): audited only when its price id is provided, otherwise skipped as reserved — a
+// missing Basic price is NOT an audit failure.
+const plans = [
   {
     label: 'Basic',
+    optional: true,
     envName: 'STRIPE_BASIC_PRICE_ID',
     expectedAmount: Number.parseInt(process.env.EXPECTED_STRIPE_BASIC_AMOUNT ?? '499', 10),
     expectedCurrency: process.env.EXPECTED_STRIPE_BASIC_CURRENCY ?? 'usd',
@@ -44,9 +48,14 @@ const fetchStripeJson = async (path) => {
 const results = [];
 const failures = [];
 
-for (const plan of requiredPlans) {
+for (const plan of plans) {
   const priceId = process.env[plan.envName];
   if (!priceId) {
+    if (plan.optional) {
+      results.push({ label: plan.label, status: 'reserved/not-configured', skipped: true });
+      console.log(`Skipping ${plan.label} price audit — ${plan.envName} not set (reserved/future product).`);
+      continue;
+    }
     failures.push(`${plan.label}: missing ${plan.envName}`);
     continue;
   }


### PR DESCRIPTION
## What
Wires every CI Stripe consumer to the explicit mode-scoped secret for the mode it actually runs in (the #11 fix). Only `secrets.*` sources in workflow env blocks change (plus making Basic non-gating — see below); no app/spec behavior change for Pro/Free.

All mode-scoped secrets are now provisioned and consumed: `STRIPE_TEST_SECRET_KEY`, `STRIPE_TEST_WEBHOOK_SECRET`, `STRIPE_TEST_PRO_PRICE_ID`, `STRIPE_LIVE_SECRET_KEY`, `STRIPE_LIVE_WEBHOOK_SECRET`, `STRIPE_LIVE_PRO_PRICE_ID`, `STRIPE_LIVE_BASIC_PRICE_ID`.

## Per-job mapping

| Job | Mode | Wiring |
|---|---|---|
| `ops-health.yml` (prod monitor) | **LIVE** | `STRIPE_LIVE_SECRET_KEY` / `_WEBHOOK_SECRET` / `_PRO_PRICE_ID`; basic via `STRIPE_LIVE_BASIC_PRICE_ID` (non-gating) |
| `service-level-evidence` ops:health snapshot | **LIVE** | same as ops-health (same `pnpm ops:health` prod command) |
| live-matrix · webhook-readiness | **LIVE** | `STRIPE_LIVE_WEBHOOK_SECRET` (what the spec reads) |
| live-matrix · paid-soft-launch | **TEST** | `STRIPE_TEST_SECRET_KEY` / `STRIPE_TEST_WEBHOOK_SECRET` / `STRIPE_TEST_PRO_PRICE_ID` |
| live-matrix · price-audit | **TEST** | `STRIPE_TEST_SECRET_KEY` + `STRIPE_TEST_PRO_PRICE_ID`; Basic = `STRIPE_TEST_BASIC_PRICE_ID` only (skipped when absent) |
| live-matrix · billing-portal | **TEST** | `STRIPE_TEST_SECRET_KEY` |
| live-matrix · checkout-readiness | — | no Stripe secret; untouched |
| `rc-gates.yml` | — | unchanged this PR (generic `STRIPE_WEBHOOK_SECRET` is test-only; migration tracked separately) |

The `ops-health.mjs` test-key-vs-live-`price_…` 404 (which polluted Stripe logs / produced false monitoring failures) is resolved: ops-health now runs the live key against live price objects.

## Basic is future-reserved (not launch scope)
Per release-owner: Basic is a preserved future option that may never launch, so missing Basic price secrets must **not** fail or degrade launch readiness — only Pro gates paid health. `STRIPE_TEST_BASIC_PRICE_ID` is intentionally **not** required:
- `stripe-price-audit.mjs`: Basic is optional — skipped (`reserved/not-configured`) when its price id is absent; Pro stays required.
- `ops-health.mjs`: basic price is non-gating (`optionalStripePrice`) — absent ⇒ `reserved/not-launched` (pass); present-but-unreadable ⇒ reserved warning (non-fatal). Pro remains a hard gate.
- price-audit basic = `STRIPE_TEST_BASIC_PRICE_ID` only (no generic fallback).

## Validation
- All three workflow YAMLs parse; both edited scripts pass `node --check`.
- Branch diff vs `origin/main` = the three workflows + the two scripts only.
- Secret inventory verified via `gh secret list`.

**For review, not merge.** Merge after #831; then rerun `gate=all + paid_launch=true` once on the new main SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
