### PR TITLE
perf(utils): trim main-thread allocations flagged by Jules (cold paths)

### DIFF
--- a/frontend/src/services/AnalyticsBuffer.ts
+++ b/frontend/src/services/AnalyticsBuffer.ts
@@ -43,9 +43,13 @@ const sanitizeAnalyticsProperties = (
   properties?: Record<string, unknown>,
 ): Record<string, unknown> | undefined => {
   if (!properties) return undefined;
-  return Object.fromEntries(
-    Object.entries(properties).map(([key, value]) => [key, sanitizeAnalyticsValue(key, value)]),
-  );
+  // Imperative single pass: avoids the intermediate entries[] + mapped[] arrays that
+  // Object.fromEntries(Object.entries().map()) allocates per event.
+  const sanitized: Record<string, unknown> = {};
+  for (const key of Object.keys(properties)) {
+    sanitized[key] = sanitizeAnalyticsValue(key, properties[key]);
+  }
+  return sanitized;
 };
 
 class AnalyticsBuffer {

--- a/frontend/src/utils/coachingNarrative.ts
+++ b/frontend/src/utils/coachingNarrative.ts
@@ -110,8 +110,12 @@ export const getTryThisNext = (stats: DeliveryAggregates): TryThisNext => {
         { metric: clarity, driver: 'clear delivery', action: 'Say the main point before the context.' },
     ];
 
-    const worst = candidates.find(c => c.metric.tone === 'off')
-        ?? candidates.find(c => c.metric.tone === 'watch');
+    // Single pass: the first 'off' wins outright; otherwise the first 'watch'.
+    let worst: (typeof candidates)[number] | undefined;
+    for (const c of candidates) {
+        if (c.metric.tone === 'off') { worst = c; break; }
+        if (!worst && c.metric.tone === 'watch') worst = c;
+    }
 
     if (!worst) {
         return { driver: null, action: 'Keep the pace steady and land the takeaway.' };

--- a/frontend/src/utils/highlightUtils.ts
+++ b/frontend/src/utils/highlightUtils.ts
@@ -48,10 +48,9 @@ export const getWordColor = (word: string): string => {
     const color = COLOR_PALETTE[index];
 
     if (WORD_COLOR_CACHE.size >= MAX_WORD_COLOR_CACHE_SIZE) {
-        const oldestKey = WORD_COLOR_CACHE.keys().next().value;
-        if (oldestKey) {
-            WORD_COLOR_CACHE.delete(oldestKey);
-        }
+        // Flush on overflow instead of allocating a keys() iterator to evict one-by-one.
+        // Colors are a deterministic hash, so rebuilding after the rare flush is cheap.
+        WORD_COLOR_CACHE.clear();
     }
     WORD_COLOR_CACHE.set(normalized, color);
 
@@ -107,8 +106,9 @@ export const parseTranscriptForHighlighting = (text: string, userWords: string[]
 
         // Maintain cache size
         if (REGEX_CACHE.size >= MAX_CACHE_SIZE) {
-            const firstKey = REGEX_CACHE.keys().next().value;
-            if (firstKey !== undefined) REGEX_CACHE.delete(firstKey);
+            // Flush on overflow instead of allocating a keys() iterator; with MAX_CACHE_SIZE
+            // distinct word-configs this branch is effectively never hit in practice.
+            REGEX_CACHE.clear();
         }
         REGEX_CACHE.set(cacheKey, { regex: tokenRegex, fillers: allFillers, fillerMap });
     }


### PR DESCRIPTION
Four micro-allocation cleanups Jules flagged, all on **cold UI/analytics paths** — none touch the STT decode/capture path or the Private finalization timing.

- **highlightUtils** (×2): `WORD_COLOR_CACHE` + `REGEX_CACHE` evict via `clear()`-on-overflow instead of allocating a `keys()` iterator. Flush is rare (caps 200/50); color rebuild is a deterministic hash, regex overflow is effectively never hit.
- **coachingNarrative**: single pass for the worst metric instead of two `.find()` scans (4-item array).
- **AnalyticsBuffer**: imperative loop instead of `Object.fromEntries(Object.entries().map())`, dropping two intermediate arrays per event.

Behavior-preserving. Lint + tsc clean; 34 unit tests across the 3 modules green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)