### PR TITLE
docs(release): split tester instructions into tester guide + internal protocol

### DIFF
--- a/product_release/INTERNAL_TEST_PROTOCOL.md
+++ b/product_release/INTERNAL_TEST_PROTOCOL.md
@@ -1,0 +1,82 @@
+# Internal Test Protocol — Soft Release (operators / dev / test agents)
+
+**Last updated:** 2026-06-26
+**Audience:** operators, dev, and test agents only. **Not for testers.**
+The tester-facing guide is **`SOFT_RELEASE_TESTER_INSTRUCTIONS.md`** — keep all technical
+detail (flags, model variants, telemetry, evidence, acceptance criteria) out of that file.
+
+> **Current gate/run status is NOT recorded here.** Workflow posture, run IDs, and the
+> signoff SHA live only in **`RELEASE_STATUS.md`** (SSOT). Do not copy changing run IDs here.
+
+---
+
+## Release posture
+
+- **Controlled private beta / early-access — non-payment.** Payments are hidden
+  (`stripeKeyClass="test"`). Not broad public launch; not paid public.
+- Live paid checkout is a separate **Ops config cutover** (live Stripe key swap), not a code
+  blocker for this beta. See `RELEASE_CLOSEOUT_LEDGER.md` §D and `ROADMAP.operational.md`.
+- **Final pre-invite check:** re-run `gate=all` on the exact signoff SHA and confirm green
+  (Final-SHA freshness — every merge to `main` resets the signoff clock). Record the run in
+  `RELEASE_STATUS.md`.
+
+---
+
+## Pre-invite operator checklist
+
+- Share only the production Vercel URL with human testers: `https://speaksharp-public.vercel.app`.
+- **Never** share `127.0.0.1:5173` with human testers. That port is mocked E2E/test mode only.
+- If a local rehearsal is required, use `pnpm dev` and `127.0.0.1:5174`; do **not** use `pnpm dev:test`.
+- Do not generate or send tester codes. Free standard-mode access is automatic for new accounts.
+- Confirm Vercel production does **not** set `VITE_TEST_MODE` or other E2E/test flags before sending invites.
+- Confirm sample fields appear on new profiles: `private_sample_limit_seconds`,
+  `private_sample_seconds_used`, and that no legacy timestamp grants paid access.
+- Keep the tester path standard-mode-first with one intentional Private sample. Cloud STT is a
+  paid Early Access feature and is **not** part of free-account sample testing.
+
+---
+
+## Entitlement / scope rules
+
+- **Free-path tester scope** must prove: standard (Browser) transcription, the one Private
+  sample, and that Cloud is unavailable without paid entitlement. Use a known Free account with
+  the sample in both unused and used states when testing both sides.
+- **Pro/admin/dev Cloud scope** (only if explicitly included): must prove Cloud recording,
+  transcript, save/history/detail, analytics, and PDF export. Do **not** ask automatic-trial
+  testers to validate Cloud.
+- Effective paid Pro requires a real `stripe_subscription_id` — DB `subscription_status='pro'`
+  alone is not effective paid Pro. Verify the subscription id, not the flag.
+
+---
+
+## Per-tester acceptance criteria (what a "successful session" means)
+
+- **Save/history/detail:** after stopping, the session must persist to History and re-open to
+  the saved analytics/session detail. A transcript without persisted history is **not** a
+  successful session.
+- **Custom words:** if a tester adds a custom word, they must say it during recording; verify
+  the analytics count after save.
+- **PDF export:** the exported file must contain session metadata, transcript, transcription
+  mode, and the analytics summary (Free and Pro exports retain the large SpeakSharp watermark).
+- **Private sample:** one-time on-device model setup; first words can take ~5s on CPU/WASM; the
+  sample is short and saves automatically when it ends.
+
+---
+
+## Browser-support wording
+
+- Chrome is recommended. Browser (standard) transcription uses the browser's built-in speech
+  recognition; availability and accuracy vary by browser.
+- Do **not** claim Edge support unless an Edge-specific proof has passed start, transcript,
+  save, history/detail, and analytics. Until then, use "Chrome recommended" wording.
+
+---
+
+## Automated first-time-tester proof (run before sending invites)
+
+- Run `.github/workflows/live-release-matrix.yml` with the first-time tester / sample suite.
+  It clears browser model storage, creates a fresh account, prepares Private STT, records,
+  stops, and verifies save/history like a first-time tester.
+- This suite owns its own cleanup (fresh account is deleted in `afterEach`). The reusable
+  live-test accounts (`*-reuse@speaksharp.app`) are intentional and must **not** be deleted by
+  hygiene tooling. Confirm persistent `auth.users` Δ = 0 around any live run.

