### PR TITLE
fix(live-tests): pass service-role key so first-time-tester afterEach cleanup works

### DIFF
--- a/.github/workflows/live-release-matrix.yml
+++ b/.github/workflows/live-release-matrix.yml
@@ -263,6 +263,10 @@ jobs:
           VITE_USE_LIVE_DB: 'true'
           VITE_SKIP_MSW: 'true'
           BASE_URL: https://speaksharp-public.vercel.app/
+          # Required so the spec's afterEach can delete the fresh first-time account it mints
+          # (otherwise it accumulates as first-time-tester-* residue).
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: pnpm exec playwright test tests/live/first-time-tester-private-trial.live.spec.ts --config=playwright.live.config.ts --project=live-stt-chromium --reporter=list --workers=1
 
       - name: Upload First-Time Tester Private Trial Artifacts

--- a/tests/live/first-time-tester-private-trial.live.spec.ts
+++ b/tests/live/first-time-tester-private-trial.live.spec.ts
@@ -13,7 +13,11 @@ const cleanupAdmin = (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_R
   : null;
 
 async function deleteTesterByEmail(email: string): Promise<void> {
-  if (!cleanupAdmin || !email) return;
+  if (!email) return;
+  if (!cleanupAdmin) {
+    console.warn(`FIRST_TIME_TESTER_CLEANUP_SKIPPED no SUPABASE_SERVICE_ROLE_KEY in env — ${email} will leak as residue`);
+    return;
+  }
   try {
     for (let pageNum = 1; pageNum <= 50; pageNum++) {
       const { data } = await cleanupAdmin.auth.admin.listUsers({ page: pageNum, perPage: 200 });


### PR DESCRIPTION
Behavioral validation of #868 caught it: the first-time-tester job lacked `SUPABASE_SERVICE_ROLE_KEY`, so the afterEach admin cleanup was a silent no-op → the fresh account leaked (audit Δ=+1). Adds the key to the job env + makes the cleanup log loudly when the key is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)