### PR TITLE
chore(frontend): DRY membership checks in AnalyticsDashboard, no behavior change

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -511,6 +511,9 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
     sessionId
 }) => {
     const [selectedSessions, setSelectedSessions] = useState<string[]>([]);
+    // Readability/future-proofing only (selectedSessions is capped at 2): O(1) membership lookup in
+    // the session-history render below. Not a performance change.
+    const selectedSessionIds = useMemo(() => new Set(selectedSessions), [selectedSessions]);
     const [showComparison, setShowComparison] = useState(false);
 
     const [selectedFocusId, setSelectedFocusId] = useState<AnalyticsFocusId>(() => {
@@ -937,19 +940,22 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                 <DropdownMenuContent align="end" className="w-64">
                                     <DropdownMenuLabel>Display Stats ({customStatCards.length}/4)</DropdownMenuLabel>
                                     <DropdownMenuSeparator />
-                                    {STAT_CARD_OPTIONS.map(option => (
-                                        <DropdownMenuCheckboxItem
-                                            key={option.id}
-                                            checked={customStatCards.includes(option.id)}
-                                            onCheckedChange={() => toggleCustomStatCard(option.id)}
-                                            disabled={
-                                                (!customStatCards.includes(option.id) && customStatCards.length >= 4) ||
-                                                (customStatCards.includes(option.id) && customStatCards.length <= 1)
-                                            }
-                                        >
-                                            {option.label}
-                                        </DropdownMenuCheckboxItem>
-                                    ))}
+                                    {STAT_CARD_OPTIONS.map(option => {
+                                        const checked = customStatCards.includes(option.id);
+                                        return (
+                                            <DropdownMenuCheckboxItem
+                                                key={option.id}
+                                                checked={checked}
+                                                onCheckedChange={() => toggleCustomStatCard(option.id)}
+                                                disabled={
+                                                    (!checked && customStatCards.length >= 4) ||
+                                                    (checked && customStatCards.length <= 1)
+                                                }
+                                            >
+                                                {option.label}
+                                            </DropdownMenuCheckboxItem>
+                                        );
+                                    })}
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         )}
@@ -990,19 +996,22 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                 <DropdownMenuContent align="end" className="w-64">
                                     <DropdownMenuLabel>Display Analysis ({customAnalysisSlides.length}/4)</DropdownMenuLabel>
                                     <DropdownMenuSeparator />
-                                    {ANALYSIS_SLIDE_OPTIONS.map(option => (
-                                        <DropdownMenuCheckboxItem
-                                            key={option.id}
-                                            checked={customAnalysisSlides.includes(option.id)}
-                                            onCheckedChange={() => toggleCustomAnalysisSlide(option.id)}
-                                            disabled={
-                                                (!customAnalysisSlides.includes(option.id) && customAnalysisSlides.length >= 4) ||
-                                                (customAnalysisSlides.includes(option.id) && customAnalysisSlides.length <= 1)
-                                            }
-                                        >
-                                            {option.label}
-                                        </DropdownMenuCheckboxItem>
-                                    ))}
+                                    {ANALYSIS_SLIDE_OPTIONS.map(option => {
+                                        const checked = customAnalysisSlides.includes(option.id);
+                                        return (
+                                            <DropdownMenuCheckboxItem
+                                                key={option.id}
+                                                checked={checked}
+                                                onCheckedChange={() => toggleCustomAnalysisSlide(option.id)}
+                                                disabled={
+                                                    (!checked && customAnalysisSlides.length >= 4) ||
+                                                    (checked && customAnalysisSlides.length <= 1)
+                                                }
+                                            >
+                                                {option.label}
+                                            </DropdownMenuCheckboxItem>
+                                        );
+                                    })}
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         )}
@@ -1114,7 +1123,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                                 session={session}
                                                 sessionHistory={sessionHistory}
                                                 isPro={isProUser}
-                                                isSelected={selectedSessions.includes(session.id)}
+                                                isSelected={selectedSessionIds.has(session.id)}
                                                 onToggleSelect={toggleSessionSelection}
                                                 profileName={profile?.email || 'User'}
                                             />


### PR DESCRIPTION
## What
Readability-only tidy of three `array.includes()` membership checks flagged by static analysis. **Not a performance change** — the underlying arrays are tiny/bounded; this is DRY + future-proofing.

## Changes
- **`selectedSessions`**: memoize a `Set` (`selectedSessionIds`) and use `.has()` in the session-history render. `selectedSessions` is **capped at 2** (`toggleSessionSelection`), so this is clarity/future-proofing, **not** a perf win.
- **Stat & Analysis dropdowns**: each option row called `.includes(option.id)` **3×** (the `checked` prop + two `disabled` clauses). Hoisted into a single per-row `const checked`. Options are fixed (7 and 9) and selections capped at 4 — so this is DRY only.

## Acceptance criteria (met)
- No changes to OpsStatusPage fallback behavior (untouched — its ordered `await fetch` loop must stay sequential).
- No changes to selection caps or the custom stat/analysis `/4` limits.
- No CORS change (file not touched).
- `tsc --noEmit` clean; `AnalyticsDashboard.component.test.tsx` (29) + `subscriptionTiers` (34) pass.

## Notes
Pure cleanup, no behavior change. Independent of the launch-critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
