### PR TITLE
feat(analytics): Pause Rhythm — first-class pause coaching tool (tool-coherence PR 1)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { NavLink } from 'react-router-dom';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
-import { TrendingUp, Clock, Layers, Download, Target, Gauge, BarChart, Settings, Activity, Mic, Cloud, Lock, Monitor, Eye, ChevronDown } from 'lucide-react';
+import { TrendingUp, Clock, Layers, Download, Target, Gauge, BarChart, Settings, Activity, Mic, Cloud, Lock, Monitor, Eye, ChevronDown, AudioLines } from 'lucide-react';
 import logger from '../lib/logger';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -22,7 +22,8 @@ import { SessionComparisonDialog } from './analytics/SessionComparisonDialog';
 import { TrendChart } from './analytics/TrendChart';
 import { useChartContainerReady } from './analytics/useChartContainerReady';
 import { formatSessionRecordingMode } from '@/utils/engineLabels';
-import { ANALYTICS_THRESHOLDS, getSessionAnalysisMetrics } from '@/utils/sessionAnalysis';
+import { ANALYTICS_THRESHOLDS, getSessionAnalysisMetrics, calculateRatePerMinute } from '@/utils/sessionAnalysis';
+import { getSessionPauseCount } from '@/lib/analyticsUtils';
 import { getTranscriptQualityCaveat } from '@/utils/speakingScore';
 
 import type { PracticeSession } from '@/types/session';
@@ -154,6 +155,14 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         unit: '%',
         description: 'Based on pace, fillers, and structure — not transcription accuracy.'
     },
+    {
+        id: 'pause_rhythm',
+        label: 'Pause Rhythm',
+        icon: <AudioLines size={24} className="text-foreground/70" />,
+        getValue: (stats) => stats.avgPausesPerMin,
+        unit: '/min',
+        description: 'Pauses per minute. Healthy pauses make key ideas easier to follow.'
+    },
     // Future stat cards can be added here
     {
         id: 'avg_session_length',
@@ -221,6 +230,11 @@ const ANALYSIS_SLIDE_OPTIONS: AnalysisSlideConfig[] = [
         description: 'Monitor your speech clarity percentage'
     },
     {
+        id: 'pause_trend',
+        label: 'Pause Rhythm Trend',
+        description: 'Pauses per minute across your sessions'
+    },
+    {
         id: 'weekly_activity',
         label: 'Weekly Activity',
         description: 'Your practice frequency this week'
@@ -264,10 +278,11 @@ const ANALYTICS_TOOL_GROUPS: AnalyticsToolGroup[] = [
         label: 'Sound Confident',
         purpose: 'Shows whether your pace, pauses, fillers, and delivery habits make you easy to follow.',
         outcome: 'Use it when you want your next session to sound steadier, calmer, and more confident.',
-        // Default focus: stat cards AND analysis-slide order are kept identical to the prior default
-        // (legacy 'delivery_control') so existing users' default dashboard is unchanged by the rename.
-        statCardIds: ['speaking_pace', 'filler_words_per_min', 'clarity_score', 'total_practice_time'],
-        analysisSlideIds: ['pace_trend', 'filler_words', 'clarity_trend', 'weekly_activity'],
+        // Default focus: the delivery toolkit. Pause Rhythm is first-class here so the cards match the
+        // promise ("pace, pauses, fillers, and delivery") — it takes the slots the progress-oriented
+        // total_practice_time / weekly_activity held, which belong to the Track Progress focus.
+        statCardIds: ['speaking_pace', 'pause_rhythm', 'filler_words_per_min', 'clarity_score'],
+        analysisSlideIds: ['pace_trend', 'pause_trend', 'filler_words', 'clarity_trend'],
     },
     {
         id: 'track_progress',
@@ -286,8 +301,8 @@ const DEFAULT_ANALYTICS_TOOL_GROUP: AnalyticsToolGroupId = 'sound_confident';
 const TOOL_GROUP_STORAGE_KEY = 'speaksharp_analytics_tool_group_v1';
 const CUSTOM_STAT_STORAGE_KEY = 'speaksharp_custom_stat_cards_v1';
 const CUSTOM_ANALYSIS_STORAGE_KEY = 'speaksharp_custom_analysis_slides_v1';
-const DEFAULT_CUSTOM_STAT_CARDS = ['speaking_pace', 'filler_words_per_min', 'clarity_score', 'total_practice_time'];
-const DEFAULT_CUSTOM_ANALYSIS_SLIDES = ['pace_trend', 'clarity_trend', 'weekly_activity', 'filler_words'];
+const DEFAULT_CUSTOM_STAT_CARDS = ['speaking_pace', 'pause_rhythm', 'filler_words_per_min', 'clarity_score'];
+const DEFAULT_CUSTOM_ANALYSIS_SLIDES = ['pace_trend', 'pause_trend', 'clarity_trend', 'filler_words'];
 
 const LEGACY_ANALYTICS_FOCUS_MAP: Record<string, AnalyticsFocusId> = {
     delivery_control: 'sound_confident',
@@ -688,6 +703,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                 wpm: metrics.wpm,
                 clarity: metrics.clarityScore,
                 fillers: metrics.fillerCount,
+                pauses: Number(calculateRatePerMinute(getSessionPauseCount(s), s.duration || 0, 1)),
             };
         });
     }, [sessionHistory]);