--- a/product_release/RELEASE_STATUS.md
+++ b/product_release/RELEASE_STATUS.md
@@ -62,7 +62,7 @@ If this file conflicts with older files in `product_release/archive/`, this file
 
 ## Tester Scope
 
-Use `SOFT_RELEASE_TESTER_INSTRUCTIONS.md` for human tester copy. The tester path is:
+Send testers the plain-language `SOFT_RELEASE_TESTER_INSTRUCTIONS.md`; operators run the validation per `INTERNAL_TEST_PROTOCOL.md`. The tester path is:
 
 1. Fresh account starts with free Browser transcription.
 2. Private sample model download/setup if prompted.

--- a/product_release/ROADMAP.operational.md
+++ b/product_release/ROADMAP.operational.md
@@ -46,7 +46,7 @@ This document tracks identified risks and their impact on the 12-hour launch win
 5. **Canary Maintenance**: Keep GitHub canary and soak green after deploys; record changing run IDs only in `RELEASE_STATUS.md`.
 6. **Benchmark Workflow Boundary**: Keep user-facing benchmark claims limited to engines with current benchmark evidence. Native Browser STT is not a corpus/WER release benchmark.
 7. **Usage Edge CORS**: Verify `check-usage-limit` returns request-aware CORS headers for allowed production origins after Edge deploys.
-8. **Soft Release Tester Setup**: Use `SOFT_RELEASE_TESTER_INSTRUCTIONS.md`; ask testers to create a fresh account; Browser is free and the Private sample is server-backed.
+8. **Soft Release Tester Setup**: Operators follow `INTERNAL_TEST_PROTOCOL.md` (environment rules, entitlement/scope checks, acceptance criteria, the first-time-tester proof); send testers the plain-language `SOFT_RELEASE_TESTER_INSTRUCTIONS.md`. Testers create a fresh account; standard (Browser) mode is free and the Private sample is server-backed.
 9. **Production Env Flag Check**: Confirm Vercel production does not set `VITE_TEST_MODE` or E2E/test flags before sending tester invites.
 10. **Private STT CPU-First Validation**: Ask testers to start with Private STT, then verify live transcript, analytics, save/history/detail, and cached second start where possible.
 11. **Private STT WebGPU Validation**: Separately validate the explicit WebGPU/WhisperTurbo accelerated path on supported hardware. This is release evidence for acceleration, not the launch-critical first-use path.

--- a/product_release/SOFT_RELEASE_TESTER_INSTRUCTIONS.md
+++ b/product_release/SOFT_RELEASE_TESTER_INSTRUCTIONS.md
@@ -1,11 +1,28 @@
-# Soft Release Tester Instructions
+# SpeakSharp — Beta Tester Guide
 
 **Last updated:** 2026-06-26
-**Release type:** Controlled private beta / early-access — **non-payment** (payments hidden, `stripeKeyClass="test"`). Not broad public launch; not paid public.
-**Tester count:** Start with 5 testers, then expand only after the first round is clean.
-**Posture note:** Re-dispatch `gate=all` on the exact final signoff SHA and confirm green (Final-SHA freshness) before sending invites.
 
