### PR TITLE
chore(ops): flip canary ceiling guard to fail-closed (max=1)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,10 +35,10 @@ jobs:
           # prevents overlapping runs, so a fixed email is safe.
           CANARY_EMAIL: canary@speaksharp.app
           # Ceiling guard: at most CANARY_MAX canary-like accounts may exist (reuse, never accumulate).
-          # Warn-only until the legacy canary-<runid> residue is deleted; flip CANARY_ENFORCE to "fail"
-          # afterward so a reappearing stray hard-fails the job.
+          # The legacy canary-<runid> residue has been deleted, so this is now fail-closed: if a stray
+          # canary-* account ever reappears (count > 1), the canary job hard-fails to surface it.
           CANARY_MAX: '1'
-          CANARY_ENFORCE: warn
+          CANARY_ENFORCE: fail
         run: node scripts/provision-canary.mjs
 
       - name: Run Smoke Test


### PR DESCRIPTION
Final step of the canary-residue remediation. The 959 legacy `canary-<runid>` accounts are deleted (auth.users 1445→486, 0 strays, stable canary preserved), so the `CANARY_MAX=1` ceiling is now satisfiable — flip `CANARY_ENFORCE` warn→fail so a reappearing stray hard-fails the canary job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)