### PR TITLE
fix(telemetry): emit Private-sample setup events from status stream (live-e2e caught it)

### DIFF
--- a/frontend/src/services/SpeechRuntimeController.ts
+++ b/frontend/src/services/SpeechRuntimeController.ts
@@ -471,6 +471,38 @@ export class SpeechRuntimeController {
         }
     }
 
+    // Private-sample SETUP telemetry, driven by the engine status stream so it fires regardless
+    // of how the model load was triggered (warmUp / auto-init on mode select / explicit download).
+    private privateSetupStartedAt: number | null = null;
+    private privateSetupResolved = false;
+    private emitPrivateSampleSetupStatus(type: string): void {
+        try {
+            if ((this.service?.getMode?.() ?? null) !== 'private') return;
+            const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            if (type === 'download-required' || type === 'downloading' || type === 'initializing') {
+                // (re)arm a setup cycle; emit started once per cycle
+                if (this.privateSetupStartedAt == null || this.privateSetupResolved) {
+                    this.privateSetupStartedAt = now;
+                    this.privateSetupResolved = false;
+                    emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_STARTED, { ...buildSampleEnvProps() });
+                }
+            } else if (type === 'ready' && !this.privateSetupResolved) {
+                this.privateSetupResolved = true;
+                this.applyPrivateSampleContext();
+                emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_SUCCEEDED, {
+                    setup_duration_ms: this.privateSetupStartedAt != null ? Math.round(now - this.privateSetupStartedAt) : null,
+                    ...buildSampleEnvProps(),
+                });
+            } else if (type === 'error' && !this.privateSetupResolved && this.privateSetupStartedAt != null) {
+                this.privateSetupResolved = true;
+                this.applyPrivateSampleContext();
+                emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_FAILED, { error_code: 'SetupError', ...buildSampleEnvProps() });
+            }
+        } catch {
+            /* telemetry must never break the recording pipeline */
+        }
+    }
+
     /**
      * UX-NAV-1: synchronously persist the in-progress transcript as a recovery draft.
      *
@@ -583,28 +615,10 @@ export class SpeechRuntimeController {
         if (!this.service) {
             await this.ensureReady({ skipIfDownloadPending: false });
         }
-        const isPrivate = mode === 'private';
-        const t0 = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        if (isPrivate) emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_STARTED);
-        try {
-            await this.service!.initiateDownload(mode);
-            if (isPrivate) {
-                this.applyPrivateSampleContext();
-                emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_SUCCEEDED, {
-                    setup_duration_ms: Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0),
-                    ...buildSampleEnvProps(),
-                });
-            }
-        } catch (error) {
-            if (isPrivate) {
-                this.applyPrivateSampleContext();
-                emitPrivateSample(PRIVATE_SAMPLE_EVENTS.SETUP_FAILED, {
-                    error_code: (error as Error)?.name ?? 'SetupError',
-                    ...buildSampleEnvProps(),
-                });
-            }
-            throw error;
-        }
+        // Setup telemetry is emitted from handleStatusChange (path-agnostic: covers warmUp /
+        // auto-init / explicit download alike), not here — initiateModelDownload is only ONE of
+        // the model-load entry points and is skipped when the model auto-loads on mode select.
+        await this.service!.initiateDownload(mode);
     }
 
     /**
@@ -1167,6 +1181,7 @@ export class SpeechRuntimeController {
         if (status.type === 'ready') {
             this.setEngineReady(true);
         }
+        this.emitPrivateSampleSetupStatus(status.type);
         // P0.2: surface engine-originated local finalization status to the store so
         // the UI shows "Processing speech locally…" during STOPPING instead of the
         // stale "Recording active". Scoped to informational status while a session

--- a/tests/live/private-sample-telemetry.live.spec.ts
+++ b/tests/live/private-sample-telemetry.live.spec.ts
@@ -119,36 +119,47 @@ test.describe('Private-sample telemetry — live app wiring @live', () => {
                 .toContain('private_sample_selected');
         });
 
-        await test.step('Prepare Private model → setup events', async () => {
+        await test.step('Prepare Private model (setup fires via warmUp/auto-init, asserted at end)', async () => {
             await preparePrivateModelIfPrompted(page);
-            const names = (await getSampleEvents(page)).map((e) => e.event);
-            expect(names).toContain('private_sample_setup_started');
-            expect(names.some((n) => n === 'private_sample_setup_succeeded' || n === 'private_sample_setup_failed')).toBe(true);
         });
 
-        await test.step('Record → recording_started + first_transcript_seen (once)', async () => {
+        await test.step('Record → wait for first transcript text', async () => {
             const startStop = page.getByTestId('session-start-stop-button');
             await expect(startStop).toBeEnabled({ timeout: 60_000 });
             await startStop.click();
             await expect(startStop).toHaveAttribute('data-recording', 'true', { timeout: 60_000 });
-            await expect.poll(async () => (await getSampleEvents(page)).map((e) => e.event), { timeout: 30_000 })
-                .toContain('private_sample_recording_started');
-            // First transcript text appears, then first_transcript_seen fires exactly once.
-            await expect.poll(async () => {
-                const events = await getSampleEvents(page);
-                return events.filter((e) => e.event === 'private_sample_first_transcript_seen').length;
-            }, { timeout: 120_000 }).toBe(1);
+            await expect.poll(async () =>
+                (await getSampleEvents(page)).filter((e) => e.event === 'private_sample_first_transcript_seen').length,
+                { timeout: 120_000 }).toBeGreaterThanOrEqual(1);
         });
 
-        await test.step('Stop + save → recording_stopped, saved, usage_updated', async () => {
+        await test.step('Stop + save', async () => {
             const startStop = page.getByTestId('session-start-stop-button');
             await startStop.click();
             await expect(startStop).toHaveAttribute('data-recording', 'false', { timeout: 60_000 });
             await expect(page.locator('html[data-session-persisted="true"]')).toBeVisible({ timeout: 60_000 });
-            const names = (await getSampleEvents(page)).map((e) => e.event);
-            expect(names).toContain('private_sample_recording_stopped');
-            expect(names).toContain('private_sample_saved');
-            expect(names).toContain('private_sample_usage_updated');
+            await expect.poll(async () => (await getSampleEvents(page)).map((e) => e.event), { timeout: 30_000 })
+                .toContain('private_sample_saved');
+        });
+
+        await test.step('Full event spine present (selected/setup/start/first-text/stop/save/usage)', async () => {
+            await expect.poll(async () => {
+                const names = new Set((await getSampleEvents(page)).map((e) => e.event));
+                const required = [
+                    'private_sample_selected',
+                    'private_sample_setup_started',
+                    'private_sample_recording_started',
+                    'private_sample_first_transcript_seen',
+                    'private_sample_recording_stopped',
+                    'private_sample_saved',
+                    'private_sample_usage_updated',
+                ];
+                return required.every((n) => names.has(n))
+                    && (names.has('private_sample_setup_succeeded') || names.has('private_sample_setup_failed'));
+            }, { timeout: 30_000 }).toBe(true);
+            // first_transcript_seen fires exactly once.
+            const ftsCount = (await getSampleEvents(page)).filter((e) => e.event === 'private_sample_first_transcript_seen').length;
+            expect(ftsCount, 'first_transcript_seen should fire exactly once').toBe(1);
         });
 
         await test.step('Saved session row records a real engine arm', async () => {


### PR DESCRIPTION
The live e2e caught a real wiring bug: `setup_started` never fired because setup events were on the `initiateModelDownload` (explicit-button) path, but the model loads via warmUp/auto-init. Moved them to `handleStatusChange` (path-agnostic). E2E now asserts the full spine at the end (poll) instead of fragile per-step checks. tsc/eslint/unit+proof green; live e2e re-validates post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)