### PR TITLE
test(session): Private-mode trust-state + save→detail proof (PR 1b)

### DIFF
--- a/tests/e2e/private-trust-state.e2e.spec.ts
+++ b/tests/e2e/private-trust-state.e2e.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * PR 1b — Private-mode trust-state + save -> history -> detail proof.
+ *
+ * Covered here (mock-transcript harness):
+ *  - Private recording trust-state: drafting/interim visible while recording (draft banner, not final);
+ *  - final state visible after Stop, with the prior transcript intact (cumulative — no blank/truncation);
+ *  - save -> history -> detail: the saved Private transcript matches and renders; engine/mode reads Private.
+ *
+ * NOT covered here (requires separate live/manual Private proof — do NOT fake in the mock harness):
+ *  - real model download / setup consent;
+ *  - real local-model latency / readiness.
+ */
+import { test, expect } from './fixtures';
+import {
+  navigateToRoute,
+  simulateTranscription,
+  selectTranscriptionEngine,
+  programmaticLoginWithRoutes,
+  waitForFeature,
+} from './helpers';
+import { TEST_IDS } from '../constants';
+
+const PRIVATE_TRANSCRIPT =
+  'this is a private on device transcript with enough words to be persisted and then rendered in the saved session detail view after stop';
+
+test.describe('Private mode trust-state + save/detail', () => {
+  test('Private: drafting -> final lifecycle, cumulative transcript, save -> detail correctness', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await programmaticLoginWithRoutes(page, { userType: 'pro' });
+    await navigateToRoute(page, '/session');
+    await selectTranscriptionEngine(page, 'private');
+
+    const startButton = page.getByTestId(TEST_IDS.SESSION_START_STOP_BUTTON);
+    const transcriptPanel = page.getByTestId(TEST_IDS.TRANSCRIPT_PANEL);
+    await page.waitForSelector('html[data-runtime-state="READY"]', { timeout: 15_000 });
+
+    // Record in Private mode and produce a transcript.
+    await startButton.click();
+    await expect(startButton).toHaveAttribute('data-recording', 'true', { timeout: 15_000 });
+    await simulateTranscription(page, PRIVATE_TRANSCRIPT, true);
+    await expect(page.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toContainText(/private on device transcript/i);
+
+    // Trust-state WHILE recording: drafting + draft banner visible, not final, mode = private.
+    await expect(transcriptPanel).toHaveAttribute('data-draft-banner-visible', 'true');
+    await expect(transcriptPanel).toHaveAttribute('data-final-state-visible', 'false');
+    const recordingTrust = await page.evaluate(
+      () =>
+        (window as Window & {
+          __SS_TRUST_STATE__?: { uiState?: string; sttMode?: string; draftBannerVisible?: boolean };
+        }).__SS_TRUST_STATE__,
+    );
+    expect(recordingTrust).toMatchObject({ uiState: 'drafting', draftBannerVisible: true, sttMode: 'private' });
+
+    // Stop -> save.
+    await page.waitForTimeout(5_200);
+    await startButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-session-persisted', 'true', { timeout: 15_000 });
+
+    // Final state + transcript INTACT (cumulative, not blank/truncated).
+    await expect(transcriptPanel).toHaveAttribute('data-final-state-visible', 'true', { timeout: 15_000 });
+    await expect(page.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toContainText(
+      /private on device transcript with enough words/i,
+    );
+
+    // save -> history -> detail.
+    await page.getByTestId(TEST_IDS.NAV_ANALYTICS_LINK).click();
+    await waitForFeature(page, 'analytics');
+    const latest = page.getByTestId(/session-history-item-/).first();
+    // History row should identify the Private engine/mode.
+    await expect(latest).toContainText(/private/i);
+    await latest.getByTestId(/session-detail-link-/).click();
+    await page.waitForURL('**/analytics/session-*');
+
+    // Detail view renders the saved Private transcript.
+    await expect(page.getByText(/private on device transcript/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## PR 1b — Private-mode trust-state + save→detail proof

**Proof/coverage only — zero source change.** Closes the Private release-gate evidence gap. Native trust-state + save/detail parity is already covered by `user-facing-regressions.e2e.spec.ts`; this adds the missing **Private** coverage. The Private path was verified **correct at runtime — no defect reproduced**, which (per the agreed scope) is an acceptable proof-only outcome since the backlog asks for runtime proof, not necessarily a code change.

### Investigation outcome
The transcript trust-state machine is already robustly built and instrumented (`data-draft-banner-visible` / `data-processing-visible` / `data-final-state-visible` + `__SS_TRUST_STATE__`/`__SS_TRUST_TRACE__`). Running the Private lifecycle confirmed it behaves correctly; no stale/blank/mislabelled Private state surfaced.

### Covered by this PR (mock-transcript e2e harness)
- **Private recording trust-state:** `drafting` + draft banner visible while recording; `final-state-visible=false`; `__SS_TRUST_STATE__ = {uiState:'drafting', draftBannerVisible:true, sttMode:'private'}`.
- **Final state after Stop** (`final-state-visible=true`) with the transcript **intact** (cumulative — no blank/truncation).
- **save → history → detail:** the saved Private transcript matches and renders in the detail view; the history row identifies **Private**.

### NOT covered here — requires separate live/manual Private proof (not faked, per guardrail)
- Real model **download / setup consent**.
- Real **local-model latency / readiness**, including the transient **local-processing/finalizing** window (near-instant in the mock harness, so not reliably assertable without a real local model).

### Evidence
`tests/e2e/private-trust-state.e2e.spec.ts` passes (Playwright trace/screenshots on failure). No billing/Stripe/Supabase/rc-gates/analytics-clarity/focus-selector/homepage/Report-Issue/STT-quality changes.

Targets `main` → rides in `v0.8.5-rc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
