### PR TITLE
feat(stt): beta close — 90s Private cap + flag-only repetition (#891)

### DIFF
--- a/frontend/src/components/session/LiveRecordingCard.tsx
+++ b/frontend/src/components/session/LiveRecordingCard.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 import { RuntimeState } from '@/services/SpeechRuntimeController';
-import { PRIV_STT_MODELS } from '@/services/transcription/sttConstants';
+import { PRIV_STT_MODELS, PRIV_STT } from '@/services/transcription/sttConstants';
 import { PRIVATE_SAMPLE_EVENTS, emitPrivateSample } from '@/services/transcription/privateSampleTelemetry';
 import { resolvePrivateModel } from '@/services/transcription/utils/privateModelFlag';
 
@@ -127,10 +127,12 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
         mock: 'Test transcription mode.',
     };
     const hasPrivateSampleAccess = canUsePrivate && !isPaidProUser;
+    // #891 beta: individual Private recordings are capped (decode latency control). Surface it up front.
+    const privateCapSeconds = PRIV_STT.MAX_PRIVATE_RECORDING_SECONDS;
     const privateModeDescription = isPaidProUser
-        ? 'Private transcription keeps transcription local after model setup. All audio processing remains local.'
+        ? `Private transcription keeps transcription local after model setup. All audio processing remains local. During beta, each recording is capped at ${privateCapSeconds}s and saves automatically.`
         : canUsePrivate
-            ? 'Try one Private sample session. Record up to 5 minutes with local transcription so you can compare it with Browser transcription.'
+            ? `Try one Private sample session — up to 5 minutes total, ${privateCapSeconds}s per recording during beta. Local transcription so you can compare it with Browser transcription.`
             : 'Private transcription is part of Early Access. Upgrade to keep using local Private transcription, full session history, and deeper reports.';
     const nativeModeDescription = "Free and instant. Uses your browser's built-in speech recognition, so accuracy varies by browser and environment.";
     const cloudModeDescription = canUseCloudStt
@@ -166,7 +168,7 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
                                     </button>
                                     {hasPrivateSampleAccess && (
                                         <p className="text-[10px] font-medium leading-snug text-foreground/60">
-                                            Record up to 5 minutes with local transcription so you can compare it with Browser transcription.
+                                            Up to 5 minutes total, {privateCapSeconds}s per recording during beta, with local transcription so you can compare it with Browser transcription.
                                         </p>
                                     )}
                                 </div>

--- a/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
@@ -117,6 +117,8 @@ describe('LiveRecordingCard', () => {
 
         expect(await screen.findByTestId(TEST_IDS.STT_MODE_PRIVATE)).toHaveAttribute('title', expect.stringMatching(/Private transcription keeps transcription local/i));
         expect(screen.getByTestId(TEST_IDS.STT_MODE_PRIVATE)).toHaveAttribute('title', expect.stringMatching(/All audio processing remains local/i));
+        // #891 beta: the 90s per-recording cap is surfaced up front.
+        expect(screen.getByTestId(TEST_IDS.STT_MODE_PRIVATE)).toHaveAttribute('title', expect.stringMatching(/capped at 90s/i));
     });
 
     it('shows explicit Private setup inside the recording card when the model is missing', () => {
@@ -160,7 +162,8 @@ describe('LiveRecordingCard', () => {
         render(<LiveRecordingCard {...defaultProps} mode="native" canUsePrivate={true} isPaidProUser={false} canUseCloudStt={false} />);
 
         expect(screen.getByTestId('first-run-setup-private')).toHaveTextContent('Try one Private sample session');
-        expect(screen.getByText(/Record up to 5 minutes with local transcription/i)).toBeDefined();
+        expect(screen.getByText(/up to 5 minutes total/i)).toBeDefined();
+        expect(screen.getByText(/90s per recording during beta/i)).toBeDefined();
         expect(screen.getByText(/compare it with Browser transcription/i)).toBeDefined();
     });
 

--- a/frontend/src/hooks/__tests__/useSessionLifecycle.test.tsx
+++ b/frontend/src/hooks/__tests__/useSessionLifecycle.test.tsx
@@ -288,6 +288,71 @@ describe('useSessionLifecycle - Auto-Stop Logic', () => {
         }, { timeout: 2000 });
     });
 
