### PR TITLE
fix(stt): state-colored status pill + hide wrong draft during finalization (#891)

### DIFF
--- a/frontend/src/components/session/LiveRecordingCard.tsx
+++ b/frontend/src/components/session/LiveRecordingCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { AlertCircle, Download, Lock, Mic, Square, ChevronDown } from 'lucide-react';
+import { AlertCircle, Download, Lock, Mic, Square, ChevronDown, Loader2 } from 'lucide-react';
 import { TEST_IDS } from '@/constants/testIds';
 import { MIN_SESSION_DURATION_SECONDS } from '@/config/env';
 import {
@@ -36,6 +36,7 @@ interface LiveRecordingCardProps {
     fsmState?: RuntimeState; // master FSM state from controller
     sttStatusType?: string; // status type from service status
     recordingIntent?: boolean; // explicit user intent to record
+    isFinalizing?: boolean; // post-Stop whole-utterance decode in progress (#891)
     className?: string;
     // Callbacks
     onModeChange: (mode: RecordingMode) => void;
@@ -75,6 +76,7 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
     fsmState,
     sttStatusType,
     recordingIntent = false,
+    isFinalizing = false,
     className = "",
     onModeChange,
     onStartStop,
@@ -122,7 +124,28 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
             return () => clearTimeout(timer);
         }
     }, [isWarming, isListening]);
