### PR TITLE
chore(ops): recognize @speaksharp.test + @test.speaksharp.dev as internal test domains

### DIFF
--- a/scripts/db-hygiene-audit.mjs
+++ b/scripts/db-hygiene-audit.mjs
@@ -52,7 +52,10 @@ const countByUser = (rows) => {
   return m;
 };
 
-const TEST_DOMAINS = ['@test.com', '@example.com'];
+// Internal test/QA domains — accounts here are never real users. @speaksharp.test and
+// @test.speaksharp.dev are internal fixtures; recognizing them keeps them out of the
+// "possible real user" bucket so the owner review surface stays the genuine real-domain set.
+const TEST_DOMAINS = ['@test.com', '@example.com', '@speaksharp.test', '@test.speaksharp.dev'];
 const isTestDomain = (e) => TEST_DOMAINS.some(d => e.endsWith(d)) || e.endsWith('@speaksharp.app');
 
 // Email patterns: each is [regex, classification, justification].


### PR DESCRIPTION
One-line classifier refinement: treat `@speaksharp.test` and `@test.speaksharp.dev` as internal test domains so the read-only audit stops flagging ~23 internal fixtures as possible real users. Read-only; no cleanup behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)