### PR TITLE
fix(analytics): capture + contain the Analytics crash (observability + recovery) [#891]

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, ErrorInfo } from 'react';
+import * as Sentry from '@sentry/react';
 import logger from '../lib/logger';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
@@ -24,8 +25,15 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // You can also log the error to an error reporting service
     logger.error({ error, errorInfo }, "Uncaught error:");
+    // Report to Sentry. Previously this app-level boundary ONLY logged locally, so any crash that
+    // reached it (e.g. the Analytics render crash) was invisible to production monitoring and could
+    // not be diagnosed without the owner pasting a console stack. Report it, with the component stack.
+    Sentry.withScope((scope) => {
+      scope.setTag('errorBoundary', 'app-root');
+      scope.setContext('react', { componentStack: errorInfo.componentStack });
+      Sentry.captureException(error);
+    });
   }
 
   render() {
@@ -39,11 +47,16 @@ class ErrorBoundary extends React.Component<Props, State> {
                 </CardHeader>
                 <CardContent>
                     <p className="text-muted-foreground mb-4">
-                        The page hit a temporary problem. Go home, then open the page again.
+                        The page hit a temporary problem. Try again, or go home and reopen the page.
                     </p>
-                    <Button onClick={() => window.location.assign('/')}>
-                        Go Home
-                    </Button>
+                    <div className="flex items-center justify-center gap-3">
+                        <Button onClick={() => window.location.reload()}>
+                            Try again
+                        </Button>
+                        <Button variant="outline" onClick={() => window.location.assign('/')}>
+                            Go Home
+                        </Button>
+                    </div>
                 </CardContent>
             </Card>
         </div>

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '../../../tests/support/test-utils';
 import ErrorBoundary from '../ErrorBoundary';
 import logger from '../../lib/logger';
+import * as Sentry from '@sentry/react';
+
+vi.mock('@sentry/react', () => ({
+    withScope: (cb: (scope: { setTag: () => void; setContext: () => void }) => void) =>
+        cb({ setTag: vi.fn(), setContext: vi.fn() }),
+    captureException: vi.fn(),
+}));
 
 // Component that throws an error for testing
 const Bomb = ({ message }: { message: string }) => {
@@ -37,9 +44,10 @@ describe('ErrorBoundary', () => {
             </ErrorBoundary>
         );
 
-        // Verify fallback UI structure
+        // Verify fallback UI structure (recoverable: Try again + Go Home)
         expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument();
-        expect(screen.getByText('The page hit a temporary problem. Go home, then open the page again.')).toBeInTheDocument();
+        expect(screen.getByText('The page hit a temporary problem. Try again, or go home and reopen the page.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
         expect(screen.queryByText(errorMsg)).not.toBeInTheDocument();
 
@@ -50,5 +58,8 @@ describe('ErrorBoundary', () => {
             }),
             "Uncaught error:"
         );
+
+        // Verify the crash is now REPORTED to Sentry (previously it was only logged locally -> invisible)
+        expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
     });
 });

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { AnalyticsDashboard } from '../components/AnalyticsDashboard';
+import { LocalErrorBoundary } from '@/components/LocalErrorBoundary';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import { arePaymentsEnabled } from '@/config/appRuntimeConfig';
@@ -198,17 +199,24 @@ const AuthenticatedAnalyticsView: React.FC = () => {
     return (
         <div>
             <PageHeader isPro={isProUser} sessionId={sessionId} upgradeLoading={upgradeLoading} onUpgrade={() => { void handleUpgrade('analytics_overview_banner'); }} />
-            <AnalyticsDashboard
-                profile={profile || null}
-                isProUser={isProUser}
-                sessionHistory={sessionHistory || []}
-                overallStats={overallStats}
-                fillerWordTrends={fillerWordTrends}
-                loading={isLoading}
-                error={error || null}
-                onUpgrade={() => { void handleUpgrade('analytics_empty_state'); }}
-                sessionId={sessionId}
-            />
+            {/* #891 Analytics-crash containment: a render throw in the dashboard (or a chart choking on
+                one bad session's data) previously bubbled to the app-level boundary — a full-page "Oops"
+                dead-end that ALSO didn't reach Sentry. Scope it: LocalErrorBoundary reports to Sentry +
+                PostHog (COMPONENT_CRASH) and shows a recoverable "Try Again" instead of the dead-end. The
+                real root-cause fix follows once the captured stack lands. */}
+            <LocalErrorBoundary componentName="Analytics" isolationKey="analytics" onReset={handleRetryAnalytics}>
+                <AnalyticsDashboard
+                    profile={profile || null}
+                    isProUser={isProUser}
+                    sessionHistory={sessionHistory || []}
+                    overallStats={overallStats}
+                    fillerWordTrends={fillerWordTrends}
+                    loading={isLoading}
+                    error={error || null}
+                    onUpgrade={() => { void handleUpgrade('analytics_empty_state'); }}
+                    sessionId={sessionId}
+                />
+            </LocalErrorBoundary>
         </div>
     );
 };


### PR DESCRIPTION
**Root cause of the invisibility:** the app-level `ErrorBoundary` (renders the "Oops! Something went wrong" the user hit) only `logger.error`'d — **no `Sentry.captureException`** — so the Analytics render crash reached it and never reached Sentry. That's why the read-only Sentry diagnostic (#912) ran clean end-to-end (both endpoints, no 403) yet found no analytics issue: it was never captured.

**Two fixes, no root-cause guess:**
1. `ErrorBoundary.componentDidCatch` → reports to Sentry (tag `errorBoundary=app-root` + component stack). Fallback adds a recoverable **Try again** beside Go Home. Test updated (asserts `captureException` fires).
2. `AnalyticsPage` wraps `AnalyticsDashboard` in `LocalErrorBoundary` (`isolationKey=analytics`) → a render throw now reports to **Sentry + PostHog `COMPONENT_CRASH`** (queryable) and degrades to a recoverable **Try Again** instead of the full-page dead-end.

Net: crash goes from **invisible + dead-end** → **captured + recoverable**. The precise render-bug root fix + regression test follow once the captured stack lands (Sentry workflow, or the PostHog `COMPONENT_CRASH` event). tsc clean; ErrorBoundary tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
