### PR TITLE
fix(session): no false unsaved banner after save + no stale transcript on manual mode switch (PR 1a)

### DIFF
--- a/frontend/src/hooks/useSessionLifecycle.ts
+++ b/frontend/src/hooks/useSessionLifecycle.ts
@@ -562,6 +562,16 @@ export const useSessionLifecycle = () => {
         setMode: (m: TranscriptionMode) => {
             const safeMode = m === 'cloud' && !canUseCloudStt ? defaultMode : m;
             modeSourceRef.current = 'user';
+            // Opt 2 (#772-safe, PR 1a): a MANUAL mode switch starts a fresh context. setSTTMode
+            // intentionally preserves a just-saved transcript for the AUTOMATIC #772 Private-sample
+            // force-switch (guarded by sessionSaved), so on a user-initiated switch we clear the
+            // prior visible transcript here so stale text does not carry into the new mode.
+            // setSTTMode's global behavior and the #772 auto-switch path are left unchanged.
+            const store = useSessionStore.getState();
+            if (store.sessionSaved && store.sttMode !== safeMode) {
+                store.updateTranscript('', '');
+                store.setChunks([]);
+            }
             setSTTMode(safeMode);
             speechRuntimeController.updatePolicy(buildPolicyForUser(canUsePrivateStt, safeMode, { allowCloud: canUseCloudStt }));
             speechRuntimeController.syncForensicState();

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -41,6 +41,7 @@ export const SessionPage: React.FC = () => {
     const updateRecoveredTranscript = useSessionStore(state => state.updateTranscript);
     const setRecoveredChunks = useSessionStore(state => state.setChunks);
     const setRecoveredStatus = useSessionStore(state => state.setSTTStatus);
+    const sessionSaved = useSessionStore(state => state.sessionSaved);
     const isTranscriptFinalizing = useSessionStore(state => state.isTranscriptFinalizing);
     const nativeFormatting = useSessionStore(state => state.nativeFormatting);
 
@@ -94,12 +95,21 @@ export const SessionPage: React.FC = () => {
             setRecoveryDraft(null);
             return;
         }
+        // A successfully-saved session is NOT an orphaned draft to recover. The stop flow writes a
+        // transient crash-safety recovery draft and clears it only after the async save completes;
+        // surfacing it on isListening->false would falsely tell the user their saved work is "unsaved".
+        // Suppress the banner (and drop the stale draft) once the current session is persisted.
+        if (sessionSaved) {
+            clearSessionRecoveryDraft();
+            setRecoveryDraft(null);
+            return;
+        }
         const draft = getSessionRecoveryDraft();
         setRecoveryDraft(draft);
         if (!draft || transcriptContent.trim()) return;
 
         restoreRecoveryDraft(draft);
-    }, [isListening, restoreRecoveryDraft, transcriptContent]);
+    }, [isListening, sessionSaved, restoreRecoveryDraft, transcriptContent]);
 
     // Keep live transcript pinned only while the user is already reading the latest text.
     useEffect(() => {

--- a/frontend/src/stores/__tests__/useSessionStore.test.ts
+++ b/frontend/src/stores/__tests__/useSessionStore.test.ts
@@ -243,4 +243,42 @@ describe('useSessionStore', () => {
             expect(useSessionStore.getState().sttStatus.type).toBe('idle');
         });
     });
