### PR TITLE
fix(analytics): boundary reset clears bad cached data (Try Again can't re-throw) [#891]

### DIFF
--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -163,6 +163,17 @@ const AuthenticatedAnalyticsView: React.FC = () => {
         void queryClient.invalidateQueries({ queryKey: ['userProfile'] });
     };
 
+    // #891 (review): reset handler for the Analytics render-crash boundary. It must REMOVE the cached
+    // analytics data, not just invalidate it — invalidate keeps the stale/bad data served while a
+    // refetch runs, so resetting the boundary would immediately re-render the dashboard against the same
+    // data that just threw and re-trip the boundary. removeQueries clears it -> the dashboard re-renders
+    // against undefined (its loading/empty state, which does not throw) and the active hooks refetch fresh.
+    const handleAnalyticsBoundaryReset = () => {
+        queryClient.removeQueries({ queryKey: ['sessionHistory'] });
+        queryClient.removeQueries({ queryKey: ['sessionCount'] });
+        queryClient.removeQueries({ queryKey: ['analyticsSummary'] });
+    };
+
     // Show loading state while fetching data
     // Loading state is now handled inside AnalyticsDashboard to provide consistent data-testids for E2E
     const isLoading = loading || isProfileLoading;
@@ -204,7 +215,7 @@ const AuthenticatedAnalyticsView: React.FC = () => {
                 dead-end that ALSO didn't reach Sentry. Scope it: LocalErrorBoundary reports to Sentry +
                 PostHog (COMPONENT_CRASH) and shows a recoverable "Try Again" instead of the dead-end. The
                 real root-cause fix follows once the captured stack lands. */}
-            <LocalErrorBoundary componentName="Analytics" isolationKey="analytics" onReset={handleRetryAnalytics}>
+            <LocalErrorBoundary componentName="Analytics" isolationKey="analytics" onReset={handleAnalyticsBoundaryReset}>
                 <AnalyticsDashboard
                     profile={profile || null}
                     isProUser={isProUser}


### PR DESCRIPTION
Resolves the unresolved review thread on #913. **Concern (valid):** the Analytics render-crash `LocalErrorBoundary` used `onReset=handleRetryAnalytics`, which *invalidates* the queries — invalidate keeps the stale/bad data served while a refetch runs, so resetting the boundary re-rendered the dashboard against the same data that just threw and re-tripped the boundary.

**Fix:** dedicated `handleAnalyticsBoundaryReset` uses `queryClient.removeQueries` for `sessionHistory`/`sessionCount`/`analyticsSummary` → clearing the cache makes the dashboard re-render against `undefined` (its loading/empty state, which does not throw), and the active hooks refetch fresh. The load-error "Retry Analytics" button keeps `invalidate` (correct there — data failed to load, not a render crash on bad data). tsc clean.

Follow-up to #913 (capture + containment). Root-cause render fix still pending the captured stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
