### PR TITLE
fix(telemetry): emit usage_updated from active context (+ e2e event diagnostics)

### DIFF
--- a/frontend/src/hooks/useUsageLimit.ts
+++ b/frontend/src/hooks/useUsageLimit.ts
@@ -128,16 +128,24 @@ export function updateLocalUsage(userId: string, additionalSeconds: number) {
         };
     });
 
-    // Emit sample usage telemetry only while a Private sample is the active arm (so native/
-    // cloud usage updates don't fire). Never blocks the optimistic update above.
+    // Emit sample usage telemetry whenever a Private sample is the active arm (so native/cloud
+    // usage updates don't fire). Driven by the active sample CONTEXT, not the cached usage shape:
+    // a fresh free account's cache may not carry private_sample_seconds_* yet, so we fall back to
+    // the context's sample_limit_seconds + this session's seconds. Never blocks the update above.
+    const ctx = getPrivateSampleContext();
     const update = sampleUpdate as { used: number; remaining: number; wasAbove: boolean } | null;
-    if (update && additionalSeconds > 0 && getPrivateSampleContext().engine_variant) {
+    if (additionalSeconds > 0 && ctx.engine_variant) {
+        const limit = ctx.sample_limit_seconds ?? null;
+        const used = update ? update.used : Math.round(additionalSeconds);
+        const remaining = update
+            ? update.remaining
+            : (limit != null ? Math.max(0, limit - used) : null);
         emitPrivateSample(PRIVATE_SAMPLE_EVENTS.USAGE_UPDATED, {
-            sample_seconds_used: update.used,
-            sample_seconds_remaining: update.remaining,
+            sample_seconds_used: used,
+            sample_seconds_remaining: remaining,
         });
-        if (update.wasAbove && update.remaining <= 0) {
-            emitPrivateSample(PRIVATE_SAMPLE_EVENTS.EXHAUSTED, { sample_seconds_used: update.used });
+        if (remaining != null && remaining <= 0) {
+            emitPrivateSample(PRIVATE_SAMPLE_EVENTS.EXHAUSTED, { sample_seconds_used: used });
         }
     }
 }

--- a/tests/live/private-sample-telemetry.live.spec.ts
+++ b/tests/live/private-sample-telemetry.live.spec.ts
@@ -98,6 +98,15 @@ test.describe('Private-sample telemetry — live app wiring @live', () => {
             w.__STT_LOAD_TIMEOUT__ = 180000;
         });
 
+        // Diagnostic: forward sample-telemetry + engine-status logs so the CI log shows exactly
+        // which events fire (and which status types the controller sees) during the real flow.
+        page.on('console', (m) => {
+            const t = m.text();
+            if (/PRIVATE_SAMPLE|SttStatus|status\.type|EngineReady|model-status|TranscriptionService.*status/i.test(t)) {
+                console.log(`[browser] ${t}`);
+            }
+        });
+
         const unique = `${Date.now()}-${process.env.GITHUB_RUN_ID ?? 'local'}`;
         const email = `private-sample-telemetry-${unique}@speaksharp.app`;
         const password = `SpeakSharpSample-${unique}!`;
@@ -143,22 +152,24 @@ test.describe('Private-sample telemetry — live app wiring @live', () => {
         });
 
         await test.step('Full event spine present (selected/setup/start/first-text/stop/save/usage)', async () => {
-            await expect.poll(async () => {
-                const names = new Set((await getSampleEvents(page)).map((e) => e.event));
-                const required = [
-                    'private_sample_selected',
-                    'private_sample_setup_started',
-                    'private_sample_recording_started',
-                    'private_sample_first_transcript_seen',
-                    'private_sample_recording_stopped',
-                    'private_sample_saved',
-                    'private_sample_usage_updated',
-                ];
-                return required.every((n) => names.has(n))
-                    && (names.has('private_sample_setup_succeeded') || names.has('private_sample_setup_failed'));
-            }, { timeout: 30_000 }).toBe(true);
-            // first_transcript_seen fires exactly once.
-            const ftsCount = (await getSampleEvents(page)).filter((e) => e.event === 'private_sample_first_transcript_seen').length;
+            await page.waitForTimeout(5000); // let any late events land
+            const all = await getSampleEvents(page);
+            console.log('[SPINE_DIAG] events=' + JSON.stringify(all.map((e) => ({ ev: e.event, variant: e.engine_variant, src: e.assignment_source }))));
+            const names = new Set(all.map((e) => e.event));
+            const required = [
+                'private_sample_selected',
+                'private_sample_setup_started',
+                'private_sample_recording_started',
+                'private_sample_first_transcript_seen',
+                'private_sample_recording_stopped',
+                'private_sample_saved',
+                'private_sample_usage_updated',
+            ];
+            const missing = required.filter((n) => !names.has(n));
+            console.log('[SPINE_DIAG] missing=' + JSON.stringify(missing));
+            expect(missing, `missing events: ${missing.join(', ')}`).toEqual([]);
+            expect(names.has('private_sample_setup_succeeded') || names.has('private_sample_setup_failed'), 'setup must resolve').toBe(true);
+            const ftsCount = all.filter((e) => e.event === 'private_sample_first_transcript_seen').length;
             expect(ftsCount, 'first_transcript_seen should fire exactly once').toBe(1);
         });
 


### PR DESCRIPTION
Live e2e proved the full spine fires except `usage_updated` — gated on cache shape that a fresh free account lacks. Now driven by the active sample context (reliable). Includes e2e diagnostics that pinpointed it. tsc/eslint/unit+proof green; live e2e re-validates post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)