+
+    // PR 1a / #772 regression guard: setSTTMode's GLOBAL behavior must stay unchanged. The B fix
+    // (clearing a stale transcript on a MANUAL mode switch) lives in the user-initiated setMode
+    // handler, NOT in setSTTMode. So setSTTMode must still PRESERVE a just-saved transcript across
+    // the automatic post-save force-switch (#772 Private-sample auto-end), and still RESET the
+    // visible session on a normal (unsaved) mode switch.
+    describe('setSTTMode visible-session reset guard (#772)', () => {
+        const seedSavedSession = (sessionSaved: boolean) => {
+            useSessionStore.setState({
+                sttMode: 'native',
+                sessionSaved,
+                runtimeState: 'READY',
+                isTranscriptFinalizing: false,
+                frozenTranscriptAtStop: null,
+                transcript: { transcript: 'just saved transcript', partial: '' },
+                chunks: [{ transcript: 'just saved transcript', timestamp: 1, isFinal: true }],
+            });
+        };
+
+        it('PRESERVES a just-saved transcript on a post-save force-switch (sessionSaved=true) — #772 intact', () => {
+            seedSavedSession(true);
+            useSessionStore.getState().setSTTMode('cloud');
+            const state = useSessionStore.getState();
+            expect(state.sttMode).toBe('cloud');
+            expect(state.transcript.transcript).toBe('just saved transcript');
+            expect(state.chunks).toHaveLength(1);
+            expect(state.sessionSaved).toBe(true);
+        });
+
+        it('RESETS the visible session on a normal (unsaved) mode switch (sessionSaved=false)', () => {
+            seedSavedSession(false);
+            useSessionStore.getState().setSTTMode('cloud');
+            const state = useSessionStore.getState();
+            expect(state.sttMode).toBe('cloud');
+            expect(state.transcript.transcript).toBe('');
+            expect(state.chunks).toHaveLength(0);
+        });
+    });
 });