-## Beta Invitation (copy — fill `[Name]` / `[insert link]`)
+This is the guide you send to testers. It is written for someone who has never seen the
+code. Keep it free of technical detail.
+
+> **Operators / dev / test:** setup, environment rules, entitlement checks, and the
+> automated first-time-tester proof now live in **`INTERNAL_TEST_PROTOCOL.md`**. Current
+> gate/run status lives in **`RELEASE_STATUS.md`**. Do not put that content back here.
+
+---
+
+## What is SpeakSharp?
+
+SpeakSharp is a speaking-practice coach. You record a short practice session, see a
+transcript of what you said, and get feedback on things like filler words ("um", "like"),
+pacing, and pauses — so you can improve one thing at a time.
+
+This is a small private beta. It is **free** for you, there is nothing to pay, and you do
+not need a card. Please try one short session and send a few sentences of honest feedback.
+
+---
+
+## Beta invitation copy (fill `[Name]` / `[insert link]`)
 
 **Email:**
 
@@ -18,17 +35,17 @@ The goal of this beta is simple: confirm that real users can complete the core l
 1. Sign up.
 2. Start a short practice session.
 3. Record for 1–3 minutes.
-4. Review the transcript and SpeakSharp Score.
+4. Review the transcript and your results.
 5. Save the session.
-6. Check the feedback and tell me what felt useful, confusing, or missing.
+6. Tell me what felt useful, confusing, or missing.
 
 A few notes before you try it:
-- Browser transcription is the easiest way to start.
-- Private transcription runs locally in the browser and may take longer depending on your device.
-- Feedback is directional; it's meant to help you improve one thing at a time, not grade you perfectly.
-- If something feels off, unclear, or broken, please use the Report Issue option or send me a note.
+- The standard recording mode is the easiest way to start, and works best in Chrome.
+- There is also a private mode that runs entirely on your own device; it can take a few seconds to get ready the first time.
+- Feedback is directional — it's meant to help you improve one thing at a time, not grade you perfectly.
+- If something feels off, unclear, or broken, please use Report Issue or send me a note.
 
-If you're willing to try it, I'd appreciate one short session and a few sentences of feedback on:
+If you're willing to try it, I'd appreciate one short session and a few sentences on:
 - Was it obvious what to do next?
 - Did the transcript feel trustworthy enough?
 - Did the feedback help you identify one thing to improve?
@@ -43,67 +60,55 @@ Akin
 **Short text message:**
 
 ```text
-I'm opening a small private beta for SpeakSharp, a speaking-practice coach I've been building. It lets you record a short practice session, review your transcript, and get feedback on clarity, filler words, pacing, pauses, and delivery.
+I'm opening a small private beta for SpeakSharp, a speaking-practice coach I've been building. You record a short practice session, see your transcript, and get feedback on filler words, pacing, and pauses.
 
-Would you be willing to try one 1–3 minute practice session and send me honest feedback? I'm mainly looking for whether the flow is clear, whether the feedback feels useful, and what feels confusing or missing.
+Would you try one 1–3 minute session and send honest feedback? I mainly want to know if the flow is clear, if the feedback feels useful, and what's confusing or missing.
 
 Beta link: [insert link]
 ```
 
-> No paid/checkout language — payments are hidden for this beta. Add paid copy only after the live Stripe Ops cutover.
+---
 
-## Share With Each Tester
+## Getting started (about 2 minutes)
 
