### PR TITLE
feat(analytics): narrative-first coaching — decoded labels + Try this next (tool-coherence PR 2)

### DIFF
--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -24,6 +24,14 @@ import { useChartContainerReady } from './analytics/useChartContainerReady';
 import { formatSessionRecordingMode } from '@/utils/engineLabels';
 import { ANALYTICS_THRESHOLDS, getSessionAnalysisMetrics, calculateRatePerMinute } from '@/utils/sessionAnalysis';
 import { getSessionPauseCount } from '@/lib/analyticsUtils';
+import {
+    decodePace,
+    decodePauseRhythm,
+    decodeFillers,
+    decodeClarity,
+    getTryThisNext,
+    type CoachingMetric,
+} from '@/utils/coachingNarrative';
 import { getTranscriptQualityCaveat } from '@/utils/speakingScore';
 
 import type { PracticeSession } from '@/types/session';
@@ -65,9 +73,17 @@ interface StatCardProps {
     value: string | number;
     unit?: string;
     description?: string;
+    interpretation?: CoachingMetric;
     className?: string;
     testId?: string;
 }
+
+// Tone → pill styling for the decoded coaching label (good = on target, watch = drifting, off = needs work).
+const COACHING_TONE_CLASS: Record<CoachingMetric['tone'], string> = {
+    good: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+    watch: 'bg-amber-100 text-amber-900 border-amber-200',
+    off: 'bg-rose-100 text-rose-800 border-rose-200',
+};
 
 interface SessionHistoryItemProps {
     session: PracticeSession;
@@ -114,6 +130,9 @@ type StatCardConfig = {
     getValue: (stats: OverallStats) => string | number;
     unit?: string;
     description?: string;
+    // Narrative-first: decode the raw value into a plain label (Fast / Choppy / Strong …) so the card
+    // leads with the coaching read and keeps the number as secondary detail.
+    getInterpretation?: (stats: OverallStats) => CoachingMetric;
 };
 
 const STAT_CARD_OPTIONS: StatCardConfig[] = [
@@ -130,14 +149,16 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         icon: <Gauge size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.averageWPM,
         unit: 'WPM',
-        description: 'Average words per minute'
+        description: 'Average words per minute',
+        getInterpretation: (stats) => decodePace(stats.averageWPM),
     },
     {
         id: 'filler_words_per_min',
         label: 'Avg. Filler Words / Min',
         icon: <TrendingUp size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.avgFillerWordsPerMin,
-        description: 'Filler word frequency per minute'
+        description: 'Filler word frequency per minute',
+        getInterpretation: (stats) => decodeFillers(stats.avgFillerWordsPerMin),
     },
     {
         id: 'total_practice_time',
@@ -153,7 +174,8 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         icon: <Target size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.avgClarity,
         unit: '%',
-        description: 'Based on pace, fillers, and structure — not transcription accuracy.'
+        description: 'Based on pace, fillers, and structure — not transcription accuracy.',
+        getInterpretation: (stats) => decodeClarity(stats.avgClarity),
     },
     {
         id: 'pause_rhythm',
@@ -161,7 +183,8 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         icon: <AudioLines size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.avgPausesPerMin,
         unit: '/min',
-        description: 'Pauses per minute. Healthy pauses make key ideas easier to follow.'
+        description: 'Pauses per minute. Healthy pauses make key ideas easier to follow.',
+        getInterpretation: (stats) => decodePauseRhythm(stats.avgPausesPerMin),
     },
     // Future stat cards can be added here
     {
@@ -336,8 +359,10 @@ const normalizeAnalysisSlideIds = (ids: string[]): string[] => {
 
 // --- Sub-components ---
 
-const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, description, className = '', testId }) => (
-    <Card className={`rounded-xl p-6 ${className}`} data-testid={testId || `stat-card-${label.toLowerCase().replace(/\s+/g, '-')}`}>
+const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, description, interpretation, className = '', testId }) => {
+    const resolvedTestId = testId || `stat-card-${label.toLowerCase().replace(/\s+/g, '-')}`;
+    return (
+    <Card className={`rounded-xl p-6 ${className}`} data-testid={resolvedTestId}>
         <div className="flex items-center justify-between mb-4">
             <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${label.includes('Filler') ? 'bg-accent/10 text-accent' : 'bg-primary/10 text-primary'}`}>
                 {/* Clone icon to enforce size and styling if needed, but usually props are fine. Wrapper handles color. */}
@@ -352,21 +377,33 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, descripti
             )}
         </div>
         <div>
-            <div className="flex items-baseline gap-1">
-                <span className="text-3xl font-bold text-foreground tracking-tight">
+            {/* Narrative-first: lead with the decoded coaching label; the number is supporting detail. */}
+            {interpretation && (
+                <span
+                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-sm font-bold ${COACHING_TONE_CLASS[interpretation.tone]}`}
+                    data-testid={`${resolvedTestId}-interpretation`}
+                >
+                    {interpretation.label}
+                </span>
+            )}
+            <div className={`flex items-baseline gap-1 ${interpretation ? 'mt-2' : ''}`}>
+                <span className={interpretation
+                    ? 'text-xl font-semibold text-foreground/70 tracking-tight'
+                    : 'text-3xl font-bold text-foreground tracking-tight'}>
                     {value}
                 </span>
                 {unit && <span className="ml-1 text-sm font-semibold text-foreground/70">{unit}</span>}
             </div>
             <p className="mt-1 text-sm font-semibold text-foreground/75">{label}</p>
             {description && (
-                <p className="mt-3 text-xs font-medium leading-snug text-foreground/70" data-testid={`${testId || `stat-card-${label.toLowerCase().replace(/\s+/g, '-')}`}-explanation`}>
+                <p className="mt-3 text-xs font-medium leading-snug text-foreground/70" data-testid={`${resolvedTestId}-explanation`}>
                     {description}
                 </p>
             )}
         </div>
     </Card>