--- a/tests/e2e/session-recovery-draft.e2e.spec.ts
+++ b/tests/e2e/session-recovery-draft.e2e.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * PR 1a — recovery-draft / transcript state correctness.
+ *
+ * Contract: after a SUCCESSFUL save, the "unsaved transcript draft" banner
+ * (`session-recovery-actions`) must NOT appear — even after waiting past the
+ * ~2s recovery-draft heartbeat, and even after re-mounting SessionPage. A false
+ * "unsaved draft" banner after a save implies data loss / failed persistence to
+ * the user, which is a high-trust-impact regression.
+ *
+ * This spec is the runtime before/after proof for the false-unsaved-banner fix.
+ */
+import { test, expect } from './fixtures';
+import { navigateToRoute, mockLiveTranscript, programmaticLoginWithRoutes, selectTranscriptionEngine } from './helpers';
+import { TEST_IDS } from '../constants';
+import { MOCK_TRANSCRIPTS } from './fixtures/mockData';
+
+const RECOVERY_BANNER = 'session-recovery-actions';
+
+test.describe('Session recovery draft', () => {
+  test('no false unsaved-draft banner after a successful save', async ({ page }) => {
+    await programmaticLoginWithRoutes(page, { userType: 'free' });
+    await navigateToRoute(page, '/session');
+    await expect(page.getByText(/Practice Session/i)).toBeVisible();
+
+    const startButton = page.getByTestId(TEST_IDS.SESSION_START_STOP_BUTTON);
+    await page.waitForSelector('html[data-runtime-state="READY"]', { timeout: 15000 });
+
+    // Record a >=5s session so it is persisted (sub-5s sessions are intentionally not saved).
+    await startButton.click();
+    await expect(startButton).toHaveAttribute('data-recording', 'true', { timeout: 15000 });
+    await mockLiveTranscript(page, MOCK_TRANSCRIPTS as unknown as string[]);
+    await expect(page.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toContainText(/simulating multiple lines/i);
+    await page.waitForTimeout(5200);
+
+    // Stop -> triggers save.
+    await startButton.click();
+    await expect(page.getByLabel(/Start Recording/i)).toBeVisible({ timeout: 10000 });
+
+    // Deterministic persistence signal: the session write path completed.
+    await expect(page.locator('html')).toHaveAttribute('data-session-persisted', 'true', { timeout: 15000 });
+
+    // Wait past the App-level recovery-draft heartbeat (2000ms) to expose any
+    // re-persist / not-cleared race.
+    await page.waitForTimeout(2600);
+
+    // CONTRACT 1: no false unsaved-draft banner on the post-save session view.
+    await expect(page.getByTestId(RECOVERY_BANNER)).toHaveCount(0);
+
+    // CONTRACT 2: it must not resurrect on a fresh SessionPage mount either
+    // (the recovery effect re-reads localStorage on mount).
+    await navigateToRoute(page, '/analytics');
+    await navigateToRoute(page, '/session');
+    await expect(page.getByText(/Practice Session/i)).toBeVisible();
+    await page.waitForTimeout(600);
+    await expect(page.getByTestId(RECOVERY_BANNER)).toHaveCount(0);
+  });
+
+  // Issue B: a prior session's transcript must not carry into a new mode after an STT mode switch.
+  test('does not carry a stale transcript across an STT mode switch', async ({ page }) => {
+    await programmaticLoginWithRoutes(page, { userType: 'pro' });
+    await navigateToRoute(page, '/session');
+    await expect(page.getByText(/Practice Session/i)).toBeVisible();
+
+    const startButton = page.getByTestId(TEST_IDS.SESSION_START_STOP_BUTTON);
+    await page.waitForSelector('html[data-runtime-state="READY"]', { timeout: 15000 });
+
+    // Record + persist a session in the default mode, producing a visible transcript.
+    await startButton.click();
+    await expect(startButton).toHaveAttribute('data-recording', 'true', { timeout: 15000 });
+    await mockLiveTranscript(page, MOCK_TRANSCRIPTS as unknown as string[]);
+    await expect(page.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toContainText(/simulating multiple lines/i);
+    await page.waitForTimeout(5200);
+    await startButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-session-persisted', 'true', { timeout: 15000 });
+
+    // Switch STT mode -> the prior transcript must NOT be carried into the new mode/session.
+    await selectTranscriptionEngine(page, 'cloud');
+    await expect(page.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).not.toContainText(/simulating multiple lines/i);
+  });
+});


### PR DESCRIPTION
## PR 1a — recovery-draft / transcript state correctness

First of the pre-release UX-gate PRs. Scope is **strictly** session recovery-draft + transcript state. No billing/Stripe/Supabase/rc-gates/analytics-clarity/focus-selector/homepage/Report-Issue/STT-quality changes.

> **`setSTTMode` global behavior is unchanged; only the manual user mode-change path clears visible session state.**

### A — false "unsaved draft" banner after a successful save
- **Root cause:** the stop flow writes a crash-safety recovery draft ([SpeechRuntimeController.ts:2131](frontend/src/services/SpeechRuntimeController.ts#L2131)) and clears it only *after* the async save ([:2228](frontend/src/services/SpeechRuntimeController.ts#L2228)). `SessionPage`'s recovery effect fires on `isListening→false`, reads that draft, and the banner's React state sticks even after localStorage is cleared.
- **Fix (narrow, one effect):** suppress the recovery banner once `sessionSaved` is true ([SessionPage.tsx](frontend/src/pages/SessionPage.tsx)).

### B — stale transcript after a MANUAL STT mode switch
- **Root cause:** `setSTTMode` only resets the visible transcript when `resetVisibleSession` is true, which requires `!sessionSaved` — a guard added deliberately for **#772** (Private-sample auto-end force-switches to native and must *keep* the just-saved transcript). It over-applied to **manual** post-save switches → stale transcript.
- **Fix (Opt 2, #772-safe):** clear the visible transcript only in the user-initiated `setMode` handler ([useSessionLifecycle.ts:562](frontend/src/hooks/useSessionLifecycle.ts#L562)). `setSTTMode` and the #772 auto-switch path are not modified.

### Proof
- **e2e** `tests/e2e/session-recovery-draft.e2e.spec.ts` (record → stop/save → assert / manual mode switch → assert): both tests went **fail → pass** on this branch. Before: false banner present after save; stale transcript carried after switch. After: neither. Playwright trace + screenshots captured per run.
- **#772 regression guard** (`useSessionStore.test.ts`): asserts `setSTTMode` **preserves** a just-saved transcript when `sessionSaved=true` (the #772 behavior) and **resets** on a normal unsaved switch — proving global behavior is intact. 20/20 store tests pass.
- `tsc --noEmit` clean.

### Acceptance criteria
- A: record → stop/save → wait beyond heartbeat/recovery interval → no recovery/unsaved banner; remount/revisit does not resurrect it. ✅
- B: save in one mode → manually switch STT mode → prior transcript no longer displayed for the new mode. ✅
- Regression: Private-sample #772 auto-switch behavior preserved. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