-```text
-I'm running a small soft release test of SpeakSharp.
+1. Open the link: **[insert link]** (Chrome works best.)
+2. Create an account with your email and a password.
+3. That's it — you're on the free plan. Nothing to buy.
 
-Link: https://speaksharp-public.vercel.app
+## Record your first session
 
-Setup:
-1. Create a new account with your own email and password.
+1. Click **Start** / **Record**.
+2. Speak for **1–3 minutes** about anything — a quick pitch, a story, or answering
+   "tell me about yourself." On purpose, drop in a few "um"s and "like"s so you can see how
+   they're caught.
+3. Click **Stop**. You'll see your **transcript** and your **results** — feedback on filler
+   words, pace, and pauses.
+4. **Save** the session, then open it again from **History** to confirm it's there.
 
-Your new account starts free with Browser transcription. You also get one short Private transcription sample so you can compare local transcription before upgrading. Cloud STT is a paid Early Access feature.
+## A few extra things to try (optional)
 
-What to test:
-1. Start with Browser transcription first so you can feel the instant record -> transcript -> save loop.
-2. Record a 1-2 minute speaking session. Please include a few deliberate filler words such as "um", "uh", and "like".
-3. Stop and review your analytics.
-4. Confirm the session appears in History and opens to the saved analytics/session detail.
-5. Export a PDF from the saved session detail and confirm it includes the transcript and analytics summary.
-6. Open Custom Words, add a word you plan to say, record a short sentence using that word, and confirm it is counted in the analytics.
-7. Try the Private sample when you are ready. Click "Set Up" or "Download Private Model" if prompted. This is a one-time private model setup in your browser; it runs on your device, so first words can take about 5 seconds to appear. The Private sample is short and saves automatically when it ends.
+- **Download the PDF summary** of a saved session and see if it looks right.
+- **Add a custom word** (a name or term you'll use), say it in a recording, and check it's
+  counted in your results.
+- **Try Private mode** — it runs entirely on your own device, so your audio never leaves
+  your computer. The first time, it takes a few seconds to get ready.
 
-Known limitations:
-- Browser transcription uses your browser's built-in speech recognition. Chrome is recommended. Availability and accuracy vary by browser.
-- Cloud STT is a paid Early Access feature.
-- User-facing baseline signup is Free. Paid Basic is reserved for a future product decision and should not appear in the tester path.
+## If something doesn't work
 
-Please report:
-1. Did signup and Browser transcription work?
-2. Did the Private setup and Start Recording flow work without getting stuck?
-3. Did transcript text appear while speaking?
-4. Were filler words detected accurately enough?
-5. Did your custom word appear in the analytics after you added it through the UI?
-6. Did analytics match what you experienced?
-7. Did the session save to History and open afterward?
-8. Did PDF export include the transcript and analytics summary?
-9. Was Browser transcription clear that Chrome is recommended and results vary by browser?
-10. Was anything confusing, slow, blocked, or surprising?
-```
+- **Use Chrome** if you can — it's the most reliable for recording and transcripts.
+- If something freezes or looks wrong, use **Report Issue** (or just message me) and tell me
+  what you clicked and what happened. That's genuinely the most useful thing you can send.
 
-## Operator Checklist
+---
 
-- Share only the production Vercel URL with human testers: `https://speaksharp-public.vercel.app`.
-- Never share `127.0.0.1:5173` with human testers. That port is mocked E2E/test mode only.
-- If a local rehearsal is required, use `pnpm dev` and `127.0.0.1:5174`; do not use `pnpm dev:test`.
-- Do not generate or send tester codes. Free Browser access is automatic for new accounts.
-- Confirm sample fields appear on new profiles: `private_sample_limit_seconds`, `private_sample_seconds_used`, and no legacy timestamp grants paid access.
-- Confirm Vercel production does not set `VITE_TEST_MODE` or other E2E/test flags.
-- Keep tester instructions Browser-first with an intentional Private sample. Cloud can be tested separately through paid Pro/admin/dev accounts, but it is not part of free-account sample testing.
-- Pro/admin/dev Cloud tester scope, if included, must explicitly prove Cloud recording, transcript, save/history/detail, analytics, and PDF export. Do not ask automatic-trial testers to validate Cloud.
-- Free-path tester scope must explicitly prove Browser transcription, the one Private sample, and Cloud unavailable without paid entitlement. Use a known Free account with sample unused/used states when testing both sides.
-- Ask every tester to check save/history/detail after stopping. A transcript without persisted history is not a successful session.
-- Ask every tester who adds a custom word to say that word during recording and verify the analytics count after save.
-- Ask every tester who exports a PDF to confirm the file contains the session metadata, transcript, transcription mode, and analytics summary.
-- Do not claim Edge support unless an Edge-specific proof has passed start, transcript, save, history/detail, and analytics. Until then, use "Chrome recommended" wording.
-- Run `.github/workflows/live-release-matrix.yml` with the first-time tester/sample suite before sending instructions. This clears browser model storage, creates a fresh account, prepares Private STT, records, stops, and verifies save/history like a first-time tester.
+## What feedback helps most
+
+You don't need to know anything technical. Just tell me:
+
+1. Was it **obvious what to do next**?
+2. Did the **transcript** look about right?
+3. Did the **feedback** help you spot one thing to improve?
+4. Did anything **freeze, confuse, or surprise** you?
+5. Would you **use it again**? Why or why not?
+
+Even 3–4 sentences is a huge help. Thank you for testing it.

