### PR TITLE
fix(telemetry): Report Issue carries last sample's arm/release/session

### DIFF
--- a/frontend/src/services/issueReportService.ts
+++ b/frontend/src/services/issueReportService.ts
@@ -1,7 +1,7 @@
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import logger from '@/lib/logger';
 import type { TranscriptionMode } from '@/services/transcription/TranscriptionPolicy';
-import { emitPrivateSample, PRIVATE_SAMPLE_EVENTS } from '@/services/transcription/privateSampleTelemetry';
+import { emitPrivateSample, getLastSampleArm, PRIVATE_SAMPLE_EVENTS } from '@/services/transcription/privateSampleTelemetry';
 
 export type IssueReportCategory = 'stt' | 'billing' | 'account' | 'analytics' | 'privacy' | 'performance' | 'general';
 export type IssueReportSeverity = 'low' | 'medium' | 'high' | 'critical';
@@ -101,10 +101,13 @@ export const issueReportService = {
     // Non-PII analytics breadcrumb so a Report Issue can be correlated to the user's
     // journey (session id, and the Private arm/release via the active sample context).
     // The strict allowlist guarantees no title/description/transcript/audio rides along.
+    const arm = getLastSampleArm();
     emitPrivateSample(PRIVATE_SAMPLE_EVENTS.REPORT_ISSUE_SUBMITTED, {
       issue_category: input.category,
       issue_severity: input.severity,
-      session_id: input.sessionId ?? null,
+      session_id: input.sessionId ?? arm.session_id ?? null,
+      engine_variant: arm.engine_variant ?? null,
+      release_sha: arm.release_sha ?? null,
     });
 
     return { id: null };

--- a/frontend/src/services/transcription/privateSampleTelemetry.ts
+++ b/frontend/src/services/transcription/privateSampleTelemetry.ts
@@ -190,12 +190,32 @@ export interface PrivateSampleContext {
 
 let activeContext: PrivateSampleContext = {};
 
+// Identity of the most recent Private sample (arm/model/release/session). Survives
+// clearPrivateSampleContext so a Report Issue filed AFTER the sample (context cleared) can still
+// be linked to the engine the user just tried. Updated as the active context is set.
+interface LastSampleArm {
+    engine_variant?: EngineVariant | null;
+    model?: string | null;
+    release_sha?: string | null;
+    session_id?: string | null;
+}
+const lastSampleArm: LastSampleArm = {};
+
 export function setPrivateSampleContext(ctx: PrivateSampleContext): void {
     activeContext = { ...activeContext, ...ctx };
+    if (ctx.engine_variant != null) lastSampleArm.engine_variant = ctx.engine_variant;
+    if (ctx.model != null) lastSampleArm.model = ctx.model;
+    if (ctx.release_sha != null) lastSampleArm.release_sha = ctx.release_sha;
+    if (ctx.session_id != null) lastSampleArm.session_id = ctx.session_id;
 }
 
 export function getPrivateSampleContext(): PrivateSampleContext {
     return { ...activeContext };
+}
+
+/** The most recent Private sample's arm/model/release/session (persists across clear). */
+export function getLastSampleArm(): LastSampleArm {
+    return { ...lastSampleArm };
 }
 
 export function clearPrivateSampleContext(): void {


### PR DESCRIPTION
E2e #6 cleared spine + engine_version + Report Issue; failed privacy step because report_issue_submitted lacked engine_variant (filed after context clear). Per go-criterion #6, track a lastSampleArm that survives clear and attach it to report_issue_submitted. tsc/eslint/unit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)