### PR TITLE
test(telemetry): fix vitest/expect-expect lint in deterministic proof (#876 follow-up)

### DIFF
--- a/frontend/src/services/transcription/__tests__/privateSampleTelemetry.proof.test.ts
+++ b/frontend/src/services/transcription/__tests__/privateSampleTelemetry.proof.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
     clearPrivateSampleContext();
 });
 
-function driveArm(arm: { engineType: string; variant: 'private_v2' | 'private_v4'; model: string; version: string }) {
+function driveArm(arm: { engineType: string; variant: 'private_v2' | 'private_v4'; model: string; version: string }): string {
     // 1) Deterministic override resolves the forced arm + attribution.
     const assignment = resolveSampleAssignment({
         resolvedEngineType: arm.engineType,
@@ -104,17 +104,21 @@ function driveArm(arm: { engineType: string; variant: 'private_v2' | 'private_v4
     // 5) first_transcript kept the numeric duration but dropped the leak attempt.
     const fts = calls.find((c) => c[0] === 'private_sample_first_transcript_seen')![1];
     expect(fts.time_to_first_text_ms).toBe(820);
+
+    return buildEngineVersion(assignment.engine_variant, arm.model);
 }
 
 describe('PROOF: deterministic v2 arm', () => {
     it('events report private_v2; durable engine_version private_v2:whisper-base.en; no PII', () => {
-        driveArm({ engineType: 'transformers-js', variant: 'private_v2', model: 'whisper-base.en', version: 'private_v2:whisper-base.en' });
+        const version = driveArm({ engineType: 'transformers-js', variant: 'private_v2', model: 'whisper-base.en', version: 'private_v2:whisper-base.en' });
+        expect(version).toBe('private_v2:whisper-base.en');
     });
 });
 
 describe('PROOF: deterministic v4 arm', () => {
     it('events report private_v4; durable engine_version private_v4:base_q4; no PII', () => {
-        driveArm({ engineType: 'transformers-js-v4', variant: 'private_v4', model: 'base_q4', version: 'private_v4:base_q4' });
+        const version = driveArm({ engineType: 'transformers-js-v4', variant: 'private_v4', model: 'base_q4', version: 'private_v4:base_q4' });
+        expect(version).toBe('private_v4:base_q4');
     });
 });
 


### PR DESCRIPTION
#876 auto-merged before the lint fix landed (unit-coverage is not a required check). Restores main's lint to green: `driveArm()` returns the built engine_version and each arm test asserts it directly. No eslint-disable. Test still 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)