--- a/product_release/content_list.md
+++ b/product_release/content_list.md
@@ -24,7 +24,8 @@ This directory contains both current release controls and historical evidence pa
 | [QUALITY_METRICS.md](./QUALITY_METRICS.md) | Release-facing alias and quick digest for quality metrics targets and latest generated evidence file names. | Canonical alias; defer detailed interpretation to `SOFTWARE_QUALITY.operational.md`. |
 | [SERVICE_LEVELS.operational.md](./SERVICE_LEVELS.operational.md) | Defines SLO/SLC/SLA terms, soft-release service targets, stress/endurance evidence, and industry comparison. | Canonical service-level interpretation. |
 | [SPEAKSHARP_SESSION_SCORE.operational.md](./SPEAKSHARP_SESSION_SCORE.operational.md) | Defines the research-backed proprietary 0.0-10.0 SpeakSharp Score, references, weights, formula, and shared implementation source of truth. | Canonical score-model interpretation. |
-| [SOFT_RELEASE_TESTER_INSTRUCTIONS.md](./SOFT_RELEASE_TESTER_INSTRUCTIONS.md) | Copy/paste human tester protocol. | Canonical tester-facing copy. |
+| [SOFT_RELEASE_TESTER_INSTRUCTIONS.md](./SOFT_RELEASE_TESTER_INSTRUCTIONS.md) | Plain-language tester guide (what you send testers): intro, invitation copy, getting started, what to try, feedback. No implementation detail. | Canonical tester-facing copy. |
+| [INTERNAL_TEST_PROTOCOL.md](./INTERNAL_TEST_PROTOCOL.md) | Operator/dev/test protocol: environment rules, entitlement/scope checks, per-tester acceptance criteria, browser-support wording, first-time-tester proof. Not for testers. | Canonical internal soft-release protocol. |
 | [OPS_HEALTH_DASHBOARD.md](./OPS_HEALTH_DASHBOARD.md) | Simple vendor/tool health dashboard scope. | Canonical ops monitoring scope. |
 | [LAUNCH_ENV_CHECKLIST.md](./LAUNCH_ENV_CHECKLIST.md) | Runtime secrets/config checklist. | Canonical for env/config only; snapshot is older and should not be used for ship status. |
 | [PUBLIC_LAUNCH_LEDGER.md](./PUBLIC_LAUNCH_LEDGER.md) | Broad public-launch evidence ledger. | Canonical for broad public launch only, not soft tester status. |
@@ -64,7 +65,8 @@ The sections below are kept for navigation, but the canonical/historical split a
 - **[LAUNCH_ENV_CHECKLIST.md](./LAUNCH_ENV_CHECKLIST.md)**: The runtime configuration verification gate. Ensures environment variables and secrets are correctly set.
 - **[MANUAL_HARDWARE_VALIDATION.md](./MANUAL_HARDWARE_VALIDATION.md)**: Manual hardware/browser test protocols. Validates the "Hardware Blindspot" (Safari/Microphone/Bluetooth).
 - **[RC_GATES.md](./RC_GATES.md)**: Release candidate gate definitions and evidence requirements.