-);
+    );
+};
 
 const SessionHistoryItem: React.FC<SessionHistoryItemProps> = ({ session, sessionHistory, isPro: _isPro, isSelected, onToggleSelect, profileName }) => {
     const metrics = getSessionAnalysisMetrics(session);
@@ -982,6 +1019,25 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                         )}
                     </div>
 
+                    {/* Try this next: one decoded, actionable recommendation from the strongest driver. */}
+                    {Number(overallStats.totalSessions) > 0 && (() => {
+                        const next = getTryThisNext({
+                            avgWpm: overallStats.averageWPM,
+                            avgPausesPerMin: overallStats.avgPausesPerMin,
+                            avgFillerWordsPerMin: overallStats.avgFillerWordsPerMin,
+                            avgClarity: overallStats.avgClarity,
+                        });
+                        return (
+                            <div className="rounded-xl border border-primary/20 bg-primary/5 p-4" data-testid="try-this-next">
+                                <p className="text-xs font-bold uppercase tracking-wide text-primary">Try this next</p>
+                                <p className="mt-1 text-sm font-semibold text-foreground" data-testid="try-this-next-action">{next.action}</p>
+                                {next.driver && (
+                                    <p className="mt-1 text-xs font-medium text-foreground/70">Main driver: {next.driver}</p>
+                                )}
+                            </div>
+                        );
+                    })()}
+
                     {/* Dynamic Stat Cards */}
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         {displayedStatCards.map(option => (
@@ -991,6 +1047,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                 label={option.label}
                                 value={option.getValue(overallStats)}
                                 unit={option.unit}
+                                interpretation={option.getInterpretation?.(overallStats)}
                                 testId={`stat-card-${option.id}`}
                             />
                         ))}

--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -153,7 +153,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.averageWPM,
         unit: 'WPM',
         description: 'Average words per minute',
-        microcopy: 'target 130–150',
+        microcopy: 'Target 130–150',
         getInterpretation: (stats) => decodePace(stats.averageWPM),
     },
     {
@@ -161,8 +161,9 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         label: 'Avg. Filler Words / Min',
         icon: <TrendingUp size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.avgFillerWordsPerMin,
+        unit: '/min',
         description: 'Filler word frequency per minute',
-        microcopy: 'swap a filler for a brief pause',
+        microcopy: 'Swap a filler for a brief pause',
         getInterpretation: (stats) => decodeFillers(stats.avgFillerWordsPerMin),
     },
     {
@@ -180,7 +181,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.avgClarity,
         unit: '%',
         description: 'Based on pace, fillers, and structure — not transcription accuracy.',
-        microcopy: 'pace + fillers + structure',
+        microcopy: 'Pace + fillers + structure',
         getInterpretation: (stats) => decodeClarity(stats.avgClarity),
     },
     {
@@ -190,7 +191,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.avgPausesPerMin,
         unit: '/min',
         description: 'Pauses per minute. Healthy pauses make key ideas easier to follow.',
-        microcopy: 'steady spacing helps ideas land',
+        microcopy: 'Steady spacing helps ideas land',
         getInterpretation: (stats) => decodePauseRhythm(stats.avgPausesPerMin),
     },
     // Future stat cards can be added here
@@ -382,7 +383,8 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, descripti
                 </p>
                 <p className="mt-1 text-sm font-semibold text-foreground/80">{label}</p>
                 <p className="mt-1 text-xs font-medium text-foreground/55" data-testid={`${resolvedTestId}-detail`}>
-                    {value}{unit ? ` ${unit}` : ''}{microcopy ? ` · ${microcopy}` : ''}
+                    {/* Cue first, number second: e.g. "Steady spacing helps ideas land · 8/min". */}
+                    {microcopy ? `${microcopy} · ` : ''}{value}{unit ? (unit === 'WPM' ? ` ${unit}` : unit) : ''}
                 </p>
             </Card>
         );
@@ -991,7 +993,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                     {/* Stats Section Header */}
                     <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                         <div className="space-y-1">
-                            <h2 className="text-lg font-semibold text-foreground">Evidence for {focusLabel}</h2>
+                            <h2 className="text-lg font-semibold text-foreground">Your {focusLabel} signals</h2>
                             <p className="text-sm font-medium text-foreground/70">
                                 {isCustomFocus ? 'Selected tools are interpreted independently.' : 'These cards are selected together because they support the current focus.'}
                             </p>

--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -22,14 +22,14 @@ import { SessionComparisonDialog } from './analytics/SessionComparisonDialog';
 import { TrendChart } from './analytics/TrendChart';
 import { useChartContainerReady } from './analytics/useChartContainerReady';
 import { formatSessionRecordingMode } from '@/utils/engineLabels';
-import { ANALYTICS_THRESHOLDS, getSessionAnalysisMetrics, calculateRatePerMinute } from '@/utils/sessionAnalysis';
+import { getSessionAnalysisMetrics, calculateRatePerMinute } from '@/utils/sessionAnalysis';
 import { getSessionPauseCount } from '@/lib/analyticsUtils';
 import {
     decodePace,
     decodePauseRhythm,
     decodeFillers,
     decodeClarity,
-    getTryThisNext,
+    getNarrativeSummary,
     type CoachingMetric,
 } from '@/utils/coachingNarrative';
 import { getTranscriptQualityCaveat } from '@/utils/speakingScore';
@@ -73,16 +73,17 @@ interface StatCardProps {
     value: string | number;
     unit?: string;
     description?: string;
+    microcopy?: string;
     interpretation?: CoachingMetric;
     className?: string;
     testId?: string;
 }
 
