### PR TITLE
feat(telemetry)+docs: Report Issue carries Private sample arm; v4 posture reframe

### DIFF
--- a/frontend/src/services/issueReportService.ts
+++ b/frontend/src/services/issueReportService.ts
@@ -1,7 +1,7 @@
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import logger from '@/lib/logger';
 import type { TranscriptionMode } from '@/services/transcription/TranscriptionPolicy';
-import { emitPrivateSample, PRIVATE_SAMPLE_EVENTS } from '@/services/transcription/privateSampleTelemetry';
+import { emitPrivateSample, getLastSampleArm, PRIVATE_SAMPLE_EVENTS } from '@/services/transcription/privateSampleTelemetry';
 
 export type IssueReportCategory = 'stt' | 'billing' | 'account' | 'analytics' | 'privacy' | 'performance' | 'general';
 export type IssueReportSeverity = 'low' | 'medium' | 'high' | 'critical';
@@ -101,10 +101,13 @@ export const issueReportService = {
     // Non-PII analytics breadcrumb so a Report Issue can be correlated to the user's
     // journey (session id, and the Private arm/release via the active sample context).
     // The strict allowlist guarantees no title/description/transcript/audio rides along.
+    const arm = getLastSampleArm();
     emitPrivateSample(PRIVATE_SAMPLE_EVENTS.REPORT_ISSUE_SUBMITTED, {
       issue_category: input.category,
       issue_severity: input.severity,
-      session_id: input.sessionId ?? null,
+      session_id: input.sessionId ?? arm.session_id ?? null,
+      engine_variant: arm.engine_variant ?? null,
+      release_sha: arm.release_sha ?? null,
     });
 
     return { id: null };

--- a/frontend/src/services/transcription/privateSampleTelemetry.ts
+++ b/frontend/src/services/transcription/privateSampleTelemetry.ts
@@ -190,12 +190,32 @@ export interface PrivateSampleContext {
 
 let activeContext: PrivateSampleContext = {};
 
+// Identity of the most recent Private sample (arm/model/release/session). Survives
+// clearPrivateSampleContext so a Report Issue filed AFTER the sample (context cleared) can still
+// be linked to the engine the user just tried. Updated as the active context is set.
+interface LastSampleArm {
+    engine_variant?: EngineVariant | null;
+    model?: string | null;
+    release_sha?: string | null;
+    session_id?: string | null;
+}
+const lastSampleArm: LastSampleArm = {};
+
 export function setPrivateSampleContext(ctx: PrivateSampleContext): void {
     activeContext = { ...activeContext, ...ctx };
+    if (ctx.engine_variant != null) lastSampleArm.engine_variant = ctx.engine_variant;
+    if (ctx.model != null) lastSampleArm.model = ctx.model;
+    if (ctx.release_sha != null) lastSampleArm.release_sha = ctx.release_sha;
+    if (ctx.session_id != null) lastSampleArm.session_id = ctx.session_id;
 }
 
 export function getPrivateSampleContext(): PrivateSampleContext {
     return { ...activeContext };
+}
+
+/** The most recent Private sample's arm/model/release/session (persists across clear). */
+export function getLastSampleArm(): LastSampleArm {
+    return { ...lastSampleArm };
 }
 
 export function clearPrivateSampleContext(): void {

--- a/product_release/INTERNAL_TEST_PROTOCOL.md
+++ b/product_release/INTERNAL_TEST_PROTOCOL.md
@@ -83,11 +83,20 @@ detail (flags, model variants, telemetry, evidence, acceptance criteria) out of 
 
 ---
 
-## Private v4 A/B rollout posture (internal — never in the tester guide)
+## Private v4 rollout posture (internal — never in the tester guide)
 
-The free 5-minute Private sample is also the v2/v4 A/B measurement window. **Default Private
-engine is v2; broad/random v4 rollout stays at 0%.** v4 is exposed only **deliberately,
-narrowly, and reversibly** after the telemetry proof passes.
+**v2 is the primary Private engine — the proven default users get.** **v4 is a first-class,
+gated candidate** that — *with enough real-world data* — could be reviewed for primary. v4 is
+**not "off" and not a second-class experiment**: it is built into the *same* telemetry spine,
+saved-session metadata, Report Issue context, and live e2e coverage as v2. But **v2 holds primary
+until v4 demonstrably earns promotion**; gating v4 is not a demotion of v4, and promoting v4 is
+not yet on the table without the data.
+
+The free 5-minute Private sample is the v2/v4 measurement window. **v2 is the default for broad
+beta traffic; broad/random v4 rollout is held (currently 0%) pending real-user evidence** — but
+**targeted v4 exposure is ready immediately after launch** (allowlist / small cohort) so we begin
+collecting real-world v4 data deliberately, narrowly, and reversibly. The goal is to give v4 a
+fair, evidence-based path toward primary — while v2 stays primary until that evidence exists.
 
 **Assignment + attribution.** Every `private_sample_*` event carries `engine_variant`
 (`private_v2`/`private_v4`) and `assignment_source` (`default | posthog_flag | allowlist |
@@ -116,6 +125,20 @@ stable.
 8. Kill switch back to v2 is verified.
 9. Tester guide stays simple and does **not** mention A/B testing.
 
-**Suggested waves:** (0) internal proof — force v2 + v4 on test accounts, confirm telemetry +
-saved metadata; (1) 1–2 trusted external testers on v4, Chrome desktop, normal use; (2) ramp to
-10–20% if setup/save/error rates are acceptable; (3) decide continue / fix / cut.
+**Promotion path (v2 → v4): a deliberate promotion, not a permanent hold.**
+- **Phase 0 — internal proof:** force v2 + v4 on owner/test accounts; confirm setup, transcript,
+  save/history/detail, Report Issue, telemetry + saved metadata. *(done via deterministic override.)*
+- **Phase 1 — selected external v4:** named allowlist (`private_stt_v4_allowlist`), Chrome desktop
+  first, 1–3 trusted testers, normal use; compare v4 reports to the v2 baseline.
+- **Phase 2 — small % rollout:** 10–20% via `private_stt_v4_enabled`; watch setup-success,
+  time-to-first-text, save success, error/Report-Issue volume vs v2.
+- **Phase 3 — 50/50:** only after early v4 pain is bounded.
+- **Phase 4 — review v4 for primary:** a deliberate review, not an automatic endpoint. **v2 stays
+  primary** until the data shows v4 is clearly better (or the tradeoff is strategically worth it).
+  If v4 doesn't earn it, v2 stays primary and v4 is cut — decided on real data, not assumption.
+
+**Promotion criteria (evidence, not perfection — qualitative + telemetry for a small beta):**
+setup-success rate acceptable; time-to-first-text not materially worse than v2 on target devices;
+save/history/detail reliable; Report Issue volume not materially worse than v2; transcript quality
+directionally better (or the tradeoff is strategically worth it); no privacy/logging regression;
+rollback to v2 stays one flag change. **If v4 can't earn this, cut it — but decide on real data.**


### PR DESCRIPTION
## Summary
**Private v4 posture docs + Report Issue telemetry context fix** (not doc-only). Two commits:

### 1. `fix(telemetry)` — Report Issue carries the Private sample arm (`58251f5a`)
`report_issue_submitted` now correlates to the Private sample the user just tried, even when the
sample context was already cleared before the report:
- `privateSampleTelemetry.ts` — adds `lastSampleArm` (`engine_variant` / `model` / `release_sha` /
  `session_id`) that **survives `clearPrivateSampleContext`**, plus `getLastSampleArm()`.
- `issueReportService.ts` — `report_issue_submitted` now emits `engine_variant`, `release_sha`, and a
  `session_id` fallback from the last arm, in addition to `issue_category` / `issue_severity`.

**PII-safe:** strict non-PII allowlist — **no** title/description/transcript/audio/raw payload rides
along (only category, severity, session_id, engine_variant, release_sha).

### 2. `docs(release)` — v4 posture reframe (`b1712c8c`)
`product_release/INTERNAL_TEST_PROTOCOL.md` — v2 is **primary/default**; v4 is a **first-class gated
candidate** (broad rollout 0%, allowlist-ready), reviewable for primary with enough real-world data
— not "off"/second-class.

## Scope
3 files: `issueReportService.ts`, `privateSampleTelemetry.ts`, `INTERNAL_TEST_PROTOCOL.md`. No other
changes.

## Gating
Part of the single §7 hardening bundle (with #885 stt-switching refactor + #886 canary→Free).
Launch remains gated on the **post-merge** signoff (deploy-health canary + telemetry e2e +
stt-switching 3/3 + `gate=all` + DB audit `auth.users` Δ=0) on the post-merge SHA — not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