-    const showMicReadyCue = isWarming || justBecameReady;
+    // #891 state-colored status pill (white card stays; only the oval pill tints by state).
+    // neutral idle -> amber warming -> green ready -> blue finalizing. Recording stays neutral.
+    const pillState: 'finalizing' | 'warming' | 'ready' | 'recording' | 'idle' =
+        isFinalizing ? 'finalizing'
+            : isWarming ? 'warming'
+                : justBecameReady ? 'ready'
+                    : isListening ? 'recording'
+                        : 'idle';
+    const pillSurface = {
+        finalizing: 'bg-blue-100 text-blue-800 ring-1 ring-blue-300',
+        warming: 'bg-amber-100 text-amber-800 ring-1 ring-amber-300',
+        ready: 'bg-green-100 text-green-800 ring-1 ring-green-400',
+        recording: 'bg-muted/55 text-foreground/70 ring-1 ring-border',
+        idle: 'bg-muted/55 text-foreground/70 ring-1 ring-border',
+    }[pillState];
+    const pillDot = {
+        finalizing: 'bg-blue-500',
+        warming: 'bg-amber-500 animate-pulse',
+        ready: 'bg-green-500',
+        recording: 'bg-primary animate-pulse',
+        idle: 'bg-muted-foreground',
+    }[pillState];
     let displayStatusMessage = _statusMessage;
     if (isPrivateDownloadRequired) {
         displayStatusMessage = 'Private model setup';
@@ -318,36 +341,30 @@ const LiveRecordingCardContent: React.FC<LiveRecordingCardProps> = ({
                             )}
                         </div>
 
-                        {/* #891 prominent mic-ready cue: amber "getting ready" -> held green "speak now". */}
-                        {showMicReadyCue && (
-                            <div
-                                data-testid="mic-ready-cue"
-                                data-state={isWarming ? 'warming' : 'ready'}
-                                aria-live="polite"
-                                className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-extrabold uppercase tracking-wide ring-1 transition-colors duration-300 ${
-                                    isWarming
-                                        ? 'bg-amber-100 text-amber-800 ring-amber-300'
-                                        : 'bg-green-100 text-green-800 ring-green-400'
-                                }`}
-                            >
-                                <span className={`h-2.5 w-2.5 rounded-full ${isWarming ? 'bg-amber-500 animate-pulse' : 'bg-green-500'}`} />
-                                {isWarming ? 'Getting mic ready — one moment…' : 'Ready — speak now'}
-                            </div>
-                        )}
-
                         {/* Timer (Matching Mic weight) */}
                         <div className="flex flex-col items-center">
                             <div className="text-3xl font-mono font-bold text-foreground tracking-tighter tabular-nums leading-none">
                                 {formattedTime}
                             </div>
-                            <div className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/55 px-3 py-1">
-                                <div className={`h-1.5 w-1.5 rounded-full ${isWarming ? 'bg-amber-500 animate-pulse' : (isListening ? 'bg-primary animate-pulse' : 'bg-muted-foreground')}`} />
-                                <span className="text-[10px] font-bold text-foreground/70 uppercase tracking-[0.14em]" data-testid="stt-status-label" data-warming={isWarming ? 'true' : 'false'}>
+                            {/* #891 state-colored status pill: the white card stays; ONLY this oval tints
+                                by state — neutral idle, amber warming, green "speak now", blue finalizing. */}
+                            <div
+                                className={`mt-2 inline-flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors duration-300 ${pillSurface}`}
+                                aria-live="polite"
+                            >
+                                {isFinalizing
+                                    ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                                    : <div className={`h-1.5 w-1.5 rounded-full ${pillDot}`} />}
+                                <span className="text-[11px] font-bold tracking-[0.06em]" data-testid="stt-status-label" data-pill-state={pillState}>
                                     {isPrivateDownloadRequired
                                         ? 'Ready'
-                                        : isWarming
-                                            ? 'Starting…'
-                                            : displayStatusMessage || (isPaused ? "Paused" : (isListening ? (activeEngine && activeEngine !== 'none' ? "Recording" : "Listening") : "Ready"))}
+                                        : isFinalizing
+                                            ? 'Finalizing your transcript…'
+                                            : isWarming
+                                                ? 'Getting mic ready — one moment…'
+                                                : justBecameReady
+                                                    ? 'Ready — speak now'
+                                                    : (displayStatusMessage || (isPaused ? 'Paused' : (isListening ? (activeEngine && activeEngine !== 'none' ? 'Recording' : 'Listening') : 'Ready to record')))}
                                 </span>
                             </div>
                         </div>

--- a/frontend/src/components/session/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/session/LiveTranscriptPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Lock, Cloud } from 'lucide-react';
+import { Lock, Cloud, Loader2 } from 'lucide-react';
 import { TEST_IDS } from '@/constants/testIds';
 import { SESSION_INSET_SURFACE_CLASS, SESSION_SURFACE_CLASS } from './sessionSurface';
 import { splitSettledActiveTranscript, hasSevereRepetitionLoop, collapseRepeatedFinalForDisplay } from './liveTranscriptUtils';
@@ -132,10 +132,8 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
     const privateStatus = hasTranscript || hasInterimTranscript ? 'Live text' : 'Private local';
     const visibleTranscript = [committedForDisplay.trim(), displayInterimTranscript.trim()].filter(Boolean).join(' ').trim();
     const finalizingBannerText = isPrivateMode ? 'Processing speech locally…' : 'Processing transcript…';
-    const finalizingEmptyTitle = isPrivateMode ? 'Finalizing local transcript…' : 'Finalizing transcript…';
-    const finalizingEmptyDescription = isPrivateMode
-        ? 'Your final transcript will appear here when local processing finishes.'
-        : 'Your final transcript will appear here when processing finishes.';
+    const finalizingEmptyTitle = isPrivateMode ? 'Finalizing your transcript locally…' : 'Finalizing your transcript…';
+    const finalizingEmptyDescription = 'Your final transcript will appear here shortly.';
     const listeningEmptyText = isPrivateMode
         ? (hasSpeechActivity ? 'Processing speech locally…' : 'Listening locally…')
         : (hasSpeechActivity ? 'Processing speech…' : 'Listening...');
@@ -270,19 +268,6 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                 aria-label="Live transcript of your speech"
                 role="log"
             >
-                {/* Finalizing banner: post-Stop whole-utterance decode in progress.
-                    Keeps the user informed during multi-second CPU finalization so
-                    stale draft text is never mistaken for the saved result. */}
-                {isFinalizing && (
-                    <div
-                        className="sticky top-0 z-20 mb-3 flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm font-medium text-primary"
-                        data-testid="live-transcript-finalizing"
-                    >
-                        <span className="h-2 w-2 animate-pulse rounded-full bg-primary" aria-hidden="true" />
-                        {finalizingBannerText}
-                    </div>
-                )}
-
                 {showDraftTrustBanner && (
                     <div
                         className="sticky top-0 z-20 mb-3 rounded-md border border-dashed border-primary/30 bg-background/95 px-3 py-2 text-sm text-foreground/80 shadow-sm backdrop-blur"
@@ -358,7 +343,7 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                         <p className="text-sm font-semibold text-primary">{finalizingBannerText}</p>
                         <p className="max-w-sm text-xs text-foreground/60">{finalizingEmptyDescription}</p>
                     </div>
-                ) : hasTranscript || hasInterimTranscript ? (
+                ) : (hasTranscript || hasInterimTranscript) && !isFinalizing ? (
                     <div
                         className={`text-foreground text-lg leading-relaxed ${isDrafting ? 'rounded-md border border-dashed border-primary/30 bg-primary/5 p-3 text-foreground/80' : ''}`}
                         data-transcript-draft={isDrafting ? 'true' : undefined}
@@ -422,9 +407,10 @@ export const LiveTranscriptPanel: React.FC<LiveTranscriptPanelProps> = ({
                     </div>
                 ) : isFinalizing ? (
                     <div
-                        className="flex min-h-[120px] flex-col items-center justify-center gap-2 text-center text-foreground/80"
+                        className="flex min-h-[120px] flex-col items-center justify-center gap-3 text-center text-foreground/80"
                         data-testid="live-transcript-finalizing-empty"
                     >
+                        <Loader2 className="h-7 w-7 animate-spin text-primary" aria-hidden="true" />
                         <p className="text-sm font-semibold text-primary">{finalizingEmptyTitle}</p>
                         <p className="max-w-sm text-xs text-foreground/60">
                             {finalizingEmptyDescription}

--- a/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveRecordingCard.test.tsx
@@ -121,16 +121,18 @@ describe('LiveRecordingCard', () => {
         expect(screen.getByTestId(TEST_IDS.STT_MODE_PRIVATE)).toHaveAttribute('title', expect.stringMatching(/capped at 90s/i));
     });
 
-    it('shows a prominent "getting mic ready" cue while the mic is warming (#891)', () => {
+    it('tints the status pill amber with "getting mic ready" while warming (#891)', () => {
         render(<LiveRecordingCard {...defaultProps} mode="private" isListening={true} sttStatusType="warming" />);
-        const cue = screen.getByTestId('mic-ready-cue');
-        expect(cue).toHaveAttribute('data-state', 'warming');
-        expect(cue.textContent).toMatch(/getting mic ready/i);
+        const pill = screen.getByTestId('stt-status-label');
+        expect(pill).toHaveAttribute('data-pill-state', 'warming');
+        expect(pill.textContent).toMatch(/getting mic ready/i);
     });
 
-    it('does NOT show the mic-ready cue when not warming and not just-ready', () => {
-        render(<LiveRecordingCard {...defaultProps} mode="private" isListening={true} sttStatusType="recording" />);
-        expect(screen.queryByTestId('mic-ready-cue')).toBeNull();
+    it('tints the status pill blue with "finalizing" during the post-Stop decode (#891)', () => {
+        render(<LiveRecordingCard {...defaultProps} mode="private" isListening={false} isFinalizing={true} />);
+        const pill = screen.getByTestId('stt-status-label');
+        expect(pill).toHaveAttribute('data-pill-state', 'finalizing');
+        expect(pill.textContent).toMatch(/finalizing your transcript/i);
     });
 
     it('shows explicit Private setup inside the recording card when the model is missing', () => {

--- a/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
+++ b/frontend/src/components/session/__tests__/LiveTranscriptPanel.component.test.tsx
@@ -398,7 +398,7 @@ describe('LiveTranscriptPanel', () => {
         expect(screen.queryByLabelText('Draft transcript, still being recognized')).not.toBeInTheDocument();
     });
 
-    it('shows "Processing speech locally…" and finalizing state during whole-utterance decode', () => {
+    it('replaces the rolling draft with the finalizing placeholder during the whole-utterance decode (#891)', () => {
         render(
             <LiveTranscriptPanel
                 transcript="rough draft so far"
@@ -408,8 +408,13 @@ describe('LiveTranscriptPanel', () => {
                 sttMode="private"
             />
         );
-        expect(screen.getByTestId('live-transcript-finalizing')).toHaveTextContent('Processing speech locally');
         expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveAttribute('data-transcript-state', 'finalizing');
+        // #891: the inaccurate rolling draft must NOT be presented as the result — it is replaced by
+        // a clear processing placeholder, and the draft-rendering elements are not shown.
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing your transcript locally…');
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Your final transcript will appear here shortly.');
+        expect(screen.queryByTestId('live-transcript-current-line')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('live-transcript-settled')).not.toBeInTheDocument();
     });
 
     it('does not show the idle placeholder while Private finalization has no text yet', () => {
@@ -425,8 +430,7 @@ describe('LiveTranscriptPanel', () => {
 
         const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
         expect(transcriptContainer).toHaveAttribute('data-transcript-state', 'finalizing');
-        expect(screen.getByTestId('live-transcript-finalizing')).toHaveTextContent('Processing speech locally');
-        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing local transcript…');
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing your transcript locally…');
         expect(transcriptContainer).not.toHaveTextContent('Start recording and your words will appear here.');
     });
 
@@ -442,11 +446,10 @@ describe('LiveTranscriptPanel', () => {
         );
 
         const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
-        expect(screen.getByTestId('live-transcript-finalizing')).toHaveTextContent('Processing transcript…');
-        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing transcript…');
-        expect(transcriptContainer).toHaveTextContent('Your final transcript will appear here when processing finishes.');
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing your transcript…');
+        expect(transcriptContainer).toHaveTextContent('Your final transcript will appear here shortly.');
         expect(transcriptContainer).not.toHaveTextContent('Processing speech locally…');
-        expect(transcriptContainer).not.toHaveTextContent('Finalizing local transcript…');
+        expect(transcriptContainer).not.toHaveTextContent('locally');
         expect(transcriptContainer).not.toHaveTextContent('local processing');
     });
 
@@ -462,8 +465,7 @@ describe('LiveTranscriptPanel', () => {
         );
 
         const transcriptContainer = screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER);
-        expect(screen.getByTestId('live-transcript-finalizing')).toHaveTextContent('Processing transcript…');
-        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing transcript…');
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing your transcript…');
         expect(transcriptContainer).not.toHaveTextContent('locally');
         expect(transcriptContainer).not.toHaveTextContent('local transcript');
     });
@@ -553,7 +555,8 @@ describe('LiveTranscriptPanel', () => {
         // finalizing banner takes over from the draft banner without a blank frame.
         const assertTrustIndicatorPresent = () => {
             const draft = screen.queryByTestId('live-transcript-trust-banner');
-            const finalizing = screen.queryByTestId('live-transcript-finalizing');
+            // #891: the finalizing surface is now the placeholder (the draft is hidden), not a banner.
+            const finalizing = screen.queryByTestId('live-transcript-finalizing-empty');
             // Exactly one trust surface is visible at each pre-final step.
             expect(Boolean(draft) || Boolean(finalizing)).toBe(true);
             const text = (draft?.textContent ?? '') + (finalizing?.textContent ?? '');
@@ -581,7 +584,7 @@ describe('LiveTranscriptPanel', () => {
             <LiveTranscriptPanel transcript="native words so far" interimTranscript="" isListening={false} isFinalizing={true} sttMode="native" />
         );
         expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveAttribute('data-transcript-state', 'finalizing');
-        expect(screen.getByTestId('live-transcript-finalizing')).toHaveTextContent('Processing transcript…');
+        expect(screen.getByTestId('live-transcript-finalizing-empty')).toHaveTextContent('Finalizing your transcript…');
         assertTrustIndicatorPresent();
 
         // 4. final (journey end): committed transcript, no banner
@@ -589,7 +592,7 @@ describe('LiveTranscriptPanel', () => {
             <LiveTranscriptPanel transcript="native words so far" interimTranscript="" isListening={false} isFinalizing={false} sttMode="native" />
         );
         expect(screen.getByTestId(TEST_IDS.TRANSCRIPT_CONTAINER)).toHaveAttribute('data-transcript-state', 'final');
-        expect(screen.queryByTestId('live-transcript-finalizing')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('live-transcript-finalizing-empty')).not.toBeInTheDocument();
         expect(screen.queryByTestId('live-transcript-trust-banner')).not.toBeInTheDocument();
     });
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -283,6 +283,7 @@ export const SessionPage: React.FC = () => {
                                     fsmState={runtimeState}
                                     sttStatusType={sttStatus.type}
                                     recordingIntent={recordingIntent}
+                                    isFinalizing={isTranscriptFinalizing}
                                     canUsePrivate={canUsePrivateStt}
                                     isPaidProUser={usageLimit?.is_pro === true}
                                     canUseCloudStt={canUseCloudStt}


### PR DESCRIPTION
Two owner-scoped UX fixes for the post-Stop experience. White card/base stays; scope is the status pill + the transcript panel's finalizing state.

## 1. State-colored status pill (not a full-card tint)
Only the oval status pill tints by state:
- neutral **"Ready to record"** → amber **"Getting mic ready — one moment…"** → green **"Ready — speak now"** (held ~2.5s) → blue **"Finalizing your transcript…"** (spinner).

Consolidates the #904 separate banner into the single oval pill the owner specified. High-contrast colored bg + dark text per state.

## 2. Finalization no longer shows the wrong draft
The core complaint: after Stop, the multi-second whole-utterance re-decode kept showing the **garbled rolling draft** (below a banner) — users read it as the result. Now during finalization the draft is **replaced** by a clear placeholder:

> 🌀 **Finalizing your transcript locally…**
> Your final transcript will appear here shortly.

…until the clean final transcript lands. Display-only — saved text is never touched. (`liveTranscriptUtils` display collapse is unrelated and untouched.)

## Verification
- tsc clean; lint clean
- 232 session/page component tests pass; the 5 finalizing tests updated to the new contract (draft hidden, placeholder shown, pill `data-pill-state`)
- The `private-no-browser-checks` release test (controller STOPPING message) is unaffected — different layer

## Still pending (separate)
- Immediate-start re-gate (Record → wait for green → speak immediately → opening preserved)
- The latency itself (~13–24s) is bounded by the 90s cap; segmented finalization is the roadmap fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
