### PR TITLE
feat(analytics): clearer Focus selector trigger — "Choose focus" + chevron (PR 2)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { NavLink } from 'react-router-dom';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
-import { TrendingUp, Clock, Layers, Download, Target, Gauge, BarChart, Settings, Activity, Mic, Cloud, Lock, Monitor, Eye } from 'lucide-react';
+import { TrendingUp, Clock, Layers, Download, Target, Gauge, BarChart, Settings, Activity, Mic, Cloud, Lock, Monitor, Eye, ChevronDown } from 'lucide-react';
 import logger from '../lib/logger';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -868,9 +868,14 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                 </div>
                                 <DropdownMenu>
                                     <DropdownMenuTrigger asChild>
-                                        <Button variant="outline" size="sm" className="gap-2 self-start">
-                                            <Settings className="h-4 w-4" />
-                                            Change Focus
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="gap-2 self-start border-[hsl(var(--border-strong))] font-semibold text-foreground hover:border-primary hover:bg-primary/10 hover:text-primary"
+                                            data-testid={TEST_IDS.ANALYTICS_FOCUS_TRIGGER}
+                                        >
+                                            Choose focus
+                                            <ChevronDown className="h-4 w-4" />
                                         </Button>
                                     </DropdownMenuTrigger>
                                     <DropdownMenuContent align="end" className="w-72">

--- a/frontend/src/constants/testIds.ts
+++ b/frontend/src/constants/testIds.ts
@@ -46,6 +46,7 @@ export const TEST_IDS = {
     ANALYTICS_UPGRADE_BUTTON: 'analytics-dashboard-upgrade-button',
     SESSION_HISTORY_LIST: 'session-history-list',
     ANALYTICS_EMPTY_STATE: 'analytics-dashboard-empty-state',
+    ANALYTICS_FOCUS_TRIGGER: 'analytics-focus-trigger',
     SESSION_HISTORY_ITEM: 'session-history-item', // Base for dynamic IDs: session-history-item-${id}
     COMPARE_CHECKBOX: 'compare-checkbox',
     STAT_CARD_TOTAL_SESSIONS: 'stat-card-total_sessions',

--- a/tests/e2e/focus-selector.e2e.spec.ts
+++ b/tests/e2e/focus-selector.e2e.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * PR 2 — Analytics Focus selector trigger UX.
+ *
+ * The trigger must be a clearly-labeled, discoverable dropdown (not a vague
+ * "Change Focus" gear): label "Choose focus", a chevron affordance, a stable
+ * data-testid (so tests are not coupled to the label), and it opens the focus
+ * options. Trigger-only change; focus logic unchanged.
+ */
+import { test, expect } from './fixtures';
+import { navigateToRoute, programmaticLoginWithRoutes, waitForFeature } from './helpers';
+
+test.describe('Analytics focus selector trigger', () => {
+  test('reads "Choose focus", is discoverable, and opens the focus options', async ({ page }) => {
+    await programmaticLoginWithRoutes(page, { userType: 'pro' });
+    await navigateToRoute(page, '/analytics');
+    await waitForFeature(page, 'analytics');
+
+    const trigger = page.getByTestId('analytics-focus-trigger');
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toContainText(/choose focus/i);
+    await expect(trigger).not.toContainText(/change focus/i);
+    await trigger.screenshot({ path: 'test-results/focus-trigger-after.png' });
+
+    // Opens the focus options.
+    await trigger.click();
+    await expect(page.getByText('Choose what you want to improve')).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: /speak clearly/i })).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: /sound confident/i })).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: /track progress/i })).toBeVisible();
+    await page.screenshot({ path: 'test-results/focus-dropdown-open.png' });
+  });
+});

--- a/tests/e2e/primary-journey.e2e.spec.ts
+++ b/tests/e2e/primary-journey.e2e.spec.ts
@@ -127,7 +127,7 @@ test.describe('Primary User Journey Matrix', () => {
       }
 
       // 10. Persistence Check (History count increment)
-      await page.getByRole('button', { name: /change focus/i }).click();
+      await page.getByTestId('analytics-focus-trigger').click();
       await page.getByText('Track Progress').click();
       const totalSessions = page.getByTestId(TEST_IDS.STAT_CARD_TOTAL_SESSIONS);
       await expect(totalSessions).toContainText('6');


### PR DESCRIPTION
## PR 2 — Focus selector trigger UX

Trigger-only fix for the Analytics Focus control, which read **"Change Focus"** with a **gear icon** (`sm/outline`) — it looked like settings, didn't signal a dropdown, and the wording was vague. Per release-owner decision (Option B): the trigger should communicate the *action* (the active focus is already shown prominently in the header card), so restating current state on the button is redundant.

### Change
| Before | After |
|---|---|
| `⚙ Change Focus` (subtle outline) | **`Choose focus ▾`** (chevron, stronger outline + hover primary tint) |

- Relabel **"Change Focus" → "Choose focus"**.
- **Settings gear → `ChevronDown`** (clear dropdown affordance — it's a selector, not config).
- **Stronger outline/text contrast** + hover primary tint; kept as a secondary control (not a filled primary button).
- **Stable `data-testid`** (`analytics-focus-trigger`); `primary-journey` e2e now selects by test id, not the label (no label coupling).
- **No tooltips** — deferred per review; the dropdown already shows each option's `outcome`, and the page has a "Why these tools are here" explainer.

**Out of scope (unchanged):** focus logic, the options/descriptions, Analytics/Clarity, billing, STT, reporting.

### Proof
- `tests/e2e/focus-selector.e2e.spec.ts` (new): asserts the trigger reads "Choose focus" (not "Change focus"), is visible/discoverable, and opens Speak Clearly / Sound Confident / Track Progress. **Passes.**
- `primary-journey.e2e.spec.ts`: passes with the new test-id selector (full journey still works).
- `tsc --noEmit` clean. Runtime screenshot captured (trigger shows `Choose focus ▾`).

Targets `main` → rides in `v0.8.5-rc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
