### PR TITLE
fix(db): usage_checkpoints.user_id ON DELETE CASCADE (schema hygiene)

### DIFF
--- a/backend/supabase/migrations/20260625120000_usage_checkpoints_user_id_on_delete_cascade.sql
+++ b/backend/supabase/migrations/20260625120000_usage_checkpoints_user_id_on_delete_cascade.sql
@@ -1,0 +1,37 @@
+-- usage_checkpoints.user_id was created inline (20260309 phase2_integration) referencing
+-- auth.users(id) with NO ON DELETE clause, which defaults to NO ACTION (RESTRICT). It is the only
+-- user-owned table whose FK blocks deleting an auth user. usage_checkpoints is dependent user data
+-- (like public.sessions and public.user_profiles, both already ON DELETE CASCADE), so its FK to the
+-- owning user should cascade as well. This aligns the delete semantics with the rest of the
+-- user-owned model:  delete auth user -> profile -> sessions -> usage_checkpoints.
+--
+-- This migration ONLY changes the delete behavior of that one FK. It deletes NO data and preserves
+-- the FK target auth.users(id). The drop is name-agnostic so a non-conventional constraint name
+-- cannot leave the old RESTRICT FK in place alongside the new CASCADE one.
+
+DO $$
+DECLARE
+  v_user_col smallint;
+  v_conname  text;
+BEGIN
+  SELECT attnum INTO v_user_col
+    FROM pg_attribute
+   WHERE attrelid = 'public.usage_checkpoints'::regclass
+     AND attname = 'user_id'
+     AND NOT attisdropped;
+
+  -- Find the single-column foreign key currently backing usage_checkpoints.user_id, by its real name.
+  SELECT conname INTO v_conname
+    FROM pg_constraint
+   WHERE conrelid = 'public.usage_checkpoints'::regclass
+     AND contype = 'f'
+     AND conkey = ARRAY[v_user_col];
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.usage_checkpoints DROP CONSTRAINT %I', v_conname);
+  END IF;
+END $$;
+
+ALTER TABLE public.usage_checkpoints
+  ADD CONSTRAINT usage_checkpoints_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;


### PR DESCRIPTION
`usage_checkpoints.user_id` references `auth.users(id)` with **no ON DELETE clause** (→ NO ACTION/RESTRICT) — the only user-owned table whose FK blocks deleting an auth user. That's why deleting canary accounts with usage rows failed (HTTP 500). It's dependent user data like `sessions`/`user_profiles` (both already CASCADE), so it should cascade too.

- Name-agnostic drop (no leftover RESTRICT FK) + re-add `ON DELETE CASCADE`.
- **Deletes no data**; preserves target `auth.users(id)`.
- Enables the remaining-214 legacy-canary delete via the normal user-delete path + clean future deletes.

Deploy path: migrations-preflight (read-only) → gated `deploy-supabase-migrations` (confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)