### PR TITLE
fix(nav): paid Pro users no longer see the "Upgrade to Pro" button

### DIFF
--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -7,7 +7,7 @@ import { useLocation, Link, useNavigate } from "react-router-dom";
 import { useAuthProvider } from "@/contexts/AuthProvider";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { useUsageLimit } from "@/hooks/useUsageLimit";
-import { getEffectiveSubscriptionStatus, isPro } from "@/constants/subscriptionTiers";
+import { getEffectiveSubscriptionStatus, isPro, hasPaidProEntitlement } from "@/constants/subscriptionTiers";
 import { arePaymentsEnabled } from "@/config/appRuntimeConfig";
 import logger from "@/lib/logger";
 import {
@@ -32,7 +32,12 @@ const Navigation = () => {
   const reportRuntimeState = useSessionStore(state => state.runtimeState);
   const [isUpgrading, setIsUpgrading] = useState(false);
   const effectiveSubscriptionStatus = getEffectiveSubscriptionStatus(usageLimit?.subscription_status, profile);
-  const isEffectiveProUser = isPro(effectiveSubscriptionStatus);
+  // A confirmed paid Pro (profile says 'pro' AND carries Stripe/subscription evidence) must never be
+  // treated as Free for the nav CTA — even if check_usage_limit transiently reports a non-'pro' tier
+  // (load race, or a usage-limit quirk). getEffectiveSubscriptionStatus prefers usageLimit over the
+  // profile, so gating the upgrade button on it alone flashed "Upgrade to Pro" at real Pro users.
+  // hasPaidProEntitlement is the canonical paid signal and is unaffected by that override.
+  const isEffectiveProUser = isPro(effectiveSubscriptionStatus) || hasPaidProEntitlement(profile);
 
   const handleSignOut = async () => {
     await signOut();

--- a/frontend/src/components/__tests__/Navigation.component.test.tsx
+++ b/frontend/src/components/__tests__/Navigation.component.test.tsx
@@ -17,10 +17,24 @@ vi.mock('@/services/issueReportService', async () => {
     };
 });
 
+// Controllable hooks/config so we can exercise the nav upgrade CTA across tiers.
+const { mockUseUserProfile, mockUseUsageLimit, mockArePaymentsEnabled } = vi.hoisted(() => ({
+    mockUseUserProfile: vi.fn(),
+    mockUseUsageLimit: vi.fn(),
+    mockArePaymentsEnabled: vi.fn(),
+}));
+
 // Mock useUserProfile hook to avoid QueryClient dependency
 vi.mock('../../hooks/useUserProfile', () => ({
-    useUserProfile: () => ({ data: null, isLoading: false, error: null }),
+    useUserProfile: () => mockUseUserProfile(),
 }));
+vi.mock('@/hooks/useUsageLimit', () => ({
+    useUsageLimit: () => mockUseUsageLimit(),
+}));
+vi.mock('@/config/appRuntimeConfig', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/config/appRuntimeConfig')>();
+    return { ...actual, arePaymentsEnabled: () => mockArePaymentsEnabled() };
+});
 
 // Mock react-router-dom
 vi.mock('react-router-dom', async () => {
@@ -39,6 +53,11 @@ describe('Navigation', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         useSessionStore.getState().resetSession();
+        // Defaults preserve prior behavior: no profile, no usage limit, payments off
+        // (so the upgrade CTA stays hidden unless a test opts in).
+        mockUseUserProfile.mockReturnValue({ data: null, isLoading: false, error: null });
+        mockUseUsageLimit.mockReturnValue({ data: undefined });
+        mockArePaymentsEnabled.mockReturnValue(false);
     });
 
     const renderNavigation = (initialRoute = '/') => {
@@ -301,6 +320,55 @@ describe('Navigation', () => {
 
             renderNavigation('/analytics');
             expect(screen.getAllByText('Analytics')).toHaveLength(2);
+        });
+    });
+
+    describe('Upgrade CTA — Pro detection', () => {
+        const paidProProfile = {
+            subscription_status: 'pro',
+            stripe_subscription_id: 'sub_live_123',
+        };
+
+        beforeEach(() => {
+            mockArePaymentsEnabled.mockReturnValue(true);
+            mockUseAuthProvider.mockReturnValue({
+                session: { user: { id: 'pro-user', email: 'pro@example.com' } },
+                signOut: mockSignOut,
+            } as unknown as AuthProvider.AuthContextType);
+        });
+
+        it('hides the upgrade button for a confirmed paid Pro even when usage-limit reports free', () => {
+            // Regression: check_usage_limit can transiently report a non-'pro' tier for a real Pro.
+            // getEffectiveSubscriptionStatus prefers that usage-limit value, so the nav used to flash
+            // "Upgrade to Pro" at paid users. It must trust the profile's paid entitlement instead.
+            mockUseUserProfile.mockReturnValue({ data: paidProProfile, isLoading: false, error: null });
+            mockUseUsageLimit.mockReturnValue({ data: { subscription_status: 'free' } });
+
+            renderNavigation('/');
+
+            expect(screen.queryByTestId('nav-upgrade-button')).not.toBeInTheDocument();
+            expect(screen.getByText('PRO')).toBeInTheDocument();
+        });
+
+        it('shows the upgrade button for a genuine free user', () => {
+            mockUseUserProfile.mockReturnValue({ data: { subscription_status: 'free' }, isLoading: false, error: null });
+            mockUseUsageLimit.mockReturnValue({ data: { subscription_status: 'free' } });
+
+            renderNavigation('/');
+
+            expect(screen.getByTestId('nav-upgrade-button')).toBeInTheDocument();
+            expect(screen.queryByText('PRO')).not.toBeInTheDocument();
+        });
+
+        it('treats a "pro" status without Stripe evidence as not-yet-paid (CTA still shows)', () => {
+            // status 'pro' with no Stripe/subscription id is NOT a paid entitlement; the OR clause must
+            // be gated on hasPaidProEntitlement, not the bare status string. usage-limit (free) wins.
+            mockUseUserProfile.mockReturnValue({ data: { subscription_status: 'pro' }, isLoading: false, error: null });
+            mockUseUsageLimit.mockReturnValue({ data: { subscription_status: 'free' } });
+
+            renderNavigation('/');
+
+            expect(screen.getByTestId('nav-upgrade-button')).toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
## Problem

A confirmed **paid Pro** user could see the **"Upgrade to Pro"** button in the top nav.

`isEffectiveProUser` was computed only from `getEffectiveSubscriptionStatus(usageLimit?.subscription_status, profile)`, which **prefers `usageLimit.subscription_status` over the profile**. When `check_usage_limit` transiently reports a non-`'pro'` tier for a real Pro (load race between `useUsageLimit`/`useUserProfile`, or a usage-limit quirk), the effective status collapses to `'free'` → `isFreeUser` true → the nav flashes `Upgrade to Pro` at a paid user. The canonical paid signal was never consulted.

## Fix

```ts
const isEffectiveProUser =
  isPro(effectiveSubscriptionStatus) || hasPaidProEntitlement(profile);
```

`hasPaidProEntitlement` requires `subscription_status === 'pro'` **and** a Stripe/subscription id, so it is immune to the usage-limit override. Result:

- a confirmed paid Pro **never** sees the upgrade button and keeps the **PRO** badge;
- a downgraded user (status `'free'`, ids cleared by #831) is correctly treated as **Free**;
- a bare `'pro'` status with **no** Stripe evidence is **not** treated as paid (CTA still shows).

Surgical: `effectiveSubscriptionStatus` is left untouched for analytics/`plan` tracking — only the Pro/Free **gate** for the nav CTA and PRO badge changes.

## Tests

Adds a `Navigation` regression describe block covering all three cases above. Full `Navigation.component.test.tsx` passes (19 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