-// Tone → pill styling for the decoded coaching label (good = on target, watch = drifting, off = needs work).
-const COACHING_TONE_CLASS: Record<CoachingMetric['tone'], string> = {
-    good: 'bg-emerald-100 text-emerald-800 border-emerald-200',
-    watch: 'bg-amber-100 text-amber-900 border-amber-200',
-    off: 'bg-rose-100 text-rose-800 border-rose-200',
+// Tone → color for the decoded coaching label (good = on target, watch = drifting, off = needs work).
+const COACHING_TONE_TEXT: Record<CoachingMetric['tone'], string> = {
+    good: 'text-emerald-700',
+    watch: 'text-amber-700',
+    off: 'text-rose-700',
 };
 
 interface SessionHistoryItemProps {
@@ -130,6 +131,8 @@ type StatCardConfig = {
     getValue: (stats: OverallStats) => string | number;
     unit?: string;
     description?: string;
+    // Short supporting microcopy shown under the (now secondary) number on a decoded card.
+    microcopy?: string;
     // Narrative-first: decode the raw value into a plain label (Fast / Choppy / Strong …) so the card
     // leads with the coaching read and keeps the number as secondary detail.
     getInterpretation?: (stats: OverallStats) => CoachingMetric;
@@ -150,6 +153,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.averageWPM,
         unit: 'WPM',
         description: 'Average words per minute',
+        microcopy: 'target 130–150',
         getInterpretation: (stats) => decodePace(stats.averageWPM),
     },
     {
@@ -158,6 +162,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         icon: <TrendingUp size={24} className="text-foreground/70" />,
         getValue: (stats) => stats.avgFillerWordsPerMin,
         description: 'Filler word frequency per minute',
+        microcopy: 'swap a filler for a brief pause',
         getInterpretation: (stats) => decodeFillers(stats.avgFillerWordsPerMin),
     },
     {
@@ -175,6 +180,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.avgClarity,
         unit: '%',
         description: 'Based on pace, fillers, and structure — not transcription accuracy.',
+        microcopy: 'pace + fillers + structure',
         getInterpretation: (stats) => decodeClarity(stats.avgClarity),
     },
     {
@@ -184,6 +190,7 @@ const STAT_CARD_OPTIONS: StatCardConfig[] = [
         getValue: (stats) => stats.avgPausesPerMin,
         unit: '/min',
         description: 'Pauses per minute. Healthy pauses make key ideas easier to follow.',
+        microcopy: 'steady spacing helps ideas land',
         getInterpretation: (stats) => decodePauseRhythm(stats.avgPausesPerMin),
     },
     // Future stat cards can be added here
@@ -359,8 +366,28 @@ const normalizeAnalysisSlideIds = (ids: string[]): string[] => {
 
 // --- Sub-components ---
 
-const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, description, interpretation, className = '', testId }) => {
+const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, description, microcopy, interpretation, className = '', testId }) => {
     const resolvedTestId = testId || `stat-card-${label.toLowerCase().replace(/\s+/g, '-')}`;
+
+    // Narrative-first: when the value is decoded into a coaching label, the LABEL is the anchor and
+    // the raw number drops to small supporting detail (action first, reason second, metrics third).
+    if (interpretation) {
+        return (
+            <Card className={`rounded-xl p-5 ${className}`} data-testid={resolvedTestId}>
+                <p
+                    className={`text-2xl font-bold tracking-tight ${COACHING_TONE_TEXT[interpretation.tone]}`}
+                    data-testid={`${resolvedTestId}-interpretation`}
+                >
+                    {interpretation.label}
+                </p>
+                <p className="mt-1 text-sm font-semibold text-foreground/80">{label}</p>
+                <p className="mt-1 text-xs font-medium text-foreground/55" data-testid={`${resolvedTestId}-detail`}>
+                    {value}{unit ? ` ${unit}` : ''}{microcopy ? ` · ${microcopy}` : ''}
+                </p>
+            </Card>
+        );
+    }
+
     return (
     <Card className={`rounded-xl p-6 ${className}`} data-testid={resolvedTestId}>
         <div className="flex items-center justify-between mb-4">
@@ -368,28 +395,10 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, unit, descripti
                 {/* Clone icon to enforce size and styling if needed, but usually props are fine. Wrapper handles color. */}
                 {React.cloneElement(icon as React.ReactElement, { size: 24, className: "stroke-current" })}
             </div>
-            {/* Trend placeholder - could be passed as prop later */}
-            {label.includes('Pace') && (
-                <span className="flex items-center gap-1 text-sm text-success font-medium">
-                    <TrendingUp className="w-4 h-4" />
-                    Target: {ANALYTICS_THRESHOLDS.TARGET_WPM_MIN}-{ANALYTICS_THRESHOLDS.TARGET_WPM_MAX}
-                </span>
-            )}
         </div>
         <div>
-            {/* Narrative-first: lead with the decoded coaching label; the number is supporting detail. */}
-            {interpretation && (
-                <span
-                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-sm font-bold ${COACHING_TONE_CLASS[interpretation.tone]}`}
-                    data-testid={`${resolvedTestId}-interpretation`}
-                >
-                    {interpretation.label}
-                </span>
-            )}
-            <div className={`flex items-baseline gap-1 ${interpretation ? 'mt-2' : ''}`}>
-                <span className={interpretation
-                    ? 'text-xl font-semibold text-foreground/70 tracking-tight'
-                    : 'text-3xl font-bold text-foreground tracking-tight'}>
+            <div className="flex items-baseline gap-1">
+                <span className="text-3xl font-bold text-foreground tracking-tight">
                     {value}
                 </span>
                 {unit && <span className="ml-1 text-sm font-semibold text-foreground/70">{unit}</span>}
@@ -1019,21 +1028,23 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                         )}
                     </div>
 
-                    {/* Try this next: one decoded, actionable recommendation from the strongest driver. */}
+                    {/* Narrative-first: action first, reason second. One recommendation, the driver, and
+                        a connecting sentence — the four cards below are the supporting evidence. */}
                     {Number(overallStats.totalSessions) > 0 && (() => {
-                        const next = getTryThisNext({
+                        const summary = getNarrativeSummary({
                             avgWpm: overallStats.averageWPM,
                             avgPausesPerMin: overallStats.avgPausesPerMin,
                             avgFillerWordsPerMin: overallStats.avgFillerWordsPerMin,
                             avgClarity: overallStats.avgClarity,
                         });
                         return (
-                            <div className="rounded-xl border border-primary/20 bg-primary/5 p-4" data-testid="try-this-next">
+                            <div className="rounded-xl border border-primary/20 bg-primary/5 p-5" data-testid="try-this-next">
                                 <p className="text-xs font-bold uppercase tracking-wide text-primary">Try this next</p>
-                                <p className="mt-1 text-sm font-semibold text-foreground" data-testid="try-this-next-action">{next.action}</p>
-                                {next.driver && (
-                                    <p className="mt-1 text-xs font-medium text-foreground/70">Main driver: {next.driver}</p>
+                                <p className="mt-1 text-base font-semibold text-foreground" data-testid="try-this-next-action">{summary.action}</p>
+                                {summary.driverDisplay && (
+                                    <p className="mt-2 text-sm font-semibold text-foreground/80" data-testid="try-this-next-driver">Main driver: {summary.driverDisplay}</p>
                                 )}
+                                <p className="mt-0.5 text-xs font-medium text-foreground/65" data-testid="try-this-next-why">{summary.why}</p>
                             </div>
                         );
                     })()}
@@ -1047,6 +1058,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
                                 label={option.label}
                                 value={option.getValue(overallStats)}
                                 unit={option.unit}
+                                microcopy={option.microcopy}
                                 interpretation={option.getInterpretation?.(overallStats)}
                                 testId={`stat-card-${option.id}`}
                             />

--- a/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
+++ b/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
@@ -167,7 +167,7 @@ describe('AnalyticsDashboard', () => {
 
         expect(screen.getByRole('heading', { name: label })).toBeInTheDocument();
         expect(screen.getByText(outcome)).toBeInTheDocument();
-        expect(screen.getByText(`Evidence for ${label}`)).toBeInTheDocument();
+        expect(screen.getByText(`Your ${label} signals`)).toBeInTheDocument();
         expect(screen.getByText(`${label} Tools`)).toBeInTheDocument();
         expect(screen.getByText(new RegExp(`${label} shows which ingredient to improve`, 'i'))).toBeInTheDocument();
         for (const testId of statCards) {
@@ -190,7 +190,7 @@ describe('AnalyticsDashboard', () => {
 
         // Narrative-first: action first, then the named driver and a connecting "why".
         expect(screen.getByTestId('try-this-next-action'))
-            .toHaveTextContent('Add a little more momentum through familiar lines.');
+            .toHaveTextContent('Pick up the pace on familiar points.');
         expect(screen.getByTestId('try-this-next-driver'))
             .toHaveTextContent('Main driver: Speaking Pace — Slow');
         expect(screen.getByTestId('try-this-next-why'))

--- a/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
+++ b/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
@@ -188,11 +188,13 @@ describe('AnalyticsDashboard', () => {
         expect(screen.getByTestId('stat-card-pause_rhythm-interpretation')).toHaveTextContent('Smooth');
         expect(screen.getByTestId('stat-card-clarity_score-interpretation')).toHaveTextContent('Strong');
 
-        // One actionable recommendation from the strongest driver (pace is off → a pace action).
-        expect(screen.getByTestId('try-this-next')).toBeInTheDocument();
+        // Narrative-first: action first, then the named driver and a connecting "why".
         expect(screen.getByTestId('try-this-next-action'))
             .toHaveTextContent('Add a little more momentum through familiar lines.');
-        expect(screen.getByText('Main driver: pace')).toBeInTheDocument();
+        expect(screen.getByTestId('try-this-next-driver'))
+            .toHaveTextContent('Main driver: Speaking Pace — Slow');
+        expect(screen.getByTestId('try-this-next-why'))
+            .toHaveTextContent('Your pause rhythm and clear delivery are steady; pace is the main adjustment.');
     });
 
     it.each([

--- a/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
+++ b/frontend/src/components/__tests__/AnalyticsDashboard.component.test.tsx
@@ -178,6 +178,23 @@ describe('AnalyticsDashboard', () => {
         expect(Boolean(accuracyComparison)).toBe(hasTranscriptQuality);
     });
 
+    it('decodes Sound Confident tools into plain labels and shows one Try this next action', () => {
+        // mockStats: averageWPM 120 → Slow (off); avgPausesPerMin 8 → Smooth; avgClarity 85 → Strong.
+        localStorage.setItem('speaksharp_analytics_tool_group_v1', 'sound_confident');
+        renderComponent({ sessionHistory: mockSessionHistory });
+
+        // Narrative-first: cards lead with the decoded coaching label.
+        expect(screen.getByTestId('stat-card-speaking_pace-interpretation')).toHaveTextContent('Slow');
+        expect(screen.getByTestId('stat-card-pause_rhythm-interpretation')).toHaveTextContent('Smooth');
+        expect(screen.getByTestId('stat-card-clarity_score-interpretation')).toHaveTextContent('Strong');
+
+        // One actionable recommendation from the strongest driver (pace is off → a pace action).
+        expect(screen.getByTestId('try-this-next')).toBeInTheDocument();
+        expect(screen.getByTestId('try-this-next-action'))
+            .toHaveTextContent('Add a little more momentum through familiar lines.');
+        expect(screen.getByText('Main driver: pace')).toBeInTheDocument();
+    });
+
     it.each([
         ['delivery_control', 'Sound Confident'],
         ['message_clarity', 'Speak Clearly'],

--- a/frontend/src/utils/__tests__/coachingNarrative.test.ts
+++ b/frontend/src/utils/__tests__/coachingNarrative.test.ts
@@ -12,8 +12,8 @@ describe('coachingNarrative decode', () => {
     it('decodes Speaking Pace as Fast / Steady / Slow (Not measured)', () => {
         expect(decodePace(0)).toEqual({ label: 'Not measured', tone: 'watch' });
         expect(decodePace(140)).toEqual({ label: 'Steady', tone: 'good' });   // 130–150 target
-        expect(decodePace(175)).toEqual({ label: 'Fast', tone: 'off' });      // > 150
-        expect(decodePace(110)).toEqual({ label: 'Slow', tone: 'off' });      // < 130
+        expect(decodePace(175)).toEqual({ label: 'Fast', tone: 'off' });      // > 150, red
+        expect(decodePace(110)).toEqual({ label: 'Slow', tone: 'watch' });    // < 130, amber (nudge, not failure)
         expect(decodePace('145')).toEqual({ label: 'Steady', tone: 'good' }); // accepts string
     });
 
@@ -85,7 +85,7 @@ describe('coachingNarrative getNarrativeSummary', () => {
     it('leads with the action, names the driver as "Name — Status", and lists the steady signals', () => {
         // pace Slow (off); pauses/fillers/clarity all good.
         const s = getNarrativeSummary({ avgWpm: 120, avgPausesPerMin: 6, avgFillerWordsPerMin: 1, avgClarity: 90 });
-        expect(s.action).toBe('Add a little more momentum through familiar lines.');
+        expect(s.action).toBe('Pick up the pace on familiar points.');
         expect(s.driver).toBe('pace');
         expect(s.driverDisplay).toBe('Speaking Pace — Slow');
         expect(s.why).toBe('Your pause rhythm, filler words, and clear delivery are steady; pace is the main adjustment.');

--- a/frontend/src/utils/__tests__/coachingNarrative.test.ts
+++ b/frontend/src/utils/__tests__/coachingNarrative.test.ts
@@ -5,6 +5,7 @@ import {
     decodeFillers,
     decodeClarity,
     getTryThisNext,
+    getNarrativeSummary,
 } from '../coachingNarrative';
 
 describe('coachingNarrative decode', () => {
@@ -63,9 +64,37 @@ describe('coachingNarrative getTryThisNext', () => {
     });
 
     it('prefers an off metric over a watch metric', () => {
-        // fillers Noticeable (watch) but clarity Needs focus (off) → clarity wins... but pace/fillers
-        // priority: here fillers is only 'watch', clarity is 'off' → clarity surfaces.
+        // fillers Noticeable (watch) but clarity Needs focus (off) → clarity (off) surfaces.
         const result = getTryThisNext({ avgWpm: 140, avgPausesPerMin: 6, avgFillerWordsPerMin: 4, avgClarity: 40 });
         expect(result.driver).toBe('clear delivery');
+    });
+});
+
+describe('coachingNarrative getNarrativeSummary', () => {
+    const onTarget = { avgWpm: 140, avgPausesPerMin: 6, avgFillerWordsPerMin: 1, avgClarity: 90 };
+
+    it('is positive with no driver when everything is on target', () => {
+        expect(getNarrativeSummary(onTarget)).toEqual({
+            action: 'Keep the pace steady and land the takeaway.',
+            driver: null,
+            driverDisplay: null,
+            why: 'Every signal is on target — keep it up.',
+        });
+    });
+
+    it('leads with the action, names the driver as "Name — Status", and lists the steady signals', () => {
+        // pace Slow (off); pauses/fillers/clarity all good.
+        const s = getNarrativeSummary({ avgWpm: 120, avgPausesPerMin: 6, avgFillerWordsPerMin: 1, avgClarity: 90 });
+        expect(s.action).toBe('Add a little more momentum through familiar lines.');
+        expect(s.driver).toBe('pace');
+        expect(s.driverDisplay).toBe('Speaking Pace — Slow');
+        expect(s.why).toBe('Your pause rhythm, filler words, and clear delivery are steady; pace is the main adjustment.');
+    });
+
+    it('formats the driver status (Fast) and handles a single steady signal', () => {
+        // pace Fast (off); pauses Choppy (off) and fillers High (off) → only clarity steady.
+        const s = getNarrativeSummary({ avgWpm: 180, avgPausesPerMin: 15, avgFillerWordsPerMin: 8, avgClarity: 90 });
+        expect(s.driverDisplay).toBe('Speaking Pace — Fast');
+        expect(s.why).toBe('Your clear delivery is steady; pace is the main adjustment.');
     });
 });

--- a/frontend/src/utils/__tests__/coachingNarrative.test.ts
+++ b/frontend/src/utils/__tests__/coachingNarrative.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+    decodePace,
+    decodePauseRhythm,
+    decodeFillers,
+    decodeClarity,
+    getTryThisNext,
+} from '../coachingNarrative';
+
+describe('coachingNarrative decode', () => {
+    it('decodes Speaking Pace as Fast / Steady / Slow (Not measured)', () => {
+        expect(decodePace(0)).toEqual({ label: 'Not measured', tone: 'watch' });
+        expect(decodePace(140)).toEqual({ label: 'Steady', tone: 'good' });   // 130–150 target
+        expect(decodePace(175)).toEqual({ label: 'Fast', tone: 'off' });      // > 150
+        expect(decodePace(110)).toEqual({ label: 'Slow', tone: 'off' });      // < 130
+        expect(decodePace('145')).toEqual({ label: 'Steady', tone: 'good' }); // accepts string
+    });
+
+    it('decodes Pause Rhythm as Smooth / Sparse / Choppy', () => {
+        expect(decodePauseRhythm(7)).toEqual({ label: 'Smooth', tone: 'good' });
+        expect(decodePauseRhythm(1)).toEqual({ label: 'Sparse', tone: 'watch' });   // < 3/min
+        expect(decodePauseRhythm(15)).toEqual({ label: 'Choppy', tone: 'off' });    // > 12/min
+    });
+
+    it('decodes Filler Words as Low / Noticeable / High', () => {
+        expect(decodeFillers(1)).toEqual({ label: 'Low', tone: 'good' });
+        expect(decodeFillers(4)).toEqual({ label: 'Noticeable', tone: 'watch' });   // >= 3/min
+        expect(decodeFillers(8)).toEqual({ label: 'High', tone: 'off' });           // >= 6/min
+    });
+
+    it('decodes Clear Delivery as Strong / Developing / Needs focus', () => {
+        expect(decodeClarity(92)).toEqual({ label: 'Strong', tone: 'good' });       // >= 80
+        expect(decodeClarity(70)).toEqual({ label: 'Developing', tone: 'watch' });  // >= 60
+        expect(decodeClarity(40)).toEqual({ label: 'Needs focus', tone: 'off' });   // < 60
+    });
+});
+
+describe('coachingNarrative getTryThisNext', () => {
+    const onTarget = { avgWpm: 140, avgPausesPerMin: 6, avgFillerWordsPerMin: 1, avgClarity: 90 };
+
+    it('returns no driver and an encouraging action when everything is on target', () => {
+        expect(getTryThisNext(onTarget)).toEqual({
+            driver: null,
+            action: 'Keep the pace steady and land the takeaway.',
+        });
+    });
+
+    it('surfaces pace first when pace is off (delivery priority)', () => {
+        const result = getTryThisNext({ ...onTarget, avgWpm: 180, avgFillerWordsPerMin: 8 });
+        expect(result.driver).toBe('pace');
+        // > FAST_WPM (170) escalates the action.
+        expect(result.action).toBe('Give the next key idea a beat of silence.');
+    });
+
+    it('escalates a slightly-fast pace to the gentler action', () => {
+        const result = getTryThisNext({ ...onTarget, avgWpm: 160 });
+        expect(result).toEqual({ driver: 'pace', action: 'Ease the pace at sentence endings.' });
+    });
+
+    it('falls through to pause rhythm when only pauses are off', () => {
+        const result = getTryThisNext({ ...onTarget, avgPausesPerMin: 15 });
+        expect(result).toEqual({ driver: 'pause rhythm', action: 'Finish a full phrase before taking the next pause.' });
+    });
+
+    it('prefers an off metric over a watch metric', () => {
+        // fillers Noticeable (watch) but clarity Needs focus (off) → clarity wins... but pace/fillers
+        // priority: here fillers is only 'watch', clarity is 'off' → clarity surfaces.
+        const result = getTryThisNext({ avgWpm: 140, avgPausesPerMin: 6, avgFillerWordsPerMin: 4, avgClarity: 40 });
+        expect(result.driver).toBe('clear delivery');
+    });
+});

--- a/frontend/src/utils/coachingNarrative.ts
+++ b/frontend/src/utils/coachingNarrative.ts
@@ -115,3 +115,59 @@ export const getTryThisNext = (stats: DeliveryAggregates): TryThisNext => {
     }
     return { driver: worst.driver, action: worst.action };
 };
+
+export interface NarrativeSummary {
+    /** The single next action to try (the dominant line). */
+    action: string;
+    /** Raw strongest driver, e.g. 'pace'; null when everything is on target. */
+    driver: string | null;
+    /** Driver shown as "Speaking Pace — Slow"; null when on target. */
+    driverDisplay: string | null;
+    /** Connecting sentence: which signals are steady vs. the one to adjust. */
+    why: string;
+}
+
+// Driver → the metric's user-facing card name.
+const DRIVER_DISPLAY_NAME: Record<string, string> = {
+    'pace': 'Speaking Pace',
+    'pause rhythm': 'Pause Rhythm',
+    'filler words': 'Filler Words',
+    'clear delivery': 'Clear Delivery',
+};
+
+const joinNatural = (items: string[]): string => {
+    if (items.length <= 1) return items[0] ?? '';
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+};
+
+/**
+ * Narrative-first summary: action first, reason second. Leads with the single "Try this next"
+ * action, names the main driver ("Speaking Pace — Slow"), and adds one connecting sentence so the
+ * four tools read as a story (driver to adjust + which signals are already steady) rather than a
+ * wall of numbers.
+ */
+export const getNarrativeSummary = (stats: DeliveryAggregates): NarrativeSummary => {
+    const next = getTryThisNext(stats);
+    const ordered = [
+        { driver: 'pace', metric: decodePace(stats.avgWpm) },
+        { driver: 'pause rhythm', metric: decodePauseRhythm(stats.avgPausesPerMin) },
+        { driver: 'filler words', metric: decodeFillers(stats.avgFillerWordsPerMin) },
+        { driver: 'clear delivery', metric: decodeClarity(stats.avgClarity) },
+    ];
+
+    if (next.driver === null) {
+        return { action: next.action, driver: null, driverDisplay: null, why: 'Every signal is on target — keep it up.' };
+    }
+
+    const driverMetric = ordered.find(x => x.driver === next.driver)?.metric;
+    const driverDisplay = `${DRIVER_DISPLAY_NAME[next.driver]} — ${driverMetric?.label ?? ''}`;
+    const steady = ordered
+        .filter(x => x.driver !== next.driver && x.metric.tone === 'good')
+        .map(x => DRIVER_DISPLAY_NAME[x.driver].toLowerCase());
+    const why = steady.length > 0
+        ? `Your ${joinNatural(steady)} ${steady.length === 1 ? 'is' : 'are'} steady; ${next.driver} is the main adjustment.`
+        : `${DRIVER_DISPLAY_NAME[next.driver]} is the main thing to adjust right now.`;
+
+    return { action: next.action, driver: next.driver, driverDisplay, why };
+};

--- a/frontend/src/utils/coachingNarrative.ts
+++ b/frontend/src/utils/coachingNarrative.ts
@@ -33,7 +33,10 @@ export const decodePace = (avgWpm: string | number): CoachingMetric => {
     const wpm = num(avgWpm);
     if (wpm <= 0) return { label: 'Not measured', tone: 'watch' };
     if (wpm > ANALYTICS_THRESHOLDS.TARGET_WPM_MAX) return { label: 'Fast', tone: 'off' };
-    if (wpm < ANALYTICS_THRESHOLDS.TARGET_WPM_MIN) return { label: 'Slow', tone: 'off' };
+    // Slow is a coaching nudge, not a failure — amber, not red. Red is reserved for the genuinely
+    // disruptive states (Fast, High fillers, Choppy). Slow still surfaces as a driver via the
+    // off-then-watch priority in getTryThisNext.
+    if (wpm < ANALYTICS_THRESHOLDS.TARGET_WPM_MIN) return { label: 'Slow', tone: 'watch' };
     return { label: 'Steady', tone: 'good' };
 };
 
@@ -91,7 +94,7 @@ export const getTryThisNext = (stats: DeliveryAggregates): TryThisNext => {
         ? 'Give the next key idea a beat of silence.'
         : pace.label === 'Fast'
             ? 'Ease the pace at sentence endings.'
-            : 'Add a little more momentum through familiar lines.';
+            : 'Pick up the pace on familiar points.';
 
     // Ordered candidates: { metric, driver, action }. First matching the worst tone wins.
     const candidates = [

--- a/frontend/src/utils/coachingNarrative.ts
+++ b/frontend/src/utils/coachingNarrative.ts
@@ -1,0 +1,117 @@
+/**
+ * Coaching narrative — "numbers support coaching, they are not the coaching."
+ *
+ * Decodes the analytics aggregates into the plain user-facing vocabulary the Sound Confident focus
+ * uses, so the dashboard can lead with a label (and one "Try this next" action) and keep the raw
+ * number secondary. Thresholds are grounded in ANALYTICS_THRESHOLDS where one exists; the pause/
+ * filler per-minute cutoffs are explicit, documented heuristics that Product can tune in one place.
+ */
+import { ANALYTICS_THRESHOLDS } from './sessionAnalysis';
+
+/** good = on target, watch = drifting, off = needs attention. Drives label copy + UI tone. */
+export type CoachingTone = 'good' | 'watch' | 'off';
+export interface CoachingMetric {
+    label: string;
+    tone: CoachingTone;
+}
+
+// Pause Rhythm cutoffs (pauses/min). CHOPPY mirrors the score's `pausesPerMinute > 12` penalty;
+// SPARSE is the "too few pauses / rushing" floor.
+export const PAUSE_RHYTHM_CHOPPY_PER_MIN = 12;
+export const PAUSE_RHYTHM_SPARSE_PER_MIN = 3;
+// Filler cutoffs (fillers/min) — the analytics card is per-minute, so the label tracks that value.
+export const FILLER_HIGH_PER_MIN = 6;
+export const FILLER_NOTICEABLE_PER_MIN = 3;
+// Clear Delivery cutoffs (clarity %, 0–100).
+export const CLARITY_STRONG = 80;
+export const CLARITY_DEVELOPING = 60;
+
+const num = (value: string | number): number => (typeof value === 'number' ? value : Number(value) || 0);
+
+/** Speaking Pace: Fast / Steady / Slow (Not measured). Grounded in TARGET_WPM_MIN/MAX (130–150). */
+export const decodePace = (avgWpm: string | number): CoachingMetric => {
+    const wpm = num(avgWpm);
+    if (wpm <= 0) return { label: 'Not measured', tone: 'watch' };
+    if (wpm > ANALYTICS_THRESHOLDS.TARGET_WPM_MAX) return { label: 'Fast', tone: 'off' };
+    if (wpm < ANALYTICS_THRESHOLDS.TARGET_WPM_MIN) return { label: 'Slow', tone: 'off' };
+    return { label: 'Steady', tone: 'good' };
+};
+
+/** Pause Rhythm: Smooth / Sparse / Choppy. */
+export const decodePauseRhythm = (pausesPerMin: string | number): CoachingMetric => {
+    const rate = num(pausesPerMin);
+    if (rate > PAUSE_RHYTHM_CHOPPY_PER_MIN) return { label: 'Choppy', tone: 'off' };
+    if (rate < PAUSE_RHYTHM_SPARSE_PER_MIN) return { label: 'Sparse', tone: 'watch' };
+    return { label: 'Smooth', tone: 'good' };
+};
+
+/** Filler Words: Low / Noticeable / High. */
+export const decodeFillers = (fillersPerMin: string | number): CoachingMetric => {
+    const rate = num(fillersPerMin);
+    if (rate >= FILLER_HIGH_PER_MIN) return { label: 'High', tone: 'off' };
+    if (rate >= FILLER_NOTICEABLE_PER_MIN) return { label: 'Noticeable', tone: 'watch' };
+    return { label: 'Low', tone: 'good' };
+};
+
+/** Clear Delivery: Strong / Developing / Needs focus. */
+export const decodeClarity = (clarityPct: string | number): CoachingMetric => {
+    const pct = num(clarityPct);
+    if (pct >= CLARITY_STRONG) return { label: 'Strong', tone: 'good' };
+    if (pct >= CLARITY_DEVELOPING) return { label: 'Developing', tone: 'watch' };
+    return { label: 'Needs focus', tone: 'off' };
+};
+
+export interface DeliveryAggregates {
+    avgWpm: string | number;
+    avgPausesPerMin: string | number;
+    avgFillerWordsPerMin: string | number;
+    avgClarity: string | number;
+}
+
+export interface TryThisNext {
+    /** Plain-language driver, e.g. "pace" — null when everything is on target. */
+    driver: string | null;
+    /** The single next action to try. */
+    action: string;
+}
+
+/**
+ * One "Try this next" recommendation from the strongest weakness. Priority follows the score's
+ * delivery weighting (pace > fillers > pauses) then clarity; an `off` metric is always preferred
+ * over a merely `watch` one. Action copy mirrors calculateSpeakingScore's actions for consistency.
+ */
+export const getTryThisNext = (stats: DeliveryAggregates): TryThisNext => {
+    const wpm = num(stats.avgWpm);
+    const pace = decodePace(stats.avgWpm);
+    const pauses = decodePauseRhythm(stats.avgPausesPerMin);
+    const fillers = decodeFillers(stats.avgFillerWordsPerMin);
+    const clarity = decodeClarity(stats.avgClarity);
+
+    const paceAction = wpm > ANALYTICS_THRESHOLDS.FAST_WPM
+        ? 'Give the next key idea a beat of silence.'
+        : pace.label === 'Fast'
+            ? 'Ease the pace at sentence endings.'
+            : 'Add a little more momentum through familiar lines.';
+
+    // Ordered candidates: { metric, driver, action }. First matching the worst tone wins.
+    const candidates = [
+        { metric: pace, driver: 'pace', action: paceAction },
+        { metric: fillers, driver: 'filler words', action: 'When a filler is coming, pause and restart.' },
+        {
+            metric: pauses,
+            driver: 'pause rhythm',
+            action: pauses.label === 'Choppy'
+                ? 'Finish a full phrase before taking the next pause.'
+                : 'Pause once before the takeaway.',
+        },
+        { metric: clarity, driver: 'clear delivery', action: 'Say the main point before the context.' },
+    ];
+
+    const worst = candidates.find(c => c.metric.tone === 'off')
+        ?? candidates.find(c => c.metric.tone === 'watch');
+
+    if (!worst) {
+        return { driver: null, action: 'Keep the pace steady and land the takeaway.' };
+    }
+    return { driver: worst.driver, action: worst.action };
+};

--- a/tests/e2e/analytics-suite.e2e.spec.ts
+++ b/tests/e2e/analytics-suite.e2e.spec.ts
@@ -28,7 +28,7 @@ test.describe('Analytics Suite & Data Matrix', () => {
     // Verify the default analytics story explains why these signals are grouped.
     await expect(page.getByText('Analytics Focus')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Sound Confident', exact: true })).toBeVisible();
-    await expect(page.getByText('Evidence for Sound Confident')).toBeVisible();
+    await expect(page.getByText('Your Sound Confident signals')).toBeVisible();
     await expect(page.getByText(/These cards are selected together because they support the current focus/i)).toBeVisible();
     await expect(page.getByTestId('stat-card-speaking_pace')).toBeVisible();
     await expect(page.getByTestId('stat-card-filler_words_per_min')).toBeVisible();


### PR DESCRIPTION
## PR 2 of tool-coherence — narrative-first analytics

**Principle:** *numbers support coaching; they are not the coaching.* The Sound Confident focus now leads with a plain coaching read and one next action, with raw numbers kept secondary. **Session page untouched** — no new live cards, SpeakSharp Score unchanged.

### What changed
- **`utils/coachingNarrative.ts`** — decodes the aggregates into the agreed vocabulary:
  - Speaking Pace → **Fast / Steady / Slow**
  - Pause Rhythm → **Smooth / Sparse / Choppy**
  - Filler Words → **Low / Noticeable / High**
  - Clear Delivery → **Strong / Developing / Needs focus**
  - `getTryThisNext` → one action from the **strongest driver** (`off` beats `watch`; priority pace → fillers → pauses → clarity), copy mirroring `calculateSpeakingScore`.
- **Cards lead with the decoded label** (tone-colored: good/watch/off); the number drops to secondary detail.
- **"Try this next" callout** above the cards: the action + "Main driver: …".

### Thresholds (centralized + tunable)
Grounded in `ANALYTICS_THRESHOLDS` (pace 130–150; pauses/min **> 12 = Choppy**, matching the score). The remaining cutoffs are explicit constants for Product to tune:
- `PAUSE_RHYTHM_SPARSE_PER_MIN = 3`
- `FILLER_NOTICEABLE_PER_MIN = 3`, `FILLER_HIGH_PER_MIN = 6`
- `CLARITY_STRONG = 80`, `CLARITY_DEVELOPING = 60`

### Tests
- `coachingNarrative.test.ts`: every decode band + `getTryThisNext` priority (off-beats-watch, fast-pace escalation).
- `AnalyticsDashboard.component.test.tsx`: Sound Confident renders decoded labels (Slow / Smooth / Strong) + the "Try this next" action + driver.
- Verified locally: 30 component tests + 9 narrative tests pass; eslint + frontend `tsc` clean.

### Scope / next
PR 2 of the plan (after Pause Rhythm #846). Remaining: ③ carry the active Focus into the live session emphasis (small cue inside the Score, no new card); ④ retire the now-absorbed `SpeakingRateCard` / `ClarityScoreCard` (their copy lives here + in the cards). `PauseMetricsDisplay`/`SpeakingTipsCard` stay until their function is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
