### PR TITLE
chore(ops): move PROTECTED_IDS (held gmail) to shared module for durable enforcement

### DIFF
--- a/scripts/db-delete-frozen-promo.mjs
+++ b/scripts/db-delete-frozen-promo.mjs
@@ -7,7 +7,7 @@
 // never a Stripe-linked / real-domain / issue-report account. Dry-run default; backup CSV first.
 
 import fs from 'node:fs';
-import { listAuthUsers, isRealStripe, isTestDomain } from './db-hygiene-audit.mjs';
+import { listAuthUsers, isRealStripe, isTestDomain, PROTECTED_IDS } from './db-hygiene-audit.mjs';
 
 const url = (process.env.SUPABASE_URL || '').replace(/\/$/, '');
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -24,9 +24,8 @@ if (!url || !key) { console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE
 if (!FROZEN_FILE) { console.error('Missing FROZEN_IDS_FILE'); process.exit(2); }
 const H = { apikey: key, Authorization: `Bearer ${key}` };
 const STABLE_CANARY = 'canary@speaksharp.app';
-// Never deletable by any cleanup path, regardless of flags — the held real/probable-user accounts.
-// (gmail account: real domain + Stripe customer + recent sign-in; owner instruction to preserve.)
-const PROTECTED_IDS = new Set(['8181e7b6-c000-422b-937a-d97d1d6a08fb']);
+// PROTECTED_IDS (the held accounts, e.g. gmail) is imported from the shared module and enforced
+// UNCONDITIONALLY below, regardless of any flag.
 const MAX_ROWS = 100000;
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 const out = [];

--- a/scripts/db-hygiene-audit.mjs
+++ b/scripts/db-hygiene-audit.mjs
@@ -61,6 +61,14 @@ const countByUser = (rows) => {
 const TEST_DOMAINS = ['@test.com', '@example.com', '@speaksharp.test', '@test.speaksharp.dev'];
 export const isTestDomain = (e) => TEST_DOMAINS.some(d => (e || '').endsWith(d)) || (e || '').endsWith('@speaksharp.app');
 
+// Accounts that must NEVER be deleted by a cleanup script — the held real/probable-user accounts.
+// Shared so the protection travels to any cleanup path that imports it; each such script MUST check
+// this set and abort on a match. This guards only scripts that import + enforce it; changing the set
+// (or bypassing it) requires explicit owner reauthorization.
+export const PROTECTED_IDS = new Set([
+  '8181e7b6-c000-422b-937a-d97d1d6a08fb', // gmail — real domain + Stripe customer + recent sign-in; owner-held
+]);
+
 export function isRealStripe(profile) {
   const stripeSub = (profile?.stripe_subscription_id || '').trim();
   const custId = (profile?.stripe_customer_id || '').trim();


### PR DESCRIPTION
Backs the corrected wording: gmail's protection is real only for scripts that import + enforce the guard. `PROTECTED_IDS` now lives in `db-hygiene-audit.mjs` (exported) and is imported + enforced unconditionally by `db-delete-frozen-promo.mjs`. No behavior change; gmail stays held. Changing/bypassing requires explicit reauthorization.

Verified: `node --check` clean; PROTECTED_IDS exported, contains the gmail id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)