@@ -1049,6 +1065,16 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                                                 description="Monitor your speech clarity percentage"
                                                                 data={trendData}
                                                                 metric="clarity"
+                                                            />
+                                                        </div>
+                                                    )}
+                                                    {option.id === 'pause_trend' && (
+                                                        <div>
+                                                            <TrendChart
+                                                                title="Pause Rhythm Trend"
+                                                                description="Pauses per minute across your sessions"
+                                                                data={trendData}
+                                                                metric="pauses"
                                                             />
                                                         </div>
                                                     )}

--- a/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
+++ b/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
@@ -47,6 +47,7 @@ const mockStats = {
     totalPracticeTime: 300,
     averageSessionLength: 30,
     avgClarity: 85,
+    avgPausesPerMin: 8,
     chartData: [
         { date: '2023-01-01', 'FW/min': 5, clarity: 80 },
         { date: '2023-01-02', 'FW/min': 4, clarity: 85 },
@@ -147,7 +148,9 @@ describe('AnalyticsDashboard', () => {
             id: 'sound_confident',
             label: 'Sound Confident',
             outcome: /steadier, calmer, and more confident/i,
-            statCards: ['stat-card-speaking_pace', 'stat-card-filler_words_per_min', 'stat-card-clarity_score', 'stat-card-total_practice_time'],
+            // Sound Confident must surface Pause Rhythm so the cards match its "pace, pauses, fillers,
+            // delivery" promise (regression guard against pauses being claimed but not shown).
+            statCards: ['stat-card-speaking_pace', 'stat-card-pause_rhythm', 'stat-card-filler_words_per_min', 'stat-card-clarity_score'],
             hasTranscriptQuality: false,
         },
         {

--- a/frontend/src/components/analytics/TrendChart.tsx
+++ b/frontend/src/components/analytics/TrendChart.tsx
@@ -9,11 +9,12 @@ interface TrendDataPoint {
     wpm: number;
     clarity: number;
     fillers: number;
+    pauses: number;
 }
 
 interface TrendChartProps {
     data: TrendDataPoint[];
-    metric: 'wpm' | 'clarity' | 'fillers';
+    metric: 'wpm' | 'clarity' | 'fillers' | 'pauses';
     title: string;
     description?: string;
 }
@@ -24,6 +25,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ data, metric, title, des
         wpm: { color: 'hsl(var(--primary))', label: `WPM (Target: ${ANALYTICS_THRESHOLDS.TARGET_WPM_MIN}-${ANALYTICS_THRESHOLDS.TARGET_WPM_MAX})`, unit: '' },
         clarity: { color: 'hsl(var(--chart-2))', label: 'Clarity', unit: '%' },
         fillers: { color: 'hsl(var(--secondary))', label: 'Fillers', unit: '' },
+        pauses: { color: 'hsl(var(--chart-4))', label: 'Pause Rhythm', unit: '/min' },
     };
 
     const config = metricConfig[metric];

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -104,6 +104,7 @@ export const useAnalytics = () => {
                     averageWPM: 0,
                     avgFillerWordsPerMin: "0.0",
                     avgClarity: "0.0",
+                    avgPausesPerMin: "0.0",
                     chartData: []
                 },
                 fillerWordTrends: {},

--- a/frontend/src/lib/__tests__/analyticsUtils.test.ts
+++ b/frontend/src/lib/__tests__/analyticsUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateOverallStats, calculateFillerWordTrends, calculateAccuracyData, calculateTopFillerWords } from '../analyticsUtils';
+import { calculateOverallStats, calculateFillerWordTrends, calculateAccuracyData, calculateTopFillerWords, getSessionPauseCount } from '../analyticsUtils';
 import { PracticeSession } from '@/types/session';
 
 const mockSessionHistory: PracticeSession[] = [
@@ -14,6 +14,7 @@ const mockSessionHistory: PracticeSession[] = [
         clarity_score: 95,
         title: 'Session 1',
         transcript: '... um ... uh ...',
+        pause_metrics: { silencePercentage: 10, transitionPauses: 8, extendedPauses: 2, longestPause: 2 },
     },
     {
         id: '2',
@@ -26,6 +27,7 @@ const mockSessionHistory: PracticeSession[] = [
         clarity_score: 90,
         title: 'Session 2',
         transcript: '... um ... like ...',
+        pause_metrics: { silencePercentage: 12, transitionPauses: 15, extendedPauses: 5, longestPause: 3 },
     },
 ];
 
@@ -38,6 +40,19 @@ describe('analyticsUtils', () => {
             expect(stats.averageWPM).toBe(100);
             expect(stats.avgFillerWordsPerMin).toBe('1.5');
             expect(stats.avgClarity).toBe('92.5');
+            // Pause Rhythm: (8+2) + (15+5) = 30 pauses over 15 speaking minutes = 2.0/min.
+            expect(stats.avgPausesPerMin).toBe('2.0');
+        });
+
+        it('aggregates Pause Rhythm (pauses/min) from short + long pauses, and is 0 without pause data', () => {
+            // getSessionPauseCount = transitionPauses + extendedPauses.
+            expect(getSessionPauseCount(mockSessionHistory[0])).toBe(10);
+            expect(getSessionPauseCount(mockSessionHistory[1])).toBe(20);
+            // A session with no pause_metrics contributes 0 (no crash, no NaN).
+            expect(getSessionPauseCount({ id: 'x' } as PracticeSession)).toBe(0);
+            expect(calculateOverallStats([
+                { id: 'no-pauses', created_at: '2026-01-01T00:00:00.000Z', user_id: 'u', duration: 60, total_words: 60, filler_words: {}, transcript: 'word '.repeat(60) },
+            ] as PracticeSession[]).avgPausesPerMin).toBe('0.0');
         });
 
         it('aggregates Clear Delivery (clarity) from clarity_score and ignores the unrelated STT accuracy field', () => {

--- a/frontend/src/lib/analyticsUtils.ts
+++ b/frontend/src/lib/analyticsUtils.ts
@@ -25,6 +25,17 @@ import {
  * 3. Keep client-side as fallback for small datasets
  */
 
+/**
+ * Pause Rhythm tool: the count of meaningful pauses the speaker took in a session — short
+ * (transition, 0.5–1.5s) plus extended (>1.5s). Surfaced as a first-class coaching metric
+ * (pauses/min) so the analytics toolkit matches the "pace, pauses, fillers, clarity" promise.
+ */
+export const getSessionPauseCount = (session: PracticeSession): number => {
+    const pm = session.pause_metrics;
+    if (!pm) return 0;
+    return (pm.transitionPauses ?? 0) + (pm.extendedPauses ?? 0);
+};
+
 export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
     // P1 FIX: Early exit for empty data
     if (!sessionHistory || sessionHistory.length === 0) {
@@ -35,6 +46,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
             averageWPM: 0,
             avgFillerWordsPerMin: "0.0",
             avgClarity: "0.0",
+            avgPausesPerMin: "0.0",
             chartData: []
         };
     }
@@ -46,6 +58,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
     let totalWords = 0;
     let totalFillerWords = 0;
     let totalClarity = 0;
+    let totalPauses = 0;
 
     for (const s of sessionHistory) {
         const duration = s.duration || 0;
@@ -55,6 +68,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
         totalWords += sessionMetrics.wordCount;
 
         totalFillerWords += sessionMetrics.fillerCount;
+        totalPauses += getSessionPauseCount(s);
         // Single source of truth: aggregate the SAME per-session delivery-clarity used by session
         // detail, PDF, Goals, and the clarity chart. The unrelated STT `accuracy` field is NOT
         // clarity; mixing it made the aggregate card read 0% while individual sessions read nonzero.
@@ -75,6 +89,8 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
     // Industry standard: Filler Rate = Total Fillers / Total Speaking Time (precise minutes)
     const avgFillerWordsPerMin = calculateRatePerMinute(totalFillerWords, totalDurationSeconds, 1);
     const avgClarity = totalSessions > 0 ? (totalClarity / totalSessions).toFixed(1) : "0.0";
+    // Pause Rhythm: pauses over aggregate speaking time (same rate basis as the filler metric).
+    const avgPausesPerMin = calculateRatePerMinute(totalPauses, totalDurationSeconds, 1);
 
     const chartData = sessionHistory.slice(0, 10).map(s => {
         const duration = s.duration || 0;
@@ -88,7 +104,7 @@ export const calculateOverallStats = (sessionHistory: PracticeSession[]) => {
         };
     }).reverse();
 
-    return { totalSessions, totalPracticeTime, averageSessionLength, averageWPM, avgFillerWordsPerMin, avgClarity, chartData };
+    return { totalSessions, totalPracticeTime, averageSessionLength, averageWPM, avgFillerWordsPerMin, avgClarity, avgPausesPerMin, chartData };
 };
 
 export const calculateFillerWordTrends = (sessionHistory: PracticeSession[]) => {

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -19,6 +19,7 @@ export interface OverallStats {
   averageWPM: number;
   avgFillerWordsPerMin: string | number;
   avgClarity: string | number;
+  avgPausesPerMin: string | number;
   chartData: ChartDataPoint[];
 }
 

--- a/tests/e2e/analytics-suite.e2e.spec.ts
+++ b/tests/e2e/analytics-suite.e2e.spec.ts
@@ -33,6 +33,8 @@ test.describe('Analytics Suite & Data Matrix', () => {
     await expect(page.getByTestId('stat-card-speaking_pace')).toBeVisible();
     await expect(page.getByTestId('stat-card-filler_words_per_min')).toBeVisible();
     await expect(page.getByTestId('stat-card-clarity_score')).toBeVisible();
+    // Pause Rhythm is now first-class in the default (Sound Confident) focus.
+    await expect(page.getByTestId('stat-card-pause_rhythm')).toBeVisible();
   });
 
   // SCENARIO 2: Detail Flow (Click-through Analysis)

--- a/tests/e2e/helpers/setupE2EManifest.ts
+++ b/tests/e2e/helpers/setupE2EManifest.ts
@@ -490,6 +490,7 @@ export async function setupE2EManifest(
                 averageWPM: 145,
                 avgFillerWordsPerMin: '1.0',
                 avgClarity: '92.0',
+                avgPausesPerMin: '2.5',
                 chartData: [],
               },
               fillerWordTrends: {},


### PR DESCRIPTION
## PR 1 of the tool-coherence plan — Pause Rhythm as a first-class analytics tool

Closes the clearest coherence gap we found: the default **"Sound Confident"** focus *promises* "whether your **pace, pauses, fillers**, and delivery habits make you easy to follow," but its tools were `speaking_pace, filler_words_per_min, clarity_score` (+ a progress card) — **no pause card, no pause trend.** Pauses only reached the user through the rolled-up SpeakSharp Score and the PDF, even though the product collects rich pause data.

### What this adds
- **`Pause Rhythm` stat card** — pauses/min, *"Healthy pauses make key ideas easier to follow."*
- **`Pause Rhythm Trend` slide** — pauses per minute across sessions (new `pauses` metric on `TrendChart`).
- **First-class in the default focus** — `sound_confident` (and the custom defaults) now lead with **pace · pause rhythm · fillers · clarity**. Pause Rhythm takes the slots held by the progress-oriented `total_practice_time` / `weekly_activity` (those belong to *Track Progress*), keeping each focus at 4 cards/slides.
- **Aggregation** — `getSessionPauseCount` (short + long pauses) and `avgPausesPerMin` (pauses over aggregate speaking time — the same rate basis as the filler metric); threaded through `OverallStats`, `useAnalytics`, and the e2e manifest.

### Tests
- `analyticsUtils.test.ts`: `avgPausesPerMin` aggregate + `getSessionPauseCount` (incl. **no-pause-data → 0**, no NaN).
- `AnalyticsDashboard.component.test.tsx`: the data-driven focus test now asserts **Sound Confident surfaces `stat-card-pause_rhythm`** — a regression guard so the promise can't silently drift again.
- `analytics-suite.e2e.spec.ts`: the default dashboard renders the pause card.
- Verified locally: 53 analytics unit/component tests pass, eslint + frontend `tsc` clean, analytics-suite e2e green (9/9).

### Scope / sequence
Per the agreed plan this is **PR 1**. Following PRs (not here): ② actionable "Try this next" tips on analytics (revives `SpeakingTipsCard` logic), ③ carry the active Focus into the live session emphasis, ④ retire the two genuinely-redundant orphans (`SpeakingRateCard`, `ClarityScoreCard`). The orphaned `PauseMetricsDisplay`/`SpeakingTipsCard` are intentionally **kept** — their function is being restored, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
