### PR TITLE
refactor(billing): stop reading legacy subscription_id for paid entitlement

### DIFF
--- a/backend/supabase/migrations/20260621120000_deprecate_legacy_subscription_id_entitlement.sql
+++ b/backend/supabase/migrations/20260621120000_deprecate_legacy_subscription_id_entitlement.sql
@@ -1,0 +1,74 @@
+-- Deprecate the legacy `subscription_id` column as a paid-entitlement signal.
+--
+-- Canonical-ID policy (release-owner, 2026-06): `stripe_subscription_id` is the ONLY production
+-- paid subscription identifier. The legacy `subscription_id` column is NO LONGER a paid signal.
+-- Previously both the entitlement resolver and the new-user guard treated
+-- `stripe_subscription_id OR subscription_id` as paid; this re-creates both so a profile is Pro
+-- only when `subscription_status='pro' AND stripe_subscription_id` is present.
+--
+-- The `subscription_id` COLUMN is intentionally NOT dropped here (read-removal first; a column
+-- drop/backfill can follow once nothing depends on it). Frontend reads were removed in the same
+-- PR (hasPaidProEntitlement, TranscriptionProvider) and test fixtures stopped writing it.
+--
+-- effective_subscription_tier keeps its 4-arg signature — many existing migrations/RPCs call it
+-- with profile.subscription_id as the 4th arg — so the parameter is accepted but IGNORED.
+
+CREATE OR REPLACE FUNCTION public.effective_subscription_tier(
+  p_subscription_status TEXT,
+  p_trial_expires_at TIMESTAMPTZ DEFAULT NULL,
+  p_stripe_subscription_id TEXT DEFAULT NULL,
+  p_subscription_id TEXT DEFAULT NULL  -- DEPRECATED: no longer read; kept for caller compatibility
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT CASE
+    WHEN lower(COALESCE(p_subscription_status, 'free')) = 'pro'
+      AND NULLIF(trim(COALESCE(p_stripe_subscription_id, '')), '') IS NOT NULL
+    THEN 'pro'
+    ELSE 'free'
+  END;
+$$;
+
+COMMENT ON FUNCTION public.effective_subscription_tier(TEXT, TIMESTAMPTZ, TEXT, TEXT) IS
+  'Returns release entitlement tier. Pro requires subscription_status=pro AND a real stripe_subscription_id. The legacy subscription_id (4th arg) is deprecated and ignored; legacy trial timestamps do not grant Pro.';
+
+CREATE OR REPLACE FUNCTION public.ensure_trial_profile_for_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.user_profiles (
+    id,
+    subscription_status,
+    private_sample_limit_seconds,
+    private_sample_seconds_used,
+    trial_started_at,
+    trial_expires_at
+  )
+  VALUES (
+    NEW.id,
+    'free',
+    300,
+    0,
+    NULL,
+    NULL
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    subscription_status = CASE
+      WHEN lower(COALESCE(public.user_profiles.subscription_status, 'free')) = 'pro'
+        AND NULLIF(trim(COALESCE(public.user_profiles.stripe_subscription_id, '')), '') IS NOT NULL
+      THEN public.user_profiles.subscription_status
+      ELSE 'free'
+    END,
+    private_sample_limit_seconds = COALESCE(public.user_profiles.private_sample_limit_seconds, EXCLUDED.private_sample_limit_seconds),
+    private_sample_seconds_used = COALESCE(public.user_profiles.private_sample_seconds_used, 0),
+    updated_at = now();
+
+  RETURN NEW;
+END;
+$$;

--- a/frontend/src/constants/__tests__/subscriptionTiers.test.ts
+++ b/frontend/src/constants/__tests__/subscriptionTiers.test.ts
@@ -115,6 +115,13 @@ describe('subscriptionTiers', () => {
                 subscription_status: 'pro',
             })).toBe(false);
         });
