### PR TITLE
fix(live-tests): reuse stable creds instead of minting per-run accounts (stops DB drift)

### DIFF
--- a/scripts/db-hygiene-audit.mjs
+++ b/scripts/db-hygiene-audit.mjs
@@ -80,6 +80,11 @@ export function isRealStripe(profile) {
 const KEEP_PATTERNS = [
   [/^canary@speaksharp\.app$/, 'canary smoke account (provision-canary)'],
   [/^soak-test\d+@test\.com$/, 'soak registry (setup-test-users)'],
+  // Stable reusable live-test accounts (the `-reuse@speaksharp.app` convention) — created once and
+  // reused every run instead of minting a new per-run user. KEEP must be checked before the
+  // tester-b-* / private-decode-ab-* / private-longform-* DELETE patterns so these are not treated
+  // as residue.
+  [/-reuse@speaksharp\.app$/, 'stable reusable live-test account (reuse, no per-run minting)'],
 ];
 const DELETE_PATTERNS = [
   [/^first-time-tester-.+@speaksharp\.app$/, 'first-time-tester residue (no cleanup, accumulates)'],

--- a/tests/live/account-wide-recording-mutex.live.spec.ts
+++ b/tests/live/account-wide-recording-mutex.live.spec.ts
@@ -36,8 +36,10 @@ test.describe('Account-wide recording mutex @live', () => {
     const account = USE_EXISTING_ACCOUNT
       ? { email: ACCOUNT_EMAIL!, password: ACCOUNT_PASSWORD!, mode: 'existing' as const }
       : {
-        email: `account-mutex-${Date.now()}@speaksharp.app`,
-        password: `SpeakSharpMutex-${Date.now()}!Aa9`,
+        // STABLE reusable fallback account (when no env reviewer creds are configured) — fixed, never
+        // a per-run mint, so it cannot accumulate as account-mutex-* residue.
+        email: 'account-mutex-reuse@speaksharp.app',
+        password: process.env.ACCOUNT_MUTEX_REUSE_PASSWORD ?? 'SpeakSharpMutex-Reuse!Aa9',
         mode: 'fresh' as const,
       };
 
@@ -146,7 +148,9 @@ async function signUp(page: Page, email: string, password: string) {
   await page.getByTestId('email-input').fill(email);
   await page.getByTestId('password-input').fill(password);
   await page.getByTestId('sign-up-submit').click();
-  await page.waitForURL(/\/session/, { timeout: 60_000 });
+  // Idempotent: if the stable reusable account already exists, sign in instead (reuse, never accumulate).
+  if (await page.waitForURL(/\/session/, { timeout: 30_000 }).then(() => true).catch(() => false)) return;
+  await signIn(page, email, password);
 }
 
 async function signIn(page: Page, email: string, password: string) {

--- a/tests/live/first-time-tester-private-trial.live.spec.ts
+++ b/tests/live/first-time-tester-private-trial.live.spec.ts
@@ -1,8 +1,31 @@
 import { test, expect, type Page } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
 import { AUDIO_ARGS, collectBenchmarkPreconditionSnapshot, selectBenchmarkMode, waitForBenchmarkSaveCandidate } from './helpers/benchmark-utils';
 import { FILLER_CONV_01_AUDIO } from './helpers/audio-fixtures';
 
 const BASE_URL = process.env.BASE_URL;
+
+// This spec MUST mint a fresh account (it tests the first-time experience), so — unlike the reuse
+// specs — it cleans up after itself so first-time-tester-* never accumulates. Requires the live
+// service-role key (already provided to the live workflows).
+const cleanupAdmin = (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY)
+  ? createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY, { auth: { autoRefreshToken: false, persistSession: false } })
+  : null;
+
+async function deleteTesterByEmail(email: string): Promise<void> {
+  if (!cleanupAdmin || !email) return;
+  try {
+    for (let pageNum = 1; pageNum <= 50; pageNum++) {
+      const { data } = await cleanupAdmin.auth.admin.listUsers({ page: pageNum, perPage: 200 });
+      const users = data?.users ?? [];
+      const match = users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+      if (match) { await cleanupAdmin.auth.admin.deleteUser(match.id); return; }
+      if (users.length < 200) return;
+    }
+  } catch (err) {
+    console.warn(`FIRST_TIME_TESTER_CLEANUP_WARN could not delete ${email}: ${(err as Error)?.message ?? err}`);
+  }
+}
 
 test.use({
   permissions: ['microphone'],
@@ -18,6 +41,15 @@ test.use({
 });
 
 test.describe('First-time tester Private sample path @live', () => {
+  // Same-run cleanup: delete whatever fresh account this run created, pass or fail (never accumulate).
+  let createdFirstTimeEmail: string | null = null;
+  test.afterEach(async () => {
+    if (createdFirstTimeEmail) {
+      await deleteTesterByEmail(createdFirstTimeEmail);
+      createdFirstTimeEmail = null;
+    }
+  });
+
   test('new tester signs up Browser-first, intentionally starts Private sample, records, saves, and keeps Browser fallback', async ({ page }) => {
     test.skip(!BASE_URL, 'BASE_URL is required.');
     test.setTimeout(360_000);
@@ -78,6 +110,7 @@ test.describe('First-time tester Private sample path @live', () => {
     const unique = `${Date.now()}-${process.env.GITHUB_RUN_ID ?? 'local'}`;
     const email = `first-time-tester-${unique}@speaksharp.app`;
     const password = `SpeakSharpSample-${unique}!`;
+    createdFirstTimeEmail = email; // register for afterEach cleanup so it never accumulates
 
     await test.step('Create a fresh tester account with Browser-first and Private sample copy visible', async () => {
       console.log('FIRST_TIME_TESTER_STEP signup_start');

--- a/tests/live/private-decode-params-ab.live.spec.ts
+++ b/tests/live/private-decode-params-ab.live.spec.ts
@@ -184,19 +184,28 @@ async function enablePrivateProofHooks(page: Page, decodeOptions: Record<string,
 }
 
 function makeTesterAccount(label: string) {
-  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}-${label}`;
+  // STABLE reusable account per variant — never mints a per-run user (which accumulated as
+  // private-decode-ab-* residue). Pro/trial state is mocked client-side, so no DB provisioning.
   return {
-    email: `private-decode-ab-${unique}@speaksharp.app`,
-    password: `SpeakSharpDecodeAb-${unique}!`,
+    email: `private-decode-ab-${label}-reuse@speaksharp.app`,
+    password: process.env.PRIVATE_DECODE_AB_REUSE_PASSWORD ?? 'SpeakSharpDecodeAb-Reuse!Aa9',
   };
 }
 
+// Idempotent: create the stable account on first run, sign in on every run after. Reuse, never accumulate.
 async function signUp(page: Page, accountEmail: string, accountPassword: string) {
   await page.goto('/auth/signup');
   await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
   await page.getByTestId('email-input').fill(accountEmail);
   await page.getByTestId('password-input').fill(accountPassword);
   await page.getByTestId('sign-up-submit').click();
+  if (await page.waitForURL(/\/session/, { timeout: 15_000 }).then(() => true).catch(() => false)) return;
+  await page.goto('/auth/signin');
+  await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
+  await page.getByTestId('email-input').fill(accountEmail);
+  await page.getByTestId('password-input').fill(accountPassword);
+  await page.getByTestId('sign-in-submit').click();
+  await expect(page).toHaveURL(/\/session|\/analytics/, { timeout: 30_000 });
 }
 
 async function readTranscriptText(page: Page) {

--- a/tests/live/private-longform-timing.live.spec.ts
+++ b/tests/live/private-longform-timing.live.spec.ts
@@ -156,19 +156,28 @@ async function enablePrivateLiveHooks(page: Page) {
 }
 
 function makeTesterAccount() {
-  const unique = `${Date.now()}-${process.env.GITHUB_RUN_ID ?? 'local'}`;
+  // STABLE reusable account — never mints a per-run user (which accumulated as private-longform-*
+  // residue). Pro/trial state is mocked client-side, so no DB provisioning.
   return {
-    email: `private-longform-${unique}@speaksharp.app`,
-    password: `SpeakSharpLongform-${unique}!`,
+    email: `private-longform-reuse@speaksharp.app`,
+    password: process.env.PRIVATE_LONGFORM_REUSE_PASSWORD ?? 'SpeakSharpLongform-Reuse!Aa9',
   };
 }
 
+// Idempotent: create the stable account on first run, sign in on every run after. Reuse, never accumulate.
 async function signUp(page: Page, accountEmail: string, accountPassword: string) {
   await page.goto('/auth/signup');
   await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
   await page.getByTestId('email-input').fill(accountEmail);
   await page.getByTestId('password-input').fill(accountPassword);
   await page.getByTestId('sign-up-submit').click();
+  if (await page.waitForURL(/\/session/, { timeout: 15_000 }).then(() => true).catch(() => false)) return;
+  await page.goto('/auth/signin');
+  await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
+  await page.getByTestId('email-input').fill(accountEmail);
+  await page.getByTestId('password-input').fill(accountPassword);
+  await page.getByTestId('sign-in-submit').click();
+  await expect(page).toHaveURL(/\/session|\/analytics/, { timeout: 30_000 });
 }
 
 async function waitForNonPlaceholderTranscript(page: Page) {

--- a/tests/live/tester-b-private-native-stt.live.spec.ts
+++ b/tests/live/tester-b-private-native-stt.live.spec.ts
@@ -111,19 +111,31 @@ async function enableNoCostTesterHooks(page: Page, options: { enablePrivate?: bo
 }
 
 function makeTesterAccount(label: SttMode) {
-  const unique = `${Date.now()}-${process.env.GITHUB_RUN_ID ?? 'local'}`;
+  // STABLE reusable account per mode — never mints a per-run user (which accumulated as tester-b-*
+  // residue). The Pro/trial state is mocked client-side via __E2E_DEPS__, so the account only needs
+  // to exist and sign in; no DB provisioning required.
   return {
-    email: `tester-b-${label}-${unique}@speaksharp.app`,
-    password: `SpeakSharpTesterB-${unique}!`,
+    email: `tester-b-${label}-reuse@speaksharp.app`,
+    password: process.env.TESTER_B_REUSE_PASSWORD ?? 'SpeakSharpTesterB-Reuse!Aa9',
   };
 }
 
+// Idempotent: create the stable account on first ever run, sign in on every run after. Reuse, never
+// accumulate. (Function name kept for its two call sites.)
 async function signUp(page: Page, accountEmail: string, accountPassword: string) {
   await page.goto('/auth/signup');
   await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
   await page.getByTestId('email-input').fill(accountEmail);
   await page.getByTestId('password-input').fill(accountPassword);
   await page.getByTestId('sign-up-submit').click();
+  if (await page.waitForURL(/\/session/, { timeout: 15_000 }).then(() => true).catch(() => false)) return;
+  // Account already exists (reused) → sign in with the same credentials.
+  await page.goto('/auth/signin');
+  await expect(page.getByTestId('auth-form')).toBeVisible({ timeout: 20_000 });
+  await page.getByTestId('email-input').fill(accountEmail);
+  await page.getByTestId('password-input').fill(accountPassword);
+  await page.getByTestId('sign-in-submit').click();
+  await expect(page).toHaveURL(/\/session|\/analytics/, { timeout: 30_000 });
 }
 
 async function preparePrivateModelIfPrompted(page: Page) {


### PR DESCRIPTION
Root cause of recurring `auth.users` drift: 5 live specs minted a unique account every run with no cleanup. Per owner policy: **reuse** stable accounts (Pro state is mocked client-side, so the account only needs to exist) for tester-b / private-decode-ab / private-longform / account-mutex; **create-and-delete** (afterEach admin cleanup) only for first-time-tester (genuinely tests first-time UX). Classifier KEEPs the `-reuse@speaksharp.app` convention so the stable accounts aren't treated as residue.

Validation: typecheck (tsconfig.e2e.json) + lint clean; classifier unit-checked. Full behavioral validation needs one live benchmark run + before/after audit (expected persistent Δ = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)