### PR TITLE
fix(stt): prominent mic-ready cue — amber 'getting ready' → held green 'speak now' (#891)

### DIFF
--- a/frontend/src/components/session/LiveRecordingCard.tsx
+++ b/frontend/src/components/session/LiveRecordingCard.tsx
@@ -109,6 +109,20 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
     const isPrivateDownloadRequired = mode === 'private' && sttStatusType === 'download-required' && !isListening;
     // #891 immediate-start gate: the mic is warming up; the UI must NOT invite speech yet.
     const isWarming = sttStatusType === 'warming';
+    // Surface a PROMINENT "Getting mic ready… -> Ready, speak now" cue. Hold the green "ready"
+    // state briefly after the mic becomes ready so the user clearly sees the transition and starts.
+    const [justBecameReady, setJustBecameReady] = React.useState(false);
+    const wasWarmingRef = React.useRef(false);
+    React.useEffect(() => {
+        const wasWarming = wasWarmingRef.current;
+        wasWarmingRef.current = isWarming;
+        if (wasWarming && !isWarming && isListening) {
+            setJustBecameReady(true);
+            const timer = setTimeout(() => setJustBecameReady(false), 2500);
+            return () => clearTimeout(timer);
+        }
+    }, [isWarming, isListening]);
+    const showMicReadyCue = isWarming || justBecameReady;
     let displayStatusMessage = _statusMessage;
     if (isPrivateDownloadRequired) {
         displayStatusMessage = 'Private model setup';
@@ -303,6 +317,23 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
                                 </Button>
                             )}
                         </div>
+
+                        {/* #891 prominent mic-ready cue: amber "getting ready" -> held green "speak now". */}
+                        {showMicReadyCue && (
+                            <div
+                                data-testid="mic-ready-cue"
+                                data-state={isWarming ? 'warming' : 'ready'}
+                                aria-live="polite"
+                                className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-extrabold uppercase tracking-wide ring-1 transition-colors duration-300 ${
+                                    isWarming
+                                        ? 'bg-amber-100 text-amber-800 ring-amber-300'
+                                        : 'bg-green-100 text-green-800 ring-green-400'
+                                }`}
+                            >
+                                <span className={`h-2.5 w-2.5 rounded-full ${isWarming ? 'bg-amber-500 animate-pulse' : 'bg-green-500'}`} />
+                                {isWarming ? 'Getting mic ready — one moment…' : 'Ready — speak now'}
+                            </div>
+                        )}
 
                         {/* Timer (Matching Mic weight) */}
                         <div className="flex flex-col items-center">

--- a/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
@@ -121,6 +121,18 @@ describe('LiveRecordingCard', () => {
         expect(screen.getByTestId(TEST_IDS.STT_MODE_PRIVATE)).toHaveAttribute('title', expect.stringMatching(/capped at 90s/i));
     });
 
+    it('shows a prominent "getting mic ready" cue while the mic is warming (#891)', () => {
+        render(<LiveRecordingCard {...defaultProps} mode="private" isListening={true} sttStatusType="warming" />);
+        const cue = screen.getByTestId('mic-ready-cue');
+        expect(cue).toHaveAttribute('data-state', 'warming');
+        expect(cue.textContent).toMatch(/getting mic ready/i);
+    });
+
+    it('does NOT show the mic-ready cue when not warming and not just-ready', () => {
+        render(<LiveRecordingCard {...defaultProps} mode="private" isListening={true} sttStatusType="recording" />);
+        expect(screen.queryByTestId('mic-ready-cue')).toBeNull();
+    });
+
     it('shows explicit Private setup inside the recording card when the model is missing', () => {
         const onDownloadModel = vi.fn();
         render(


### PR DESCRIPTION
The #902 readiness gate shipped but was wired to an **invisible cue** (a tiny status-label dot that flipped within ~250–800ms) — so users saw immediate recording and never knew to wait, defeating the gate.

This adds a **prominent** cue in the recording card:
- **Amber "Getting mic ready — one moment…"** pill while the mic warms up
- Flips to a **green "Ready — speak now"** that is **held ~2.5s** so the user clearly sees the transition and starts speaking *after* it.

Capture still runs from frame 1 underneath — this only changes how loudly the UI signals readiness. tsc clean; 17 LiveRecordingCard tests (incl. 2 new cue tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)