+
+        it('does not treat the legacy subscription_id column as a paid signal', () => {
+            expect(hasPaidProEntitlement({
+                subscription_status: 'pro',
+                subscription_id: 'sub_legacy_123',
+            })).toBe(false);
+        });
 	    });
 
 	    describe('hasCloudSttEntitlement', () => {

--- a/frontend/src/constants/subscriptionTiers.ts
+++ b/frontend/src/constants/subscriptionTiers.ts
@@ -33,6 +33,7 @@ type TierProfile = {
     subscription_status?: string | null;
     trial_expires_at?: string | null;
     stripe_subscription_id?: string | null;
+    /** @deprecated legacy column — no longer a paid-entitlement signal; use stripe_subscription_id. */
     subscription_id?: string | null;
 } | null | undefined;
 
@@ -50,7 +51,9 @@ export function hasPaidProEntitlement(profile: TierProfile): boolean {
         return false;
     }
 
-    return Boolean(profile?.stripe_subscription_id?.trim() || profile?.subscription_id?.trim());
+    // Production Pro requires the canonical stripe_subscription_id. The legacy subscription_id
+    // column is deprecated and intentionally NOT read here (see migration deprecating it).
+    return Boolean(profile?.stripe_subscription_id?.trim());
 }
 
 export function hasCloudSttEntitlement(profile: TierProfile): boolean {

--- a/frontend/src/providers/TranscriptionProvider.tsx
+++ b/frontend/src/providers/TranscriptionProvider.tsx
@@ -31,14 +31,12 @@ export const TranscriptionProvider: React.FC<TranscriptionProviderProps> = ({
             subscription_status: profile.subscription_status,
             trial_expires_at: profile.trial_expires_at,
             stripe_subscription_id: profile.stripe_subscription_id,
-            subscription_id: profile.subscription_id,
         };
     }, [
         profile?.id,
         profile?.subscription_status,
         profile?.trial_expires_at,
         profile?.stripe_subscription_id,
-        profile?.subscription_id,
     ]);
 
 

--- a/scripts/setup-test-users.mjs
+++ b/scripts/setup-test-users.mjs
@@ -201,7 +201,6 @@ function buildProfilePatchForTier(tier, email) {
     return {
         subscription_status: tier,
         stripe_subscription_id: paidSubscriptionId,
-        subscription_id: paidSubscriptionId,
     };
 }
 

--- a/scripts/sync-reviewer-test-users.mjs
+++ b/scripts/sync-reviewer-test-users.mjs
@@ -39,7 +39,6 @@ function profilePatchForTier(tier, email) {
   return {
     subscription_status: tier,
     stripe_subscription_id: paidSubscriptionId,
-    subscription_id: paidSubscriptionId,
     updated_at: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## What
Makes `stripe_subscription_id` the **only** production paid-subscription identifier and stops treating the legacy `subscription_id` column as a paid-entitlement signal. The column is **kept** (read-removal first; a drop/backfill can follow once nothing depends on it).

Production Pro is now `subscription_status='pro' AND stripe_subscription_id IS NOT NULL`.

## Why
The profile carries two paid-id columns; entitlement previously treated `stripe_subscription_id` **OR** `subscription_id` as paid (frontend `hasPaidProEntitlement`, server `effective_subscription_tier`, and the new-user guard). A lingering `subscription_id` could therefore make a flag-only `pro` row read as legitimately paid. (#831 already clears both ids on downgrade; this removes the stale read path entirely.)

## Changes
- **frontend `hasPaidProEntitlement`** ([subscriptionTiers.ts](frontend/src/constants/subscriptionTiers.ts)): drop the `|| subscription_id` clause. `TierProfile.subscription_id` kept (marked `@deprecated`) so callers/tests can still pass it and prove it is ignored.
- **`TranscriptionProvider`**: stop threading `subscription_id` into the policy profile (it fed entitlement, now unused).
- **migration** `20260621120000_…`: re-create `effective_subscription_tier` (4-arg signature **kept** — many callers pass `profile.subscription_id` as the 4th arg — but `p_subscription_id` is now accepted-and-ignored) and `ensure_trial_profile_for_new_user` to drop the `OR subscription_id` guard.
- **test fixtures** (`setup-test-users.mjs`, `sync-reviewer-test-users.mjs`): stop writing `subscription_id`. They already set `stripe_subscription_id`, so `PRO_TEST` stays entitled.
- **unit test**: a lone `subscription_id` no longer grants Pro.

## Validation
- `subscriptionTiers.test.ts` — 34 passed (incl. the new legacy-`subscription_id` assertion).
- `tsc --noEmit` clean.
- No remaining frontend entitlement reads of `subscription_id` (only the kept type defs).

## Notes
- Column drop is intentionally deferred to a later PR.
- Independent of the launch-critical path; merge order is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