-- **[SOFT_RELEASE_TESTER_INSTRUCTIONS.md](./SOFT_RELEASE_TESTER_INSTRUCTIONS.md)**: Copy/paste tester invite, Private-first test path, trial-access prerequisites, and feedback questions for the controlled soft release.
+- **[SOFT_RELEASE_TESTER_INSTRUCTIONS.md](./SOFT_RELEASE_TESTER_INSTRUCTIONS.md)**: Plain-language tester guide to send testers — intro, invitation copy, getting started, what to try, feedback questions. No implementation detail.
+- **[INTERNAL_TEST_PROTOCOL.md](./INTERNAL_TEST_PROTOCOL.md)**: Operator/dev/test protocol for the controlled soft release — environment rules, entitlement/scope checks, per-tester acceptance criteria, browser-support wording, and the automated first-time-tester proof. Not for testers.
 
 ### 🛠️ Decision & Recovery
 - **[RELEASE_STATUS.md](./RELEASE_STATUS.md)**: The current go/no-go gate for controlled tester release decisions.

--- a/tests/release/tester-instructions.test.ts
+++ b/tests/release/tester-instructions.test.ts
@@ -2,54 +2,79 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+// Normalize markdown formatting so these content guards assert wording/invariants,
+// not layout: strip bold markers and collapse line-wrapped whitespace.
 const readReleaseDoc = (name: string) =>
-    readFileSync(resolve(process.cwd(), 'product_release', name), 'utf8');
+    readFileSync(resolve(process.cwd(), 'product_release', name), 'utf8')
+        .replace(/\*\*/g, '')
+        .replace(/\s+/g, ' ');
 
