### PR TITLE
fix(analytics): single source-of-truth "Clear Delivery" clarity (fixes aggregate 0% mismatch) (PR 3)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -148,11 +148,11 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
     },
     {
         id: 'clarity_score',
-        label: 'Clarity Score',
+        label: 'Clear Delivery',
         icon: <Target size={24} className="text-foreground/70" />,
-        getValue: (stats) => stats.avgAccuracy,
+        getValue: (stats) => stats.avgClarity,
         unit: '%',
-        description: 'Average speech clarity percentage'
+        description: 'Based on pace, fillers, and structure — not transcription accuracy.'
     },
     // Future stat cards can be added here
     {
@@ -744,7 +744,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                         />
                         <StatCard
                             icon={<Target />}
-                            label="Clarity Score"
+                            label="Clear Delivery"
                             value={targetSessionMetrics.isClarityScorable ? targetSessionMetrics.clarityScore : '--'}
                             unit={targetSessionMetrics.isClarityScorable ? '%' : undefined}
                             description={targetSessionMetrics.clarityExplanation}

--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -217,7 +217,7 @@ const ANALYSIS_SLIDE_OPTIONS: AnalysisSlideConfig[] = [
     },
     {
         id: 'clarity_trend',
-        label: 'Clarity Score Trend',
+        label: 'Clear Delivery Trend',
         description: 'Monitor your speech clarity percentage'
     },
     {

--- a/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
+++ b/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
@@ -46,7 +46,7 @@ const mockStats = {
     avgFillerWordsPerMin: 5,
     totalPracticeTime: 300,
     averageSessionLength: 30,
-    avgAccuracy: 85,
+    avgClarity: 85,
     chartData: [
         { date: '2023-01-01', 'FW/min': 5, clarity: 80 },
         { date: '2023-01-02', 'FW/min': 4, clarity: 85 },

--- a/frontend/src/components/analytics/EditGoalsDialog.tsx
+++ b/frontend/src/components/analytics/EditGoalsDialog.tsx
@@ -70,7 +70,7 @@ export const EditGoalsDialog: React.FC<EditGoalsDialogProps> = ({ goals, onSave 
                 <DialogHeader>
                     <DialogTitle>Edit Your Goals</DialogTitle>
                     <DialogDescription>
-                        Set personalized targets for your weekly practice sessions and clarity score.
+                        Set personalized targets for your weekly practice sessions and Clear Delivery.
                     </DialogDescription>
                 </DialogHeader>
                 <div className="grid gap-4 py-4">

--- a/frontend/src/components/analytics/GoalsSection.tsx
+++ b/frontend/src/components/analytics/GoalsSection.tsx
@@ -43,9 +43,9 @@ export const GoalsSection: React.FC = () => {
     const weeklyProgress = Math.min((weeklySessions / weeklyGoal) * 100, 100);
 
     // Calculate average clarity score from recent sessions
-    const avgClarityScore = typeof overallStats?.avgAccuracy === 'string'
-        ? parseFloat(overallStats.avgAccuracy)
-        : (overallStats?.avgAccuracy ?? 0);
+    const avgClarityScore = typeof overallStats?.avgClarity === 'string'
+        ? parseFloat(overallStats.avgClarity)
+        : (overallStats?.avgClarity ?? 0);
 
     const clarityProgress = Math.min((avgClarityScore / clarityGoal) * 100, 100);
 
@@ -97,7 +97,7 @@ export const GoalsSection: React.FC = () => {
                     <div className="flex justify-between text-sm">
                         <span className="font-medium flex items-center gap-2 text-foreground">
                             <Trophy className="h-4 w-4 text-muted-foreground" />
-                            Clarity Score Avg
+                            Clear Delivery Avg
                         </span>
                         <span className="font-bold text-foreground" data-testid="clarity-avg-value">{avgClarityScore.toFixed(0)}% <span className="text-muted-foreground font-normal">/ {clarityGoal}%</span></span>
                     </div>

--- a/frontend/src/components/analytics/__tests__/STTAccuracyVsBenchmark.test.tsx
+++ b/frontend/src/components/analytics/__tests__/STTAccuracyVsBenchmark.test.tsx
@@ -34,7 +34,7 @@ describe('STTAccuracyVsBenchmark', () => {
                 averageSessionLength: 0,
                 averageWPM: 0,
                 avgFillerWordsPerMin: "0.0",
-                avgAccuracy: "0.0",
+                avgClarity: "0.0",
                 chartData: []
             },
             fillerWordTrends: {},
@@ -81,7 +81,7 @@ describe('STTAccuracyVsBenchmark', () => {
                 averageSessionLength: 0,
                 averageWPM: 0,
                 avgFillerWordsPerMin: "0.0",
-                avgAccuracy: "0.0",
+                avgClarity: "0.0",
                 chartData: []
             },
             fillerWordTrends: {
@@ -114,7 +114,7 @@ describe('STTAccuracyVsBenchmark', () => {
                 averageSessionLength: 0,
                 averageWPM: 0,
                 avgFillerWordsPerMin: "0.0",
-                avgAccuracy: "0.0",
+                avgClarity: "0.0",
                 chartData: []
             },
             fillerWordTrends: {},
@@ -154,7 +154,7 @@ describe('STTAccuracyVsBenchmark', () => {
                 averageSessionLength: 0,
                 averageWPM: 0,
                 avgFillerWordsPerMin: "0.0",
-                avgAccuracy: "0.0",
+                avgClarity: "0.0",
                 chartData: []
             },
             fillerWordTrends: {},

--- a/frontend/src/components/analytics/__tests__/TopFillerWords.component.test.tsx
+++ b/frontend/src/components/analytics/__tests__/TopFillerWords.component.test.tsx
@@ -14,7 +14,7 @@ describe('TopFillerWords', () => {
             averageSessionLength: 0,
             averageWPM: 0,
             avgFillerWordsPerMin: "0.0",
-            avgAccuracy: "0.0",
+            avgClarity: "0.0",
             chartData: []
         },
         fillerWordTrends: {},

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -103,7 +103,7 @@ export const useAnalytics = () => {
                     averageSessionLength: 0,
                     averageWPM: 0,
                     avgFillerWordsPerMin: "0.0",
-                    avgAccuracy: "0.0",
+                    avgClarity: "0.0",
                     chartData: []
                 },
                 fillerWordTrends: {},

--- a/frontend/src/lib/__tests__/analyticsUtils.test.ts
+++ b/frontend/src/lib/__tests__/analyticsUtils.test.ts
@@ -11,6 +11,7 @@ const mockSessionHistory: PracticeSession[] = [
         total_words: 500,
         filler_words: { um: { count: 5 }, uh: { count: 3 }, total: { count: 8 } },
         accuracy: 0.95,
+        clarity_score: 95,
         title: 'Session 1',
         transcript: '... um ... uh ...',
     },
@@ -22,6 +23,7 @@ const mockSessionHistory: PracticeSession[] = [
         total_words: 1000,
         filler_words: { um: { count: 10 }, like: { count: 5 }, total: { count: 15 } },
         accuracy: 0.90,
+        clarity_score: 90,
         title: 'Session 2',
         transcript: '... um ... like ...',
     },
@@ -35,7 +37,28 @@ describe('analyticsUtils', () => {
             expect(stats.totalPracticeTime).toBe(15);
             expect(stats.averageWPM).toBe(100);
             expect(stats.avgFillerWordsPerMin).toBe('1.5');
-            expect(stats.avgAccuracy).toBe('92.5');
+            expect(stats.avgClarity).toBe('92.5');
+        });
+
+        it('aggregates Clear Delivery (clarity) from clarity_score and ignores the unrelated STT accuracy field', () => {
+            // Regression for the aggregate-Clarity-0% bug: a session can have accuracy=0 (or absent)
+            // while clarity_score is high. The aggregate must reflect clarity_score, not STT accuracy.
+            const stats = calculateOverallStats([
+                {
+                    id: 'mismatch',
+                    created_at: '2026-01-01T00:00:00.000Z',
+                    user_id: 'user-1',
+                    duration: 120,
+                    total_words: 200,
+                    transcript: Array.from({ length: 200 }, (_, i) => `word${i}`).join(' '),
+                    filler_words: {},
+                    accuracy: 0,
+                    clarity_score: 85,
+                    title: 'Accuracy 0, Clarity 85',
+                },
+            ] as PracticeSession[]);
+
+            expect(stats.avgClarity).toBe('85.0');
         });
 
         it('uses aggregate words over aggregate time so short sessions do not distort average WPM', () => {

--- a/frontend/src/lib/__tests__/pdfGenerator.test.ts
+++ b/frontend/src/lib/__tests__/pdfGenerator.test.ts
@@ -89,7 +89,7 @@ describe('generateSessionPdf', () => {
         ['Session ID', '123'],
         ['Total Words', '5'],
         ['Speaking Pace (WPM)', '1 (Too Slow)'],
-        ['Clarity Score', '0% (Keep practicing)'],
+        ['Clear Delivery', '0% (Keep practicing)'],
         ['Total Filler Words', '8'],
         ['Tracked Custom Words', 'None'],
         ['Custom Words Detected', '0'],

--- a/frontend/src/lib/analyticsUtils.ts
+++ b/frontend/src/lib/analyticsUtils.ts
@@ -34,7 +34,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
             averageSessionLength: 0,
             averageWPM: 0,
             avgFillerWordsPerMin: "0.0",
-            avgAccuracy: "0.0",
+            avgClarity: "0.0",
             chartData: []
         };
     }
@@ -45,7 +45,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
     let totalDurationSeconds = 0;
     let totalWords = 0;
     let totalFillerWords = 0;
-    let totalAccuracy = 0;
+    let totalClarity = 0;
 
     for (const s of sessionHistory) {
         const duration = s.duration || 0;
@@ -55,9 +55,10 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
         totalWords += sessionMetrics.wordCount;
 
         totalFillerWords += sessionMetrics.fillerCount;
-        totalAccuracy += typeof s.accuracy === 'number'
-            ? s.accuracy * 100
-            : sessionMetrics.clarityScore;
+        // Single source of truth: aggregate the SAME per-session delivery-clarity used by session
+        // detail, PDF, Goals, and the clarity chart. The unrelated STT `accuracy` field is NOT
+        // clarity; mixing it made the aggregate card read 0% while individual sessions read nonzero.
+        totalClarity += sessionMetrics.clarityScore;
     }
 
     // totalPracticeTime: rounded for display (e.g., "1 min")
@@ -73,7 +74,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
         : 0;
     // Industry standard: Filler Rate = Total Fillers / Total Speaking Time (precise minutes)
     const avgFillerWordsPerMin = calculateRatePerMinute(totalFillerWords, totalDurationSeconds, 1);
-    const avgAccuracy = totalSessions > 0 ? (totalAccuracy / totalSessions).toFixed(1) : "0.0";
+    const avgClarity = totalSessions > 0 ? (totalClarity / totalSessions).toFixed(1) : "0.0";
 
     const chartData = sessionHistory.slice(0, 10).map(s => {
         const duration = s.duration || 0;
@@ -87,7 +88,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
         };
     }).reverse();
 
-    return { totalSessions, totalPracticeTime, averageSessionLength, averageWPM, avgFillerWordsPerMin, avgAccuracy, chartData };
+    return { totalSessions, totalPracticeTime, averageSessionLength, averageWPM, avgFillerWordsPerMin, avgClarity, chartData };
 };
 
 export const calculateFillerWordTrends = (sessionHistory: PracticeSession[]) => {

--- a/frontend/src/lib/pdfGenerator.ts
+++ b/frontend/src/lib/pdfGenerator.ts
@@ -192,7 +192,7 @@ export const generateSessionPdf = async (
       ['Session ID', session.id],
       ['Total Words', `${metrics.wordCount}`],
       ['Speaking Pace (WPM)', `${metrics.wpm} (${metrics.wpmLabel})`],
-      ['Clarity Score', `${Math.round(metrics.clarityScore)}% (${metrics.clarityLabel})`],
+      ['Clear Delivery', `${Math.round(metrics.clarityScore)}% (${metrics.clarityLabel})`],
       ['Total Filler Words', `${metrics.fillerCount}`],
       ['Tracked Custom Words', customWords.length > 0 ? customWords.join(', ') : 'None'],
       ['Custom Words Detected', `${customWordsDetected}`],

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -18,7 +18,7 @@ export interface OverallStats {
   averageSessionLength: number;
   averageWPM: number;
   avgFillerWordsPerMin: string | number;
-  avgAccuracy: string | number;
+  avgClarity: string | number;
   chartData: ChartDataPoint[];
 }
 

--- a/tests/e2e/analytics-suite.e2e.spec.ts
+++ b/tests/e2e/analytics-suite.e2e.spec.ts
@@ -51,7 +51,7 @@ test.describe('Analytics Suite & Data Matrix', () => {
       await expect(page.getByText(/session analysis/i)).toBeVisible();
       
       // Verify Detail Metrics
-      await expect(page.getByText(/clarity score/i)).toBeVisible();
+      await expect(page.getByText(/clear delivery/i)).toBeVisible();
       await expect(page.getByTestId('stat-card-speaking_pace')).toBeVisible();
     }
   });

--- a/tests/e2e/helpers/setupE2EManifest.ts
+++ b/tests/e2e/helpers/setupE2EManifest.ts
@@ -489,7 +489,7 @@ export async function setupE2EManifest(
                   : 0,
                 averageWPM: 145,
                 avgFillerWordsPerMin: '1.0',
-                avgAccuracy: '92.0',
+                avgClarity: '92.0',
                 chartData: [],
               },
               fillerWordTrends: {},

--- a/tests/live/pro-stt-artifact-matrix.live.spec.ts
+++ b/tests/live/pro-stt-artifact-matrix.live.spec.ts
@@ -248,7 +248,7 @@ async function assertPdfExport(page: Page, testInfo: TestInfo) {
   expect(pdfText).toContain('SpeakSharp Session Report');
   expect(pdfText).toContain('Session ID');
   expect(pdfText).toContain('Speaking Pace');
-  expect(pdfText).toContain('Clarity Score');
+  expect(pdfText).toContain('Clear Delivery');
   expect(pdfText).toContain('Total Filler Words');
   expect(pdfText).toContain('Transcription Mode');
   expect(pdfText).toContain('Transcript');
@@ -259,7 +259,7 @@ async function assertPdfExport(page: Page, testInfo: TestInfo) {
     artifact: artifactPath,
     textIncludesTranscript: /swan dive|park truck|pepper|twister|quick brown fox|stale smell|old beer/i.test(pdfText),
     textIncludesSessionId: pdfText.includes('Session ID'),
-    textIncludesAnalytics: /Speaking Pace|Clarity Score|Total Filler Words|Transcription Mode/.test(pdfText),
+    textIncludesAnalytics: /Speaking Pace|Clear Delivery|Total Filler Words|Transcription Mode/.test(pdfText),
     textLength: pdfText.length,
   };
   console.log(`LIVE_PDF_EXPORT_EVIDENCE ${JSON.stringify(evidence)}`);


### PR DESCRIPTION
## PR 3 — Analytics clarity: single source of truth + honest label

Fixes the credibility bug where the dashboard clarity card could read **0%** while an individual session read a nonzero clarity.

### Root cause
The dashboard clarity card aggregated the unrelated **STT `accuracy`** field (`s.accuracy * 100`), while sessions, PDF export, Goals, and the dashboard's own clarity **chart** all use the per-session delivery **`clarity_score`**. Two different fields → divergent values. (Real STT accuracy is a separate path — `accuracyData` / `STTAccuracyVsBenchmark` — untouched.)

### Fix
- **Single source of truth:** `analyticsUtils` now aggregates `sessionMetrics.clarityScore`; the `s.accuracy * 100` branch is removed. Every clarity surface (card, chart, session, PDF, Goals) now derives from the same `clarity_score`.
- **Rename** the misnamed `avgAccuracy → avgClarity` across type / hook / utils / components / test mocks.
- **Honest labeling** (per release-owner): user-facing metric → **"Clear Delivery"** (dashboard card, session card, Goals), with the caveat **"Based on pace, fillers, and structure — not transcription accuracy."**

### Proof
- New unit regression: a session with `accuracy=0, clarity_score=85` → aggregate **`85.0`** (would have been `0.0` under the old code). Existing aggregate test made deterministic via `clarity_score`.
- `tsc --noEmit` clean; affected unit/component suites pass (analyticsUtils, AnalyticsDashboard, GoalsSection-adjacent, TopFillerWords, STTAccuracyVsBenchmark mocks).
- Consistency is now **structural** — all surfaces share `clarity_score`.

**Scope: Clarity-only** — no billing / STT-mode / focus selector / homepage / Report Issue / rc-gates. Targets `main` → `v0.8.5-rc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
