### PR TITLE
chore(score): rename "Audience impact" UI label to "Listener Takeaway"

### DIFF
--- a/frontend/src/components/landing/FeaturesSection.tsx
+++ b/frontend/src/components/landing/FeaturesSection.tsx
@@ -45,7 +45,7 @@ const features = [
   {
     icon: <BarChart3 className="size-8" />,
     title: "Coaching That Goes Deeper",
-    description: "Review pacing, fillers, structure, vocabulary variety, and audience impact so practice becomes repeatable progress.",
+    description: "Review pacing, fillers, structure, vocabulary variety, and listener takeaway so practice becomes repeatable progress.",
     iconBgColor: "bg-primary/20",
     iconTextColor: "text-primary",
   },

--- a/frontend/src/components/session/LiveCoachingScoreCard.tsx
+++ b/frontend/src/components/session/LiveCoachingScoreCard.tsx
@@ -200,7 +200,7 @@ export const LiveCoachingScoreCard: React.FC<LiveCoachingScoreCardProps> = ({
                             </div>
                             <div className="flex justify-between gap-2">
                                 <span>Listener Takeaway</span>
-                                <span>{formatBreakdown(result.breakdown.audienceImpact)}</span>
+                                <span>{formatBreakdown(result.breakdown.listenerTakeaway)}</span>
                             </div>
                         </div>
                         <p className="mt-3 text-[11px] font-semibold leading-snug text-foreground/60">

--- a/frontend/src/components/session/LiveCoachingScoreCard.tsx
+++ b/frontend/src/components/session/LiveCoachingScoreCard.tsx
@@ -108,7 +108,7 @@ export const LiveCoachingScoreCard: React.FC<LiveCoachingScoreCardProps> = ({
                     </div>
                     <h2 className="text-xl font-extrabold text-foreground">SpeakSharp Score*</h2>
                     <p className="mt-1 text-sm font-semibold leading-snug text-foreground/75">
-                        The visible tools roll up into one coaching score: structure, pace/fillers/pauses, clarity, and audience impact.
+                        The visible tools roll up into one coaching score: structure, pace/fillers/pauses, clarity, and listener takeaway.
                     </p>
                     <p className="mt-1 text-sm font-semibold leading-snug text-foreground/75">
                         Improve the ingredients, then come back and try to lift the score.
@@ -199,7 +199,7 @@ export const LiveCoachingScoreCard: React.FC<LiveCoachingScoreCardProps> = ({
                                 <span>{formatBreakdown(result.breakdown.languageClarity)}</span>
                             </div>
                             <div className="flex justify-between gap-2">
-                                <span>Audience impact</span>
+                                <span>Listener Takeaway</span>
                                 <span>{formatBreakdown(result.breakdown.audienceImpact)}</span>
                             </div>
                         </div>

--- a/frontend/src/utils/speakingScore.ts
+++ b/frontend/src/utils/speakingScore.ts
@@ -7,7 +7,7 @@ export const SPEAKSHARP_SCORE_WEIGHTS = {
     messageStructure: 0.35,
     deliveryControl: 0.30,
     languageClarity: 0.20,
-    audienceImpact: 0.15,
+    listenerTakeaway: 0.15,
 } as const;
 
 export const SPEAKSHARP_CONFIDENCE_THRESHOLDS = {
@@ -55,7 +55,7 @@ export interface SpeakingScoreBreakdown {
     messageStructure: number;
     deliveryControl: number;
     languageClarity: number;
-    audienceImpact: number;
+    listenerTakeaway: number;
 }
 
 export interface SpeakingScoreResult {
@@ -144,7 +144,7 @@ const scoreMessageStructure = (transcript: string, wordCount: number): number =>
     return clamp(lengthScore + structureBonus);
 };
 
-const scoreAudienceImpact = (transcript: string, wordCount: number): number => {
+const scoreListenerTakeaway = (transcript: string, wordCount: number): number => {
     if (wordCount < ANALYTICS_THRESHOLDS.MIN_RELIABLE_SCORING_WORDS) return 0;
 
     const normalized = transcript.toLowerCase();
@@ -302,14 +302,14 @@ export const calculateSpeakingScore = ({
         languageClarity: wordCount < ANALYTICS_THRESHOLDS.MIN_RELIABLE_SCORING_WORDS
             ? 0
             : clamp(clarityScore / 10),
-        audienceImpact: scoreAudienceImpact(transcript, wordCount),
+        listenerTakeaway: scoreListenerTakeaway(transcript, wordCount),
     };
 
     const score = roundTenth(
         (breakdown.messageStructure * SPEAKSHARP_SCORE_WEIGHTS.messageStructure)
         + (breakdown.deliveryControl * SPEAKSHARP_SCORE_WEIGHTS.deliveryControl)
         + (breakdown.languageClarity * SPEAKSHARP_SCORE_WEIGHTS.languageClarity)
-        + (breakdown.audienceImpact * SPEAKSHARP_SCORE_WEIGHTS.audienceImpact)
+        + (breakdown.listenerTakeaway * SPEAKSHARP_SCORE_WEIGHTS.listenerTakeaway)
     );
 
     const actions: string[] = [];
@@ -332,7 +332,7 @@ export const calculateSpeakingScore = ({
         if (totalPauses === 0 && elapsedSeconds >= 20) actions.push('Pause once before the takeaway.');
         else if (pausesPerMinute > 12) actions.push('Finish a full phrase before taking the next pause.');
 
-        if (breakdown.audienceImpact < 5.5) actions.push('Use one concrete example to make it land.');
+        if (breakdown.listenerTakeaway < 5.5) actions.push('Use one concrete example to make it land.');
     }
 
     const label = getScoreLabel(score);


### PR DESCRIPTION
Renames "Audience impact" → **"Listener Takeaway"** across both the UI label and the internal identifier, per release-owner. Rationale: "Audience impact" implied measuring real audience reaction, but the metric is a transcript proxy for whether a listener walks away with a takeaway/example/recommendation — the new name is more honest.

## Changes
**UI label + copy**
- `LiveCoachingScoreCard.tsx` — breakdown row label + the "rolls up into one coaching score: …, clarity, and listener takeaway" sentence
- `FeaturesSection.tsx` (landing) — coaching-feature description

**Internal identifier (follows the label)**
- `speakingScore.ts` — `SpeakingScoreBreakdown` key `audienceImpact` → `listenerTakeaway`; `scoreAudienceImpact()` → `scoreListenerTakeaway()`; `SPEAKSHARP_SCORE_WEIGHTS` key
- `LiveCoachingScoreCard.tsx` — `result.breakdown.listenerTakeaway`

## Safety
- **Weight value unchanged (0.15)**; the four weights stay 0.35 / 0.30 / 0.20 / 0.15 and the score computation is identical — **18/18** `speakingScore` unit tests green.
- **No analytics/DB continuity break**: the breakdown key is not persisted to the DB and not emitted to analytics (`sessionCoachingExperiment` emits only `score_band`/`confidence`).
- ESLint + frontend `tsc` clean; no test asserted the old label/key.

Separate from the beta launch — **not invite-blocking**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