-describe('soft release tester instructions', () => {
-    it('do not send testers looking for removed promo-code flows', () => {
-        const instructions = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
+// The soft-release tester doc was split (2026-06-26):
+//   - SOFT_RELEASE_TESTER_INSTRUCTIONS.md = plain-language, tester-facing guide.
+//   - INTERNAL_TEST_PROTOCOL.md           = operator/dev/test protocol.
+// Tester-facing invariants are asserted on the guide; operator/technical
+// invariants are asserted on the protocol.
 
-        expect(instructions).not.toMatch(/promo\s*code|promo-code|redeem/i);
+describe('soft release tester guide (tester-facing)', () => {
+    const guide = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
+
+    it('does not send testers looking for removed promo-code flows', () => {
+        expect(guide).not.toMatch(/promo\s*code|promo-code|redeem/i);
     });
 
-    it('keeps Cloud STT out of the free-account sample tester task list', () => {
-        const instructions = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
-
-        expect(instructions).toMatch(/Cloud STT is a paid Early Access feature/i);
-        expect(instructions).not.toMatch(/optionally try cloud/i);
+    it('does not promise paid Cloud STT in the free tester path', () => {
+        expect(guide).not.toMatch(/cloud stt|free cloud|optionally try cloud/i);
     });
 
-    it('matches the current database-backed Private sample duration', () => {
-        const instructions = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
-
-        expect(instructions).toMatch(/one short Private transcription sample/i);
-        expect(instructions).not.toMatch(/1 hour of trial access|24 hours of trial access|24-hour Pro trial|60-minute Pro trial/i);
+    it('does not use the removed multi-hour trial language', () => {
+        expect(guide).not.toMatch(/1 hour of trial access|24 hours of trial access|24-hour Pro trial|60-minute Pro trial/i);
     });
 
-    it('sets Private first-text expectations before testers record', () => {
-        const instructions = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
-
-        expect(instructions).toMatch(/runs on your device/i);
-        expect(instructions).toMatch(/first words can take about 5 seconds to appear/i);
+    it('sets the on-device Private expectation in plain language', () => {
+        expect(guide).toMatch(/runs entirely on your own device/i);
+        expect(guide).toMatch(/few seconds to get ready/i);
     });
 
-    it('explicitly covers the current human tester protocol', () => {
-        const instructions = readReleaseDoc('SOFT_RELEASE_TESTER_INSTRUCTIONS.md');
+    it('stays jargon-free (no developer/internal terms leak to testers)', () => {
+        expect(guide).not.toMatch(/VITE_|127\.0\.0\.1|PostHog|WebGPU|stripeKeyClass|live-release-matrix|feature flag|effective_subscription_tier/i);
+    });
+});
 
-        expect(instructions).toMatch(/Set Up|Download Private Model/i);
-        expect(instructions).toMatch(/Export a PDF/i);
-        expect(instructions).toMatch(/Custom Words/i);
-        expect(instructions).toMatch(/saved analytics\/session detail/i);
-        expect(instructions).toMatch(/Browser transcription uses your browser's built-in speech recognition/i);
-        expect(instructions).toMatch(/Chrome is recommended/i);
-        expect(instructions).toMatch(/Do not claim Edge support unless an Edge-specific proof has passed/i);
+describe('internal test protocol (operator/dev/test)', () => {
+    const protocol = readReleaseDoc('INTERNAL_TEST_PROTOCOL.md');
+
+    it('keeps Cloud STT framed as paid, out of the free sample path', () => {
+        expect(protocol).toMatch(/Cloud STT is a paid Early Access feature/i);
+    });
+
+    it('matches the current database-backed Private sample (not old trial grants)', () => {
+        expect(protocol).toMatch(/Private sample/i);
+        expect(protocol).toMatch(/private_sample_limit_seconds/i);
+        expect(protocol).not.toMatch(/1 hour of trial access|24 hours of trial access|24-hour Pro trial|60-minute Pro trial/i);
+    });
+
+    it('preserves the per-tester acceptance criteria', () => {
+        expect(protocol).toMatch(/PDF export/i);
+        expect(protocol).toMatch(/custom word/i);
+        expect(protocol).toMatch(/saved analytics\/session detail/i);
+    });
+
+    it('keeps the browser-support wording guard', () => {
+        expect(protocol).toMatch(/built-in speech recognition/i);
+        expect(protocol).toMatch(/Chrome is recommended/i);
+        expect(protocol).toMatch(/Do not claim Edge support unless an Edge-specific proof has passed/i);
+    });
+
+    it('keeps the environment safety rules', () => {
+        expect(protocol).toMatch(/127\.0\.0\.1:5173/);
+        expect(protocol).toMatch(/VITE_TEST_MODE/);
     });
 });
 
 describe('release candidate gate evidence contract', () => {
-    it('requires latest complete passing artifacts, not stale passing evidence', () => {
-        const readiness = readReleaseDoc('RELEASE_STATUS.md');
+    const readiness = readReleaseDoc('RELEASE_STATUS.md');
 
+    it('requires latest complete passing artifacts, not stale passing evidence', () => {
         expect(readiness).toMatch(/latest complete passing run/i);
         expect(readiness).toMatch(/newer run fails any required criterion/i);
         expect(readiness).toMatch(/parent gate returns to red/i);
@@ -57,8 +82,6 @@ describe('release candidate gate evidence contract', () => {
     });
 
     it('folds the STT binary gates into their parent RC gates with named artifacts', () => {
-        const readiness = readReleaseDoc('RELEASE_STATUS.md');
-
         expect(readiness).toMatch(/Private sample recording/i);
         expect(readiness).toMatch(/SESSION_LIFECYCLE_WARMUP/i);
         expect(readiness).toMatch(/speaksharp-private-human-\[timestamp\]\.json/i);


### PR DESCRIPTION
Splits the developer-oriented tester doc into a plain-language **Tester Guide** (what you send testers, zero jargon) and a new **INTERNAL_TEST_PROTOCOL.md** (operator/dev/test: env rules, entitlement/scope, acceptance criteria, first-time-tester proof). Every operator-checklist item verified preserved. Cross-refs updated (ROADMAP, RELEASE_STATUS, content_list).

Doc-only; no app code changed. Confirmed none of the 5 RC gates read `product_release/*.md`, so gate outcomes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)