### PR TITLE
chore(ops): Phase 1+2 cleanup — normalize 42 + delete 184 (gated, separate guards)

### DIFF
--- a/.github/workflows/db-phase1and2-cleanup.yml
+++ b/.github/workflows/db-phase1and2-cleanup.yml
@@ -1,0 +1,74 @@
+name: DB Phase 1+2 cleanup — normalize 42 + delete 184 (gated)
+
+# PRODUCTION cleanup acting on the EXACT hygiene-audit classification (single source of truth):
+#   Phase 1: classification=NORMALIZE -> subscription_status='free'   (separate guard, expected 42)
+#   Phase 2: classification=DELETE    -> delete auth user by id        (separate guard, expected 184)
+# Never touches KEEP or INVESTIGATE. Phase 2 refuses any Stripe-linked or real-domain row. Fail-closed:
+# exact confirm phrase, dry-run default, both guards must match before ANY write, backup CSV first.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run (guards + backup, no writes) or apply"
+        type: choice
+        options: [dry-run, apply]
+        default: dry-run
+      confirm:
+        description: "Type CLEANUP-NORMALIZE-DELETE to authorize"
+        type: string
+        required: true
+      normalize_expected:
+        description: "Exact NORMALIZE rows expected (Phase 1)"
+        type: string
+        default: "42"
+      delete_expected:
+        description: "Exact DELETE rows expected (Phase 2)"
+        type: string
+        default: "184"
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Phase 1+2 cleanup (gated)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Verify confirm phrase (fail-closed)
+        if: ${{ inputs.confirm != 'CLEANUP-NORMALIZE-DELETE' }}
+        run: |
+          echo "::error::confirm phrase mismatch — aborting without any DB access."
+          exit 1
+
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Run Phase 1+2 cleanup
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NORMALIZE_EXPECTED: ${{ inputs.normalize_expected }}
+          DELETE_EXPECTED: ${{ inputs.delete_expected }}
+          DRY_RUN: ${{ inputs.mode == 'apply' && '0' || '1' }}
+          # Reviewer/CI emails feed the classifier's KEEP set (must match the audit exactly).
+          CANARY_EMAIL: ${{ secrets.CANARY_EMAIL || vars.CANARY_EMAIL }}
+          PRO_TEST_EMAIL: ${{ secrets.PRO_TEST_EMAIL || vars.PRO_TEST_EMAIL }}
+          BASIC_TEST_EMAIL: ${{ secrets.BASIC_TEST_EMAIL || vars.BASIC_TEST_EMAIL }}
+          FREE_TEST_EMAIL: ${{ secrets.FREE_TEST_EMAIL || vars.FREE_TEST_EMAIL }}
+          E2E_PRO_EMAIL: ${{ secrets.E2E_PRO_EMAIL || vars.E2E_PRO_EMAIL }}
+          E2E_FREE_EMAIL: ${{ secrets.E2E_FREE_EMAIL || vars.E2E_FREE_EMAIL }}
+          E2E_BASIC_EMAIL: ${{ secrets.E2E_BASIC_EMAIL || vars.E2E_BASIC_EMAIL }}
+        run: node scripts/db-phase1and2-cleanup.mjs
+
+      - name: Upload affected-rows backup (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-phase1and2-backup
+          path: db-phase1and2-backup.csv
+          retention-days: 30
+          if-no-files-found: ignore

--- a/scripts/db-hygiene-audit.mjs
+++ b/scripts/db-hygiene-audit.mjs
@@ -4,12 +4,15 @@
 // classifies every account KEEP / DELETE / NORMALIZE / INVESTIGATE using the agreed rubric
 // (incl. the audit-found ephemeral patterns and the synthetic-vs-real Stripe distinction).
 // Emits category counts to the job summary and a redacted CSV artifact for owner review.
+//
+// Exports classify/gatherAndClassify so the gated cleanup workflows act on the EXACT same
+// classification (single source of truth). Importing this module does not run the audit.
 
 import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 const url = (process.env.SUPABASE_URL || '').replace(/\/$/, '');
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
-if (!url || !key) { console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'); process.exit(2); }
 const rest = { apikey: key, Authorization: `Bearer ${key}` };
 
 const MAX_ROWS = 100000; // safety cap per table
@@ -21,7 +24,7 @@ const ENV_KEEP = new Set([
   process.env.E2E_BASIC_EMAIL,
 ].filter(Boolean).map(e => e.toLowerCase()));
 
-async function listAuthUsers() {
+export async function listAuthUsers() {
   const users = [];
   for (let page = 1; page <= 1000; page++) {
     const r = await fetch(`${url}/auth/v1/admin/users?page=${page}&per_page=200`, { headers: rest });
@@ -56,7 +59,14 @@ const countByUser = (rows) => {
 // @test.speaksharp.dev are internal fixtures; recognizing them keeps them out of the
 // "possible real user" bucket so the owner review surface stays the genuine real-domain set.
 const TEST_DOMAINS = ['@test.com', '@example.com', '@speaksharp.test', '@test.speaksharp.dev'];
-const isTestDomain = (e) => TEST_DOMAINS.some(d => e.endsWith(d)) || e.endsWith('@speaksharp.app');
+export const isTestDomain = (e) => TEST_DOMAINS.some(d => (e || '').endsWith(d)) || (e || '').endsWith('@speaksharp.app');
+
+export function isRealStripe(profile) {
+  const stripeSub = (profile?.stripe_subscription_id || '').trim();
+  const custId = (profile?.stripe_customer_id || '').trim();
+  const synthetic = stripeSub.startsWith('sub_test_');
+  return Boolean((stripeSub && !synthetic) || (custId && !custId.startsWith('cus_test_')));
+}
 
 // Email patterns: each is [regex, classification, justification].
 const KEEP_PATTERNS = [
@@ -76,14 +86,12 @@ const DELETE_PATTERNS = [
   [/^soak-test@test\.com$/, 'legacy soak-test (renamed to soak-test0)'],
 ];
 
-function classify(email, profile, sessions, usage, issues) {
+export function classify(email, profile, sessions, usage, issues) {
   const e = (email || '').toLowerCase();
   const status = (profile?.subscription_status || '').toLowerCase();
   const stripeSub = (profile?.stripe_subscription_id || '').trim();
-  const custId = (profile?.stripe_customer_id || '').trim();
   const legacyId = (profile?.subscription_id || '').trim();
-  const synthetic = stripeSub.startsWith('sub_test_');
-  const realStripe = (stripeSub && !synthetic) || (custId && !custId.startsWith('cus_test_'));
+  const realStripe = isRealStripe(profile);
 
   if (ENV_KEEP.has(e)) return ['KEEP', 'configured reviewer/CI account (env)'];
   for (const [re, why] of KEEP_PATTERNS) if (re.test(e)) return ['KEEP', why];
@@ -109,6 +117,38 @@ function classify(email, profile, sessions, usage, issues) {
   return ['INVESTIGATE', 'unclassified — manual review'];
 }
 
+// Fetch + classify every auth user. Returns one record per user (single source of truth used by
+// both the audit and the gated cleanup workflows). Read-only.
+export async function gatherAndClassify() {
+  if (!url || !key) { throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'); }
+  const [authUsers, profiles, sessionRows, usageRows, issueRows] = await Promise.all([
+    listAuthUsers(),
+    fetchAll('user_profiles', 'id,subscription_status,stripe_customer_id,stripe_subscription_id,subscription_id'),
+    fetchAll('sessions', 'user_id'),
+    fetchAll('usage_checkpoints', 'user_id'),
+    fetchAll('user_issue_reports', 'user_id'),
+  ]);
+  const profById = new Map(profiles.map(p => [p.id, p]));
+  const sessCount = countByUser(sessionRows);
+  const usageCount = countByUser(usageRows);
+  const issueCount = countByUser(issueRows);
+
+  const records = authUsers.map(u => {
+    const profile = profById.get(u.id) || null;
+    const sessions = sessCount.get(u.id) || 0;
+    const usage = usageCount.get(u.id) || 0;
+    const issues = issueCount.get(u.id) || 0;
+    const [classification, justification] = classify(u.email, profile, sessions, usage, issues);
+    return {
+      id: u.id, email: u.email || '', profile, sessions, usage, issues,
+      classification, justification, realStripe: isRealStripe(profile),
+      realDomain: !isTestDomain((u.email || '').toLowerCase()),
+      created_at: u.created_at, last_sign_in_at: u.last_sign_in_at,
+    };
+  });
+  return { records, totalProfiles: profiles.length };
+}
+
 const redactEmail = (e) => {
   if (!e) return '(no email)';
   if (isTestDomain(e)) return e; // test patterns are safe to show
@@ -118,45 +158,28 @@ const redactEmail = (e) => {
 const csvCell = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`;
 
 async function main() {
-  const [authUsers, profiles, sessionRows, usageRows, issueRows] = await Promise.all([
-    listAuthUsers(),
-    fetchAll('user_profiles', 'id,subscription_status,stripe_customer_id,stripe_subscription_id,subscription_id'),
-    fetchAll('sessions', 'user_id'),
-    fetchAll('usage_checkpoints', 'user_id'),
-    fetchAll('user_issue_reports', 'user_id'),
-  ]);
-
-  const profById = new Map(profiles.map(p => [p.id, p]));
-  const sessCount = countByUser(sessionRows);
-  const usageCount = countByUser(usageRows);
-  const issueCount = countByUser(issueRows);
-
+  const { records, totalProfiles } = await gatherAndClassify();
   const counts = { KEEP: 0, DELETE: 0, NORMALIZE: 0, INVESTIGATE: 0 };
   const csv = ['email_or_pattern,auth_user_id,profile_exists,subscription_status,has_stripe_customer,has_stripe_subscription,stripe_synthetic,has_legacy_subscription_id,session_count,usage_count,issue_report_count,created_at,last_sign_in_at,classification,justification'];
 
-  for (const u of authUsers) {
-    const p = profById.get(u.id) || null;
-    const s = sessCount.get(u.id) || 0;
-    const us = usageCount.get(u.id) || 0;
-    const iss = issueCount.get(u.id) || 0;
-    const [cls, why] = classify(u.email, p, s, us, iss);
-    counts[cls] = (counts[cls] || 0) + 1;
+  for (const rec of records) {
+    counts[rec.classification] = (counts[rec.classification] || 0) + 1;
+    const p = rec.profile;
     const stripeSub = (p?.stripe_subscription_id || '').trim();
     csv.push([
-      redactEmail(u.email), u.id, Boolean(p), p?.subscription_status ?? '',
+      redactEmail(rec.email), rec.id, Boolean(p), p?.subscription_status ?? '',
       Boolean((p?.stripe_customer_id || '').trim()), Boolean(stripeSub), stripeSub.startsWith('sub_test_'),
-      Boolean((p?.subscription_id || '').trim()), s, us, iss,
-      u.created_at ?? '', u.last_sign_in_at ?? '', cls, why,
+      Boolean((p?.subscription_id || '').trim()), rec.sessions, rec.usage, rec.issues,
+      rec.created_at ?? '', rec.last_sign_in_at ?? '', rec.classification, rec.justification,
     ].map(csvCell).join(','));
   }
 
   fs.writeFileSync('db-hygiene-audit.csv', csv.join('\n'));
 
-  const total = authUsers.length;
   const summary = [
     '## Production DB hygiene audit (read-only — nothing was modified)',
     '',
-    `Total auth.users: **${total}** · user_profiles: **${profiles.length}**`,
+    `Total auth.users: **${records.length}** · user_profiles: **${totalProfiles}**`,
     '',
     '| Category | Count |',
     '|---|---:|',
@@ -166,10 +189,14 @@ async function main() {
     `| INVESTIGATE | ${counts.INVESTIGATE} |`,
     '',
     '> Per-account detail (redacted emails, full ids) is in the `db-hygiene-audit` CSV artifact.',
-    '> NORMALIZE = stale status=pro with no Stripe/legacy id (the ~1012). Soak-pro `sub_test_*` ids are synthetic and KEEP, not real-paid.',
+    '> NORMALIZE = stale status=pro with no Stripe/legacy id. Soak-pro `sub_test_*` ids are synthetic and KEEP, not real-paid.',
   ].join('\n');
   console.log(summary);
   if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary + '\n');
 }
 
-main().catch(e => { console.error(e.message || e); process.exit(1); });
+// Only run the audit when executed directly — importing this module must have no side effects.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  if (!url || !key) { console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'); process.exit(2); }
+  main().catch(e => { console.error(e.message || e); process.exit(1); });
+}

--- a/scripts/db-phase1and2-cleanup.mjs
+++ b/scripts/db-phase1and2-cleanup.mjs
@@ -1,0 +1,105 @@
+// Phase 1 (NORMALIZE) + Phase 2 (DELETE) production cleanup. Acts on the EXACT audit classification
+// (imported gatherAndClassify — single source of truth), with SEPARATE fail-closed guards and
+// SEPARATE counts. Dry-run by default. Never touches KEEP or INVESTIGATE rows. Phase 2 additionally
+// refuses to delete any Stripe-linked or real-domain account even if it somehow classified DELETE.
+//
+//   Phase 1: classification == NORMALIZE  -> subscription_status = 'free'   (expected 42)
+//   Phase 2: classification == DELETE     -> delete auth user by id (FK cascade)  (expected 184)
+
+import fs from 'node:fs';
+import { gatherAndClassify } from './db-hygiene-audit.mjs';
+
+const url = (process.env.SUPABASE_URL || '').replace(/\/$/, '');
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const NORM_EXPECTED = Number(process.env.NORMALIZE_EXPECTED || '42');
+const DEL_EXPECTED = Number(process.env.DELETE_EXPECTED || '184');
+const DRY = process.env.DRY_RUN !== '0'; // dry-run unless DRY_RUN=0
+if (!url || !key) { console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'); process.exit(2); }
+const H = { apikey: key, Authorization: `Bearer ${key}` };
+
+const out = [];
+const log = (s = '') => out.push(s);
+function finish(code) {
+  const text = out.join('\n');
+  console.log(text);
+  if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, text + '\n');
+  process.exit(code);
+}
+
+async function patchToFree(ids) {
+  let affected = 0; const now = new Date().toISOString();
+  for (let i = 0; i < ids.length; i += 100) {
+    const inList = `(${ids.slice(i, i + 100).join(',')})`;
+    const r = await fetch(`${url}/rest/v1/user_profiles?id=in.${inList}&subscription_status=eq.pro`, {
+      method: 'PATCH',
+      headers: { ...H, 'Content-Type': 'application/json', Prefer: 'count=exact,return=minimal' },
+      body: JSON.stringify({ subscription_status: 'free', updated_at: now }),
+    });
+    if (!r.ok) throw new Error(`PATCH HTTP ${r.status}: ${(await r.text()).slice(0, 200)}`);
+    affected += Number(r.headers.get('content-range')?.split('/')?.[1] ?? '0');
+  }
+  return affected;
+}
+
+async function deleteUsers(ids) {
+  let deleted = 0, failed = 0;
+  for (const id of ids) {
+    const r = await fetch(`${url}/auth/v1/admin/users/${id}`, { method: 'DELETE', headers: H });
+    if (r.ok) deleted++; else { failed++; if (failed <= 5) console.error(`  delete ${id} HTTP ${r.status}`); }
+  }
+  return { deleted, failed };
+}
+
+async function main() {
+  const { records } = await gatherAndClassify();
+  const norm = records.filter(r => r.classification === 'NORMALIZE');
+  const del = records.filter(r => r.classification === 'DELETE');
+
+  // Backup the affected ids first (both phases), written in dry-run and apply.
+  const backup = ['phase,id,classification,subscription_status,session_count,usage_count', ...records
+    .filter(r => r.classification === 'NORMALIZE' || r.classification === 'DELETE')
+    .map(r => `${r.classification === 'NORMALIZE' ? 1 : 2},${r.id},${r.classification},${r.profile?.subscription_status ?? ''},${r.sessions},${r.usage}`)];
+  fs.writeFileSync('db-phase1and2-backup.csv', backup.join('\n'));
+
+  log('## Phase 1 (NORMALIZE) + Phase 2 (DELETE) — gated cleanup');
+  log();
+  log(`Mode: **${DRY ? 'DRY-RUN (no writes)' : 'APPLY'}**`);
+  log();
+
+  // ---- Phase 1 guard (NORMALIZE) ----
+  log('### Phase 1 — NORMALIZE stale status=pro → free');
+  log(`- Target (classification=NORMALIZE): **${norm.length}** (expected ${NORM_EXPECTED})`);
+  if (norm.length !== NORM_EXPECTED) { log(); log(`**ABORT** — NORMALIZE count ${norm.length} ≠ ${NORM_EXPECTED}. No writes.`); finish(1); }
+
+  // ---- Phase 2 guard + safety (DELETE) ----
+  log('### Phase 2 — DELETE residue');
+  log(`- Target (classification=DELETE): **${del.length}** (expected ${DEL_EXPECTED})`);
+  const badStripe = del.filter(r => r.realStripe);
+  const badDomain = del.filter(r => r.realDomain);
+  if (badStripe.length || badDomain.length) {
+    log(); log(`**ABORT** — DELETE set contains ${badStripe.length} Stripe-linked and ${badDomain.length} real-domain rows. No writes.`);
+    finish(1);
+  }
+  log('- Safety: 0 Stripe-linked, 0 real-domain in DELETE set ✅');
+  if (del.length !== DEL_EXPECTED) { log(); log(`**ABORT** — DELETE count ${del.length} ≠ ${DEL_EXPECTED}. No writes.`); finish(1); }
+
+  log(); log(`- Backup written: db-phase1and2-backup.csv (${norm.length + del.length} rows)`);
+
+  if (DRY) {
+    log(); log(`**DRY RUN** — both guards + Phase-2 safety passed. Would normalize ${norm.length} and delete ${del.length}. No writes performed.`);
+    finish(0);
+  }
+
+  // ---- Apply Phase 1 then Phase 2 (ids fixed from the single classification pass above) ----
+  const normAffected = await patchToFree(norm.map(r => r.id));
+  log(); log(`- Phase 1: normalized **${normAffected}** / ${norm.length} → free`);
+  const { deleted, failed } = await deleteUsers(del.map(r => r.id));
+  log(`- Phase 2: deleted **${deleted}** / ${del.length} (failed: ${failed})`);
+
+  const ok = normAffected === NORM_EXPECTED && deleted === DEL_EXPECTED && failed === 0;
+  log();
+  log(`**${ok ? 'DONE' : 'WARNING'}** — normalize ${normAffected}/${NORM_EXPECTED}, delete ${deleted}/${DEL_EXPECTED} (failed ${failed}).`);
+  finish(ok ? 0 : 1);
+}
+
+main().catch(e => { console.error(e.message || e); process.exit(1); });


### PR DESCRIPTION
Acts on the **exact audit classification** (refactored `db-hygiene-audit.mjs` to export its classifier; importing it has no side effects).

- **Phase 1:** classification=NORMALIZE → `subscription_status='free'` (separate guard, expected **42**).
- **Phase 2:** classification=DELETE → delete auth user by id, FK cascade (separate guard, expected **184**).
- Never touches KEEP/INVESTIGATE; Phase 2 refuses any Stripe-linked or real-domain row; fail-closed confirm; dry-run default; both guards must match before any write; backup CSV first.

Verified: `node --check` clean; import side-effect-free; replayed on latest audit CSV → NORMALIZE 42 (all stale-pro), DELETE 184 (0 real-domain, 0 Stripe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)