### PR TITLE
fix(canary): poll for release-tier affordance (root-cause the intermittent canary)

### DIFF
--- a/tests/canary/smoke.canary.spec.ts
+++ b/tests/canary/smoke.canary.spec.ts
@@ -89,14 +89,21 @@ test.describe('Production Smoke Canary @canary', () => {
         // see an upgrade prompt or a Private-sample affordance; Pro users see the Pro badge.
         // This validates profile/usage hydration through behavior, without requiring
         // production UI to preserve one exact tier phrase.
-        const releaseTierAffordanceVisible = await Promise.all(
-            validReleaseTierAffordances.map(async (locator) => {
-                if ((await locator.count()) === 0) return false;
-                return locator.first().isVisible();
-            })
-        );
-        const isProfileValid = releaseTierAffordanceVisible.some(Boolean);
-        expect(isProfileValid, 'Schema Valid: Profile must reflect a known release tier/access state').toBe(true);
+        // Poll for the affordance (up to 15s, matching the start-button wait above) instead of a
+        // single synchronous snapshot. Profile/usage/entitlement hydration can finish a beat after
+        // the start button renders; an un-polled check raced that and failed intermittently on
+        // identical app builds. If NO affordance appears within the window, this still fails — so a
+        // genuine missing-affordance regression (e.g. effective-tier resolution) is NOT masked.
+        await expect(async () => {
+            const releaseTierAffordanceVisible = await Promise.all(
+                validReleaseTierAffordances.map(async (locator) => {
+                    if ((await locator.count()) === 0) return false;
+                    return locator.first().isVisible();
+                })
+            );
+            const isProfileValid = releaseTierAffordanceVisible.some(Boolean);
+            expect(isProfileValid, 'Schema Valid: Profile must reflect a known release tier/access state').toBe(true);
+        }).toPass({ timeout: 15000, intervals: [500, 1000, 2000, 3000] });
 
         // 3. Configure for Native STT (Free/Low Risk)
         debugLog('[CANARY] Configuring Native STT mode...');


### PR DESCRIPTION
## Root cause (confirmed mechanism)
The intermittent canary failures (`smoke.canary.spec.ts:99` "Profile must reflect a known release tier") are a **hydration race**, not a code regression:

- The affordance check was a **single synchronous snapshot with no polling**, while the start-button check above it waits 15s.
- The accepted affordances include **both** Free ("upgrade to pro") **and** Pro (`PRO_BADGE`). `getEffectiveSubscriptionStatus` is a DB/profile read gated on the **async `useUsageLimit` query**. Until profile+usage hydrate, neither affordance has rendered — the un-polled check caught exactly that window.
- Evidence it is timing, not code: it flips pass/fail on **identical app builds** — doc-only `03ad82e0` failed while same-build `4ab6ece4` passed; `07b535d8` failed twice; `5537601c` failed then `6e5a08315e` passed minutes later. A code regression fails consistently from its SHA forward.

## Fix
Wrap the affordance check in `expect(async () => ...).toPass({ timeout: 15000 })` (matches the start-button wait). If no affordance renders within 15s it still fails — a genuine effective-tier regression is NOT masked, only hydration delay is tolerated.

## Verification
Merge then run the canary several times. Reliably green = race confirmed + fixed. If it stays flaky even with 15s polling, the next suspect is effective-Pro resolution for `canary@speaksharp.app` (entitlement #851) and I escalate rather than paper over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
