### PR TITLE
ci: read-only migrations preflight (pending-set check, no apply)

### DIFF
--- a/.github/workflows/migrations-preflight.yml
+++ b/.github/workflows/migrations-preflight.yml
@@ -1,0 +1,47 @@
+name: Migrations Preflight (read-only)
+
+# Read-only preflight to establish the PENDING production migration set WITHOUT applying anything.
+# Runs `supabase migration list` (Local vs Remote/applied) and `supabase db push --dry-run` (what
+# WOULD apply). No `--yes`, no `migration repair`, no edge functions, no secrets — nothing is
+# written to production. Use this before dispatching deploy-supabase-migrations.yml to confirm the
+# pending set is exactly the expected migration(s).
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Pending migrations (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: supabase/setup-cli@v2
+        env:
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+        with:
+          version: 2.101.0
+
+      - name: Link to Supabase project
+        working-directory: backend/supabase
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Migration list (read-only) + dry-run (no apply)
+        working-directory: backend/supabase
+        run: |
+          echo "## supabase migration list — Local (repo) vs Remote (applied in prod)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          supabase migration list 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## supabase db push --dry-run — migrations that WOULD apply (NOTHING is applied)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          supabase db push --dry-run 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Read-only preflight (`supabase migration list` + `db push --dry-run`, no `--yes`/repair/edge/secrets) to establish the pending prod migration set before dispatching the real deploy. Nothing is applied. Reusable safety gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)