+    it('caps a Private recording at 90s (auto-stops past the per-recording cap, independent of budget)', async () => {
+        // #891 beta latency control. Generous usage budget so ONLY the 90s cap can trigger the stop.
+        const mockLimit: UsageLimitCheck = {
+            daily_remaining: 99999,
+            daily_limit: 99999,
+            monthly_remaining: 99999,
+            monthly_limit: 99999,
+            remaining_seconds: 99999,
+            can_start: true,
+            subscription_status: 'pro',
+            is_pro: true,
+            streak_count: 0,
+        };
+        const mockStore = createTestSessionStore({
+            sttMode: 'private',
+            isListening: true,
+            elapsedTime: 91, // past the 90s per-recording cap
+            startTime: Date.now() - 91000,
+        });
+        (useSessionStore as unknown as Mock).mockImplementation(mockStore);
+        (useSessionStore as unknown as { getState: typeof mockStore.getState }).getState = mockStore.getState;
+        (useSessionStore as unknown as { setState: typeof mockStore.setState }).setState = mockStore.setState;
+
+        vi.mocked(useSpeechRecognition).mockReturnValue({
+            transcript: baseTranscript,
+            chunks: [],
+            interimTranscript: '',
+            fillerData: { total: { count: 0, color: '' } },
+            startListening: mockStartListening,
+            stopListening: mockStopListening,
+            isListening: true,
+            isReady: true,
+            isSupported: true,
+            error: null,
+            reset: mockReset,
+            pauseMetrics: basePauseMetrics,
+            modelLoadingProgress: null,
+            sttStatus: { type: 'recording', message: 'Speak now' },
+            mode: 'private',
+            micWarning: null,
+            micLevel: 0,
+            hasSpeechActivity: false,
+        });
+
+        vi.mocked(useUsageLimit).mockReturnValue({
+            data: mockLimit,
+            isLoading: false,
+            isError: false,
+            error: null,
+            status: 'success',
+        } as unknown as UseQueryResult<UsageLimitCheck, Error>);
+
+        renderHook(() => useSessionLifecycle(), {
+            wrapper: ({ children }) => (
+                <TranscriptionProvider>
+                    {children}
+                </TranscriptionProvider>
+            )
+        });
+
+        await waitFor(() => {
+            expect(speechRuntimeController.stopRecording).toHaveBeenCalled();
+        }, { timeout: 2000 });
+    });
+
     it('should NOT trigger stop when time remains', () => {
         const mockStore = createTestSessionStore({
             elapsedTime: 25,

--- a/frontend/src/hooks/useSessionLifecycle.ts
+++ b/frontend/src/hooks/useSessionLifecycle.ts
@@ -15,6 +15,7 @@ import { getEffectiveSubscriptionStatus, hasCloudSttEntitlement, isPro } from '@
 import { useTranscriptionContext } from '@/providers/useTranscriptionContext';
 import { speechRuntimeController } from '@/services/SpeechRuntimeController';
 import { MIN_SESSION_DURATION_SECONDS } from '@/config/env';
+import { PRIV_STT } from '@/services/transcription/sttConstants';
 import { buildPolicyForUser, type TranscriptionMode } from '@/services/transcription/TranscriptionPolicy';
 import type { FillerCounts } from '@/utils/fillerWordUtils';
 import { ENV } from '@/config/TestFlags';
@@ -527,6 +528,29 @@ export const useSessionLifecycle = () => {
             }
         }
     }, [elapsedTime, effectiveMode, isListening, usageLimit, sttStatus.message, isProUser, isVerified, setSTTStatus, setSunsetModal]);
+
+    // #891 beta latency control: cap a SINGLE Private recording at 90s so the Stop re-decode stays
+    // under the 30s ceiling. Independent of the usage allowance above — whichever limit (budget or
+    // 90s cap) is hit first triggers the single auto-stop (shared hasAutoStoppedRef). The 5-min
+    // Private sample budget is unchanged; this only bounds one take. Warns 15s before the cap.
+    useEffect(() => {
+        if (effectiveMode !== 'private' || !isListening) return;
+        const capRemaining = PRIV_STT.MAX_PRIVATE_RECORDING_SECONDS - elapsedTime;
+
+        if (capRemaining <= 0) {
+            if (hasAutoStoppedRef.current) return;
+            hasAutoStoppedRef.current = true;
+            logger.warn({ elapsedTime }, '[useSessionLifecycle] ⚠️ AUTO-STOPPING: Private 90s per-recording cap reached');
+            void handleStartStopRef.current?.({
+                stopReason: 'Private recordings are capped at 90 seconds during beta. We stopped and saved your session.',
+            });
+        } else if (capRemaining <= PRIV_STT.PRIVATE_RECORDING_CAP_WARNING_SECONDS) {
+            const warningMsg = `${Math.ceil(capRemaining)}s left — Private recordings are capped at 90s during beta. We’ll stop and save automatically.`;
+            if (sttStatus.message !== warningMsg) {
+                setSTTStatus({ type: 'info', message: warningMsg });
+            }
+        }
+    }, [effectiveMode, isListening, elapsedTime, sttStatus.message, setSTTStatus]);
 
     // VAD Auto-Pause Logic: 5 minutes of silence detected via transcript inactivity
     const lastTranscriptRef = useRef(transcript.transcript);

--- a/frontend/src/services/transcription/TranscriptionService.ts
+++ b/frontend/src/services/transcription/TranscriptionService.ts
@@ -2,7 +2,7 @@ import { Session } from '@supabase/supabase-js';
 import { NavigateFunction } from 'react-router-dom';
 import { isEqual } from 'lodash-es';
 import { TranscriptionModeOptions, Transcript } from '@/services/transcription/modes/types';
-import { collapseTranscriptRepetitionLoops } from '@/utils/repetitionRisk';
+import { detectRepetitionRisk } from '@/utils/repetitionRisk';
 
 import { TranscriptionError } from './errors';
 import { STTStrategy } from './STTStrategy';
@@ -1113,12 +1113,12 @@ export default class TranscriptionService {
         transcript = visibleTranscript.length > strategyTranscript.length
           ? visibleTranscript
           : strategyTranscript || visibleTranscript;
-        // Final-result repetition guard (saved-transcript integrity). The length-preferring
-        // selection above can pick a streaming-accumulated `visibleTranscript` that bypassed
-        // the per-segment collapse, producing a near_whole_doubling in the saved transcript
-        // (service_result / selectedForSave). Collapse the authoritative final transcript here
-        // so the persisted value can never contain a whole-text/multi-word repetition loop.
-        transcript = collapseTranscriptRepetitionLoops(transcript);
+        // #891 data-integrity (FLAG-ONLY): preserve the saved transcript. We previously collapsed
+        // repetition loops here for "saved-transcript integrity", but a hallucinated loop cannot be
+        // reliably distinguished from genuine repeated speech, so we keep the raw authoritative text
+        // and only FLAG repetition risk (non-mutating). Engine-agnostic. v4 loop behavior stays
+        // internal/targeted only until genuinely fixed — it is NOT masked by rewriting saved text.
+        const repetitionRisk = detectRepetitionRisk(transcript);
         logger.info({
           sId: this.serviceId,
           rId: this.runId,
@@ -1127,6 +1127,9 @@ export default class TranscriptionService {
           currentTranscriptLength: this.currentTranscript.length,
           partialTranscriptLength: this.partialTranscript.length,
           selectedTranscriptLength: transcript.length,
+          repetitionRisk: repetitionRisk.repetitionRisk,
+          repetitionRiskReason: repetitionRisk.repetitionRiskReason,
+          repeatedSpanSummary: repetitionRisk.repeatedSpanSummary,
         }, '[DEBUG-STOP] TranscriptionService.stopTranscription transcript selected');
       }
 

--- a/frontend/src/services/transcription/__tests__/TranscriptionService.pause.test.ts
+++ b/frontend/src/services/transcription/__tests__/TranscriptionService.pause.test.ts
@@ -129,10 +129,12 @@ describe('TranscriptionService Pause/Resume', () => {
     expect(mockStrategy.resume).not.toHaveBeenCalled();
   });
 
-  it('collapses a whole-text repetition loop in the final saved transcript (regression: near_whole_doubling)', async () => {
-    // Live Private-sample regression: the final stop transcript (service_result / selectedForSave)
-    // saved a 100% doubled transcript that the per-segment collapse missed. stopTranscription must
-    // collapse-guard the authoritative final transcript so the persisted value has no whole-text loop.
+  it('PRESERVES a repetition loop in the saved transcript (flag-only, no mutation) and flags the risk', async () => {
+    // #891 data-integrity decision: the authoritative final stop transcript is NO LONGER collapsed.
+    // A hallucinated loop cannot be reliably distinguished from genuine repeated speech (emphasis/
+    // correction), so we PRESERVE the raw saved text and only FLAG repetition risk via the
+    // non-mutating detector. (Previously this collapsed the doubling — that silently altered saved
+    // user speech, which the team reverted for data integrity.)
     const doubled = 'We should literally like, wait, um, basically, we should literally like, wait, um, basically.';
     expect(detectRepetitionRisk(doubled).repetitionRisk).toBe(true); // sanity: input IS doubled
     vi.mocked(mockStrategy.getTranscript).mockResolvedValue(doubled);
@@ -142,8 +144,10 @@ describe('TranscriptionService Pause/Resume', () => {
     const out = result?.transcript ?? '';
 
     expect(out).toBeTruthy(); // not the empty-catch path
-    expect(out.toLowerCase()).toContain('we should literally like'); // content preserved once
-    expect(detectRepetitionRisk(out).repetitionRisk).toBe(false); // no whole-text loop
-    expect(out.length).toBeLessThan(doubled.length); // collapsed
+    // saved text is PRESERVED, not collapsed — BOTH occurrences remain
+    expect((out.toLowerCase().match(/we should literally like/g) || []).length).toBe(2);
+    expect(out.length).toBeGreaterThanOrEqual(doubled.length - 2); // not shortened (allow a trailing trim)
+    // repetition risk is still FLAGGED (non-mutating)
+    expect(detectRepetitionRisk(out).repetitionRisk).toBe(true);
   });
 });

--- a/frontend/src/services/transcription/modes/PrivateWhisper.ts
+++ b/frontend/src/services/transcription/modes/PrivateWhisper.ts
@@ -33,7 +33,7 @@
 import logger from '../../../lib/logger';
 import { redactTranscript } from '../../../lib/logRedaction';
 import { sanitizeTranscriptText } from '../transcriptSanitizer';
-import { collapseTranscriptRepetitionLoops } from '../../../utils/repetitionRisk';
+import { detectRepetitionRisk } from '../../../utils/repetitionRisk';
 import { createPrivateSTT, EngineType } from '../engines';
 import { IPrivateSTT } from '../../../contracts/IPrivateSTT';
 import type { PrivateSTTInitOptions } from '../../../contracts/IPrivateSTT';
@@ -2291,10 +2291,14 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
       return;
     }
 
-    // Collapse Whisper repetition loops before this becomes the saved authority
-    // (service_result / selectedForSave). This is the proven duplication boundary
-    // for Private — the raw whole-utterance decode, which has no repetition handling.
-    const transcript = collapseTranscriptRepetitionLoops(sanitizePrivateTranscriptCandidate(rawText));
+    // #891 data-integrity (FLAG-ONLY): do NOT mutate the saved transcript. Repetition loops are a
+    // known Private/Whisper artifact, but a hallucinated loop cannot be reliably distinguished from
+    // genuine repeated speech (emphasis/correction), so we PRESERVE the raw model output and only
+    // FLAG repetition risk via the non-mutating detector into diagnostics. This replaces the prior
+    // collapse, which silently altered saved user speech. v4 loop behavior stays internal/targeted
+    // only until genuinely fixed — it is NOT masked here.
+    const transcript = sanitizePrivateTranscriptCandidate(rawText);
+    const repetitionRisk = detectRepetitionRisk(transcript);
     if (!transcript || isPurePrivateHallucinationTranscript(transcript)) {
       pushPrivateTimeline('whole_utterance_commit_reject', {
         serviceId: this.serviceId,
@@ -2320,6 +2324,10 @@ export default class PrivateWhisper extends STTEngine implements ITranscriptionE
       replacedRollingPreview: redactTranscript(replacedRollingTranscript),
       // Final-decode wall-clock: time the model spent on the whole-utterance buffer.
       decodeMs,
+      // #891 flag-only: repetition risk recorded as NON-MUTATING metadata; saved text is untouched.
+      repetitionRisk: repetitionRisk.repetitionRisk,
+      repetitionRiskReason: repetitionRisk.repetitionRiskReason,
+      repeatedSpanSummary: repetitionRisk.repeatedSpanSummary,
     });
 
     // AUTHORITATIVE whole-utterance re-transcription: this single final REPLACES the rolling

--- a/frontend/src/services/transcription/sttConstants.ts
+++ b/frontend/src/services/transcription/sttConstants.ts
@@ -68,6 +68,13 @@ export const PRIV_STT = {
   // confirmation), so a hard cap bounds memory on a stuck/overlong recording. On overflow we keep
   // the BEGINNING (the opening) and stop appending, rather than rolling the buffer forward.
   MAX_UTTERANCE_SECONDS: 600,
+  // #891 beta latency control: cap a SINGLE Private recording so the Stop whole-utterance
+  // re-decode (~0.27x realtime, single-thread WASM on the deployed build) finalizes UNDER the 30s
+  // ceiling — 90s of audio => ~24-26s stop-to-final (margin). This caps ONE take, NOT the 5-min
+  // Private sample budget. Segmented finalization (decode only the unfinalized tail at Stop) is the
+  // roadmap fix that lifts this cap; until then 90s is the honest beta control.
+  MAX_PRIVATE_RECORDING_SECONDS: 90,
+  PRIVATE_RECORDING_CAP_WARNING_SECONDS: 15,
   PROCESSING_INTERVAL_MS: 250,
   MAX_RETRY_SECONDS: 12,
   WHISPER_WINDOW_SECONDS: STT_PROVIDER_REQUIREMENTS.PRIVATE_TRANSFORMERS_WHISPER.MODEL_CONTEXT_WINDOW_SECONDS,


### PR DESCRIPTION
Release-closure batch (owner decisions B + C). Builds on #902 (merged).

## B — Cap individual Private recordings at 90s (beta latency control)
The Stop whole-utterance re-decode is ~0.27× realtime (single-thread WASM on the deployed build), so a 5-minute take implies ~78–86s stop-to-final — far over the 30s ceiling. Until segmented finalization lands (the roadmap fix), a single Private take is **auto-stopped + saved at 90s** (~24–26s finalize, margin under 30s).
- `PRIV_STT.MAX_PRIVATE_RECORDING_SECONDS=90` (+ 15s warning).
- `useSessionLifecycle`: a parallel auto-stop effect; whichever of (5-min sample **budget**, 90s **per-take** cap) is hit first stops once (shared `hasAutoStoppedRef`). **The 5-minute total sample allowance is unchanged** — this only bounds one take.
- Up-front UI copy in both Private mode descriptions ("up to 5 minutes total, 90s per recording during beta").
- Tests: caps-at-90s auto-stop + updated copy assertions.

## C — Saved-transcript repetition collapse → flag-only (data integrity)
A hallucinated loop cannot be reliably distinguished from genuine repeated speech (emphasis/correction), so we **preserve the raw model output and only FLAG repetition risk**. Found and converted **both** saved-path mutation sites:
- `PrivateWhisper.commitWholeUtteranceTranscript` (whole-utterance saved authority)
- `TranscriptionService.stopTranscription` (authoritative final, **all engines**)

Both now call the non-mutating `detectRepetitionRisk` and record `repetitionRisk`/`reason`/`span` as diagnostics; **saved text is untouched**. `liveTranscriptUtils.collapseRepeatedFinalForDisplay` is DISPLAY-only (never saved) and left as-is — see note below. v4 loop behavior stays **internal/targeted only** until genuinely fixed — not masked by rewriting saved text.

### Follow-up flag (not in this PR)
Now that the saved transcript is raw, the **display-only** post-stop collapse (`liveTranscriptUtils`, #772) would make the post-stop *visible* final differ from the (now raw) saved/History transcript. Decide separately whether to neutralize it so display == saved. Out of scope for "do not mutate saved transcripts."

## Verification
tsc clean; 193 affected tests green (micReadiness, PrivateWhisper, TranscriptionService, useSessionLifecycle, session components). Re-gate after deploy: immediate/delayed-start opening preserved, **90s stop-to-final latency**, repetition-risk metadata present + **no saved-text mutation**, v4